### PR TITLE
LPD-98297 Fix deletion of fully provisioned virtual instances

### DIFF
--- a/modules/apps/headless/headless-data-mask/headless-data-mask-impl/src/main/java/com/liferay/headless/data/mask/internal/model/listener/DataMaskRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-data-mask/headless-data-mask-impl/src/main/java/com/liferay/headless/data/mask/internal/model/listener/DataMaskRelevantObjectEntryModelListener.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PortalInstances;
 
 import java.io.Serializable;
 
@@ -72,7 +73,9 @@ public class DataMaskRelevantObjectEntryModelListener
 	public void onBeforeRemove(ObjectEntry objectEntry)
 		throws ModelListenerException {
 
-		if (_isBatchEngineBundle()) {
+		if (_isBatchEngineBundle() ||
+			PortalInstances.isCurrentCompanyInDeletionProcess()) {
+
 			return;
 		}
 

--- a/modules/apps/headless/headless-data-mask/headless-data-mask-test/src/testIntegration/java/com/liferay/headless/data/mask/internal/model/listener/test/DataMaskRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-data-mask/headless-data-mask-test/src/testIntegration/java/com/liferay/headless/data/mask/internal/model/listener/test/DataMaskRelevantObjectEntryModelListenerTest.java
@@ -13,11 +13,16 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -113,6 +118,38 @@ public class DataMaskRelevantObjectEntryModelListenerTest {
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
 				objectEntry2.getObjectEntryId()));
+	}
+
+	@Test
+	public void testOnBeforeRemoveWhenCompanyInDeletionProcess()
+		throws Exception {
+
+		Company company = CompanyTestUtil.addCompany();
+
+		long companyId = company.getCompanyId();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			DataMaskTestUtil.processBatchEngineUnits();
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_DATA_MASK", companyId);
+
+		int objectEntriesCount = _objectEntryLocalService.getObjectEntriesCount(
+			0, objectDefinition.getObjectDefinitionId());
+
+		Assert.assertTrue(objectEntriesCount > 0);
+
+		_companyLocalService.deleteCompany(company);
+
+		Assert.assertNull(
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_DATA_MASK", companyId));
 	}
 
 	@Test
@@ -299,6 +336,9 @@ public class DataMaskRelevantObjectEntryModelListenerTest {
 
 	private static final String _DATA_MASK_BATCH_FILE_NAME =
 		"com.liferay.headless.data.mask.impl_1.0.0 [1]";
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileDataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileDataMaskObjectEntryModelListener.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PortalInstances;
 
 import jakarta.validation.ValidationException;
 
@@ -34,6 +35,10 @@ public class MCPServerProfileDataMaskObjectEntryModelListener
 	@Override
 	public void onBeforeRemove(ObjectEntry objectEntry)
 		throws ModelListenerException {
+
+		if (PortalInstances.isCurrentCompanyInDeletionProcess()) {
+			return;
+		}
 
 		if (Validator.isNull(
 				MapUtil.getString(objectEntry.getValues(), "deleteReason"))) {

--- a/modules/apps/mcp/mcp-server-rest-test/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.6"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "io.modelcontextprotocol.sdk", name: "mcp-core", version: "1.0.1"
 	testIntegrationImplementation group: "io.modelcontextprotocol.sdk", name: "mcp-json-jackson2", version: "1.0.1"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileDataMaskObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileDataMaskObjectEntryModelListenerTest.java
@@ -9,14 +9,17 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PortalInstances;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,6 +72,35 @@ public class MCPServerProfileDataMaskObjectEntryModelListenerTest {
 
 		MCPServerTestUtil.deleteMCPServerProfileDataMaskObjectEntry(
 			RandomTestUtil.randomString(), mcpServerProfileDataMaskObjectEntry);
+
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				mcpServerProfileDataMaskObjectEntry.getObjectEntryId()));
+	}
+
+	@Test
+	public void testOnBeforeRemoveWhenCompanyInDeletionProcess()
+		throws Exception {
+
+		ObjectEntry dataMaskObjectEntry =
+			MCPServerTestUtil.fetchDataMaskObjectEntry("Email Address");
+		ObjectEntry mcpServerProfileObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileObjectEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				"mcp-server-profiles getMCPServerProfilesPage");
+
+		ObjectEntry mcpServerProfileDataMaskObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileDataMaskObjectEntry(
+				dataMaskObjectEntry.getObjectEntryId(), 1,
+				mcpServerProfileObjectEntry.getExternalReferenceCode());
+
+		try (SafeCloseable safeCloseable =
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					TestPropsValues.getCompanyId())) {
+
+			_objectEntryLocalService.deleteObjectEntry(
+				mcpServerProfileDataMaskObjectEntry.getObjectEntryId());
+		}
 
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(

--- a/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/internal/portlet/action/DeleteInstanceMVCActionCommand.java
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/internal/portlet/action/DeleteInstanceMVCActionCommand.java
@@ -49,9 +49,7 @@ public class DeleteInstanceMVCActionCommand extends BaseMVCActionCommand {
 			_companyService.deleteCompany(companyId);
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
+			_log.error(exception);
 
 			SessionErrors.add(actionRequest, exception.getClass());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98297

**What is being fixed:** Once a virtual instance finishes its asynchronous provisioning, it can no longer be deleted. Provisioning seeds system data masks (`maskType = "system"`) into the company's `L_DATA_MASK` object definition, and `DataMaskRelevantObjectEntryModelListener#onBeforeRemove` vetoes any deletion of those entries unless the caller is the data mask batch engine unit itself. `CompanyLocalService#deleteCompany` cascades through the company's object definitions, hits the guard, and aborts, so every fully provisioned instance becomes undeletable. The failure is also invisible: `DeleteInstanceMVCActionCommand` logs the exception at DEBUG and shows a generic "an unexpected error occurred". The MCP server module has the same latent problem — its `MCPServerProfileDataMaskObjectEntryModelListener` rejects deleting profile data masks without a delete reason, and the auto-seeded default MCP profile attaches one per system mask; company deletion currently survives only because the object definition cascade happens to process `DataMask` and `MCPServerProfile` (whose listeners clean the guarded entries up) before `MCPServerProfileDataMaskObjectEntryModelListener` by alphabetical name ordering.

**How it is being fixed:** Both listeners now skip their system-entry guard when `PortalInstances.isCurrentCompanyInDeletionProcess()` is true, the same exemption pattern already used by `AccountGroupModelListener` and `ObjectFolderModelListener` (`doDeleteCompany` runs inside `setCompanyInDeletionProcessWithSafeCloseable`, so the check is scoped exactly to the company deletion path and the guards keep protecting every other caller). `DeleteInstanceMVCActionCommand` now logs the caught exception at ERROR so administrators can see why a deletion failed. Integration tests cover both exemptions: one provisions a company with seeded system data masks and deletes it, the other deletes a reason-less MCP profile data mask while the company is flagged as in deletion. The tests live in a separate final commit so hotfixes can cherry-pick the fixes without them.

**pr-check: PASS** — tested on `23aa508bf250b2155f126e86e49a704b89998191`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |