### PR TITLE
LPD-97694 Fix validation of private page references in web content

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -232,15 +232,8 @@ public class LayoutReferencesExportImportContentProcessor
 						url = urlWithoutLocale;
 					}
 					else {
-						Layout layout =
-							_layoutLocalService.fetchLayoutByFriendlyURL(
-								group.getGroupId(), false, urlWithoutLocale);
-
-						if (layout == null) {
-							layout =
-								_layoutLocalService.fetchLayoutByFriendlyURL(
-									group.getGroupId(), true, urlWithoutLocale);
-						}
+						Layout layout = _fetchLayoutByFriendlyURL(
+							group.getGroupId(), false, urlWithoutLocale);
 
 						if (layout != null) {
 							urlSB.append(localePath);
@@ -1034,14 +1027,8 @@ public class LayoutReferencesExportImportContentProcessor
 					url = urlWithoutLocale;
 				}
 				else {
-					Layout layout =
-						_layoutLocalService.fetchLayoutByFriendlyURL(
-							group.getGroupId(), false, urlWithoutLocale);
-
-					if (layout == null) {
-						layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-							group.getGroupId(), true, urlWithoutLocale);
-					}
+					Layout layout = _fetchLayoutByFriendlyURL(
+						group.getGroupId(), false, urlWithoutLocale);
 
 					if (layout != null) {
 						urlSB.append(localePath);
@@ -1119,13 +1106,8 @@ public class LayoutReferencesExportImportContentProcessor
 				privateLayout = layoutSet.isPrivateLayout();
 			}
 
-			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			Layout layout = _fetchLayoutByFriendlyURL(
 				groupId, privateLayout, url);
-
-			if (layout == null) {
-				layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-					groupId, !privateLayout, url);
-			}
 
 			if (layout != null) {
 				continue;
@@ -1196,6 +1178,20 @@ public class LayoutReferencesExportImportContentProcessor
 				throw exportImportContentValidationException;
 			}
 		}
+	}
+
+	private Layout _fetchLayoutByFriendlyURL(
+		long groupId, boolean privateLayout, String url) {
+
+		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, privateLayout, url);
+
+		if (layout != null) {
+			return layout;
+		}
+
+		return _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, !privateLayout, url);
 	}
 
 	private String _getPortalURL(String url, String portalURL)

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1122,6 +1122,11 @@ public class LayoutReferencesExportImportContentProcessor
 			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
 				groupId, privateLayout, url);
 
+			if (layout == null) {
+				layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+					groupId, !privateLayout, url);
+			}
+
 			if (layout != null) {
 				continue;
 			}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -657,6 +657,26 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97694")
+	public void testValidateContentRelativePrivatePageURLWithVirtualHost()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(group, true);
+		GroupTestUtil.addLayoutSetVirtualHost(group, false);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group, true);
+
+		_layoutReferencesExportImportContentProcessor.validateContentReferences(
+			group.getGroupId(),
+			StringBundler.concat(
+				_CONTENT_PREFIX, layout.getFriendlyURL(),
+				_CONTENT_POSTFIX));
+
+	}
+
+	@Test
 	public void testValidateContentRelativePublicDefaultPageURLWithLocale()
 		throws Exception {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -671,9 +671,7 @@ public class LayoutReferencesExportImportContentProcessorTest {
 		_layoutReferencesExportImportContentProcessor.validateContentReferences(
 			group.getGroupId(),
 			StringBundler.concat(
-				_CONTENT_PREFIX, layout.getFriendlyURL(),
-				_CONTENT_POSTFIX));
-
+				_CONTENT_PREFIX, layout.getFriendlyURL(), _CONTENT_POSTFIX));
 	}
 
 	@Test


### PR DESCRIPTION
Builds on top of #4019 (same fix, full commit history included below), plus a follow-up commit consolidating duplicated lookup logic.

## Original PR Description (#4019)

https://liferay.atlassian.net/browse/LPD-97694

### What Is Being Fixed

Referencing a private page from web content could fail export/import
reference validation even when the page exists. When a layout set uses a
virtual host, the private/public flag derived from the relative page URL
did not necessarily match the layout set the page actually lives in, so
the lookup missed the layout and the reference was reported as invalid.

### How It Is Being Fixed

`LayoutReferencesExportImportContentProcessor` now falls back to the
opposite layout set when the friendly URL lookup against the assumed
layout set returns no layout. If the page is found in either the private
or public layout set, the reference is treated as valid.

## What This PR Adds On Top

The "try the guessed layout set, then try the opposite" lookup was now duplicated three times in this file (twice pre-existing in locale-handling blocks, once more from #4019's fix). This adds one commit that extracts it into a single `_fetchLayoutByFriendlyURL` helper. No behavior change, pure consolidation.

We reviewed the original fix and think it's LGTM. This fallback pattern has direct precedent in this file: it was introduced for the same bug class back in 2022 (`LPS-151464`), and the team deliberately mirrored it across both `validateLayoutReferences` and `replaceExportContentReferences` at the time via a dedicated follow-up commit (`e489a108c` "Also for private pages", then `bdcab61d` "Apply the same logic to replaceExportLayoutReferences"). Consolidating into a shared helper removes the coordination risk that produced those two separate historical commits — the next fix to this lookup only needs to happen once.