### PR TITLE
LPD-98414 LPD-68626 Fix Type column sort in the import report

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
@@ -41,7 +41,12 @@ public class ImportErrorsTableFDSView extends BaseTableFDSView {
 			"classExternalReferenceCode", "external-reference-code",
 			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
 		).add(
-			"type.label", "type"
+			"type.label", "type",
+			fdsTableSchemaField -> fdsTableSchemaField.setSortable(
+				true
+			).setSortFieldName(
+				"type/label"
+			)
 		).add(
 			"errorMessage", "description"
 		).add(

--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 24.4.2
+Bundle-Version: 24.5.0
 Export-Package:\
 	com.liferay.frontend.data.set,\
 	com.liferay.frontend.data.set.action,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -35,6 +35,10 @@ public class FDSTableSchemaField {
 		return _label;
 	}
 
+	public String getSortFieldName() {
+		return _sortFieldName;
+	}
+
 	public SortingOrder getSortingOrder() {
 		return _sortingOrder;
 	}
@@ -103,6 +107,12 @@ public class FDSTableSchemaField {
 		return this;
 	}
 
+	public FDSTableSchemaField setSortFieldName(String sortFieldName) {
+		_sortFieldName = sortFieldName;
+
+		return this;
+	}
+
 	public FDSTableSchemaField setSortingOrder(SortingOrder sortingOrder) {
 		_sortingOrder = sortingOrder;
 
@@ -134,6 +144,15 @@ public class FDSTableSchemaField {
 		).put(
 			"sortable", isSortable()
 		).put(
+			"sortFieldName",
+			() -> {
+				if (isSortable() && (_sortFieldName != null)) {
+					return _sortFieldName;
+				}
+
+				return null;
+			}
+		).put(
 			"sortingOrder",
 			() -> {
 				FDSTableSchemaField.SortingOrder sortingOrder =
@@ -162,6 +181,7 @@ public class FDSTableSchemaField {
 	private String _label;
 	private boolean _localizeLabel = true;
 	private boolean _sortable;
+	private String _sortFieldName;
 	private SortingOrder _sortingOrder;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
@@ -28,6 +28,8 @@ import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.FDSViewContextContributor;
 import com.liferay.frontend.data.set.view.FDSViewContextContributorRegistry;
 import com.liferay.frontend.data.set.view.FDSViewRegistry;
+import com.liferay.frontend.data.set.view.table.FDSTableSchema;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaField;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -46,6 +48,7 @@ import com.liferay.portal.kernel.util.Validator;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -351,7 +354,30 @@ public class SystemFDSSerializer
 			return Collections.emptyList();
 		}
 
-		return fdsSorts.getFDSSortItems(httpServletRequest);
+		List<FDSSortItem> fdsSortItems = fdsSorts.getFDSSortItems(
+			httpServletRequest);
+
+		if (fdsSortItems.isEmpty()) {
+			return fdsSortItems;
+		}
+
+		Map<String, String> sortFieldNamesMap = _getSortFieldNamesMap(
+			fdsName, httpServletRequest);
+
+		if (sortFieldNamesMap.isEmpty()) {
+			return fdsSortItems;
+		}
+
+		for (FDSSortItem fdsSortItem : fdsSortItems) {
+			String sortFieldName = sortFieldNamesMap.get(
+				fdsSortItem.get("key"));
+
+			if (sortFieldName != null) {
+				fdsSortItem.setKey(sortFieldName);
+			}
+		}
+
+		return fdsSortItems;
 	}
 
 	@Override
@@ -440,6 +466,42 @@ public class SystemFDSSerializer
 
 	@Reference
 	protected SystemFDSEntryRegistry systemFDSEntryRegistry;
+
+	private Map<String, String> _getSortFieldNamesMap(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		List<FDSView> fdsViews = fdsViewRegistry.getFDSViews(fdsName);
+
+		if (ListUtil.isEmpty(fdsViews)) {
+			return Collections.emptyMap();
+		}
+
+		Locale locale = PortalUtil.getLocale(httpServletRequest);
+
+		Map<String, String> sortFieldNamesMap = new HashMap<>();
+
+		for (FDSView fdsView : fdsViews) {
+			FDSTableSchema fdsTableSchema = fdsView.getFDSTableSchema(locale);
+
+			if (fdsTableSchema == null) {
+				continue;
+			}
+
+			for (FDSTableSchemaField fdsTableSchemaField :
+					fdsTableSchema.getFDSTableSchemaFieldsMap(
+					).values()) {
+
+				String sortFieldName = fdsTableSchemaField.getSortFieldName();
+
+				if (sortFieldName != null) {
+					sortFieldNamesMap.put(
+						fdsTableSchemaField.getFieldName(), sortFieldName);
+				}
+			}
+		}
+
+		return sortFieldNamesMap;
+	}
 
 	private void _serializeFilters(
 		List<FDSFilter> fdsFilters, JSONArray jsonArray, Locale locale) {

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -56,6 +56,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -1257,6 +1258,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-98414")
 	public void testSerializeSortItems() throws Exception {
 
 		// Different sorts
@@ -1351,6 +1353,30 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		_unregisterServices();
 
+		// No sort field name
+
+		mockLanguage();
+
+		_registerServices(
+			_registerFDSSorts(
+				FDS_NAMES[0], _createFDSSortItemList(FIELD_NAMES[0])),
+			_registerFDSView(
+				FDS_NAMES[0], _createTableFDSView(FIELD_NAMES[0], null)),
+			_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		List<FDSSortItem> fdsSortItems = systemFDSSerializer.serializeSorts(
+			FDS_NAMES[0], httpServletRequest);
+
+		Assert.assertEquals(
+			FIELD_NAMES[0],
+			fdsSortItems.get(
+				0
+			).get(
+				"key"
+			));
+
+		_unregisterServices();
+
 		// No sorts
 
 		_registerServices(_registerSystemFDSEntry(FDS_NAMES[0]));
@@ -1359,6 +1385,39 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 			systemFDSSerializer.serializeSorts(
 				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
+
+		_unregisterServices();
+
+		// No table schema
+
+		_registerServices(
+			_registerFDSSorts(
+				FDS_NAMES[0], _createFDSSortItemList(FIELD_NAMES[0])),
+			_registerFDSView(
+				FDS_NAMES[0],
+				new BaseTableFDSView() {
+
+					@Override
+					public FDSTableSchema getFDSTableSchema(Locale locale) {
+						return null;
+					}
+
+				}),
+			_registerFDSView(
+				FDS_NAMES[0],
+				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
+			_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		fdsSortItems = systemFDSSerializer.serializeSorts(
+			FDS_NAMES[0], httpServletRequest);
+
+		Assert.assertEquals(
+			FIELD_NAMES[1],
+			fdsSortItems.get(
+				0
+			).get(
+				"key"
+			));
 
 		_unregisterServices();
 
@@ -1375,6 +1434,51 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				FDS_NAMES[0], httpServletRequest),
 			systemFDSSerializer.serializeSorts(
 				FDS_NAMES[1], httpServletRequest));
+
+		_unregisterServices();
+
+		// Sort field name
+
+		_registerServices(
+			_registerFDSSorts(
+				FDS_NAMES[0], _createFDSSortItemList(FIELD_NAMES[0])),
+			_registerFDSView(
+				FDS_NAMES[0],
+				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
+			_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		fdsSortItems = systemFDSSerializer.serializeSorts(
+			FDS_NAMES[0], httpServletRequest);
+
+		Assert.assertEquals(
+			FIELD_NAMES[1],
+			fdsSortItems.get(
+				0
+			).get(
+				"key"
+			));
+
+		_unregisterServices();
+
+		// Unmatched key
+
+		_registerServices(
+			_registerFDSSorts(FDS_NAMES[0], _createFDSSortItemList(IDS[0])),
+			_registerFDSView(
+				FDS_NAMES[0],
+				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
+			_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		fdsSortItems = systemFDSSerializer.serializeSorts(
+			FDS_NAMES[0], httpServletRequest);
+
+		Assert.assertEquals(
+			IDS[0],
+			fdsSortItems.get(
+				0
+			).get(
+				"key"
+			));
 
 		_unregisterServices();
 	}
@@ -1789,6 +1893,43 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 			@Override
 			public Map<String, Object> getPreloadedData() {
 				return preloadedData;
+			}
+
+		};
+	}
+
+	private FDSSortItemList _createFDSSortItemList(String key) {
+		return FDSSortItemListBuilder.add(
+			FDSSortItemBuilder.setActive(
+				true
+			).setDirection(
+				"asc"
+			).setKey(
+				key
+			).setLabel(
+				LABELS[0]
+			).build()
+		).build();
+	}
+
+	private FDSView _createTableFDSView(
+		String fieldName, String sortFieldName) {
+
+		return new BaseTableFDSView() {
+
+			@Override
+			public FDSTableSchema getFDSTableSchema(Locale locale) {
+				FDSTableSchemaBuilder fdsTableSchemaBuilder =
+					new FDSTableSchemaBuilderImpl();
+
+				return fdsTableSchemaBuilder.add(
+					fieldName, LABELS[0],
+					fdsTableSchemaField -> fdsTableSchemaField.setSortable(
+						true
+					).setSortFieldName(
+						sortFieldName
+					)
+				).build();
 			}
 
 		};

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -1364,12 +1364,11 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				FDS_NAMES[0], _createTableFDSView(FIELD_NAMES[0], null)),
 			_registerSystemFDSEntry(FDS_NAMES[0]));
 
-		List<FDSSortItem> fdsSortItems = systemFDSSerializer.serializeSorts(
-			FDS_NAMES[0], httpServletRequest);
-
 		Assert.assertEquals(
 			FIELD_NAMES[0],
-			fdsSortItems.get(
+			systemFDSSerializer.serializeSorts(
+				FDS_NAMES[0], httpServletRequest
+			).get(
 				0
 			).get(
 				"key"
@@ -1408,12 +1407,11 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
 			_registerSystemFDSEntry(FDS_NAMES[0]));
 
-		fdsSortItems = systemFDSSerializer.serializeSorts(
-			FDS_NAMES[0], httpServletRequest);
-
 		Assert.assertEquals(
 			FIELD_NAMES[1],
-			fdsSortItems.get(
+			systemFDSSerializer.serializeSorts(
+				FDS_NAMES[0], httpServletRequest
+			).get(
 				0
 			).get(
 				"key"
@@ -1447,12 +1445,11 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
 			_registerSystemFDSEntry(FDS_NAMES[0]));
 
-		fdsSortItems = systemFDSSerializer.serializeSorts(
-			FDS_NAMES[0], httpServletRequest);
-
 		Assert.assertEquals(
 			FIELD_NAMES[1],
-			fdsSortItems.get(
+			systemFDSSerializer.serializeSorts(
+				FDS_NAMES[0], httpServletRequest
+			).get(
 				0
 			).get(
 				"key"
@@ -1469,12 +1466,11 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				_createTableFDSView(FIELD_NAMES[0], FIELD_NAMES[1])),
 			_registerSystemFDSEntry(FDS_NAMES[0]));
 
-		fdsSortItems = systemFDSSerializer.serializeSorts(
-			FDS_NAMES[0], httpServletRequest);
-
 		Assert.assertEquals(
 			IDS[0],
-			fdsSortItems.get(
+			systemFDSSerializer.serializeSorts(
+				FDS_NAMES[0], httpServletRequest
+			).get(
 				0
 			).get(
 				"key"

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -801,6 +801,12 @@ const Table = ({
 		'item-actions'
 	);
 
+	const getFieldSortKey = (field: any): string =>
+		field.sortFieldName ?? String(field.fieldName);
+
+	const getFieldByColumnId = (columnId: string | undefined) =>
+		visibleFields.find((f) => String(f.fieldName) === columnId);
+
 	const getSorting = (): Sorting | null => {
 		const activeSort = sorts.find((sort: any) => sort.active);
 
@@ -808,18 +814,29 @@ const Table = ({
 			return null;
 		}
 
+		const matchedField = visibleFields.find(
+			(f) => getFieldSortKey(f) === activeSort.key
+		);
+
 		return {
-			column: activeSort.key,
+			column: matchedField
+				? String(matchedField.fieldName)
+				: activeSort.key,
 			direction:
 				activeSort.direction === 'desc' ? 'descending' : 'ascending',
 		};
 	};
 
 	const onSortChange = (sorting: Sorting | null) => {
+		const matchedField = getFieldByColumnId(sorting?.column?.toString());
+		const sortKey = matchedField
+			? getFieldSortKey(matchedField)
+			: String(sorting?.column);
+
 		let updatedSorts: TSort[] = [];
 
 		updatedSorts = sorts.map((sort: any) =>
-			sort.key === sorting?.column
+			sort.key === sortKey
 				? {
 						...sort,
 						active: true,
@@ -833,14 +850,14 @@ const Table = ({
 		);
 
 		const newSort: boolean = Boolean(
-			!sorts.find((sort: any) => sort.key === sorting?.column)
+			!sorts.find((sort: any) => sort.key === sortKey)
 		);
 
 		if (newSort) {
 			updatedSorts.push({
 				active: true,
 				direction: 'asc',
-				key: String(sorting?.column),
+				key: sortKey,
 			});
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -37,7 +37,6 @@ import {
 	ITableSchema,
 	IView,
 	TRenderer,
-	TSort,
 	VisibleFieldNames,
 } from '../../utils/types';
 import ViewsContext, {
@@ -51,6 +50,7 @@ import getCellColumnClassName from '../utils/getCellColumnClassName';
 import {EViewsActionTypes} from '../viewsReducer';
 import TableContext from './TableContext';
 import TableContextProvider from './TableContextProvider';
+import {Sorting, getTableSorting, getUpdatedSorts} from './sorting';
 
 type Column = {
 	fieldName: string;
@@ -64,11 +64,6 @@ type Field = {
 	localizeLabel?: boolean;
 	mapData?: Function;
 	sortable?: boolean;
-};
-
-type Sorting = {
-	column: React.Key;
-	direction: 'ascending' | 'descending';
 };
 
 const defaultAddItem = {
@@ -801,67 +796,10 @@ const Table = ({
 		'item-actions'
 	);
 
-	const getFieldSortKey = (field: any): string =>
-		field.sortFieldName ?? String(field.fieldName);
-
-	const getFieldByColumnId = (columnId: string | undefined) =>
-		visibleFields.find((f) => String(f.fieldName) === columnId);
-
-	const getSorting = (): Sorting | null => {
-		const activeSort = sorts.find((sort: any) => sort.active);
-
-		if (!activeSort) {
-			return null;
-		}
-
-		const matchedField = visibleFields.find(
-			(f) => getFieldSortKey(f) === activeSort.key
-		);
-
-		return {
-			column: matchedField
-				? String(matchedField.fieldName)
-				: activeSort.key,
-			direction:
-				activeSort.direction === 'desc' ? 'descending' : 'ascending',
-		};
-	};
-
 	const onSortChange = (sorting: Sorting | null) => {
-		const matchedField = getFieldByColumnId(sorting?.column?.toString());
-		const sortKey = matchedField
-			? getFieldSortKey(matchedField)
-			: String(sorting?.column);
-
-		let updatedSorts: TSort[] = [];
-
-		updatedSorts = sorts.map((sort: any) =>
-			sort.key === sortKey
-				? {
-						...sort,
-						active: true,
-						direction:
-							sorting?.direction === 'ascending' ? 'asc' : 'desc',
-					}
-				: {
-						...sort,
-						active: false,
-					}
+		viewsDispatch(
+			updateActiveSorts(getUpdatedSorts(sorts, visibleFields, sorting))
 		);
-
-		const newSort: boolean = Boolean(
-			!sorts.find((sort: any) => sort.key === sortKey)
-		);
-
-		if (newSort) {
-			updatedSorts.push({
-				active: true,
-				direction: 'asc',
-				key: sortKey,
-			});
-		}
-
-		viewsDispatch(updateActiveSorts(updatedSorts));
 	};
 
 	return (
@@ -914,7 +852,7 @@ const Table = ({
 
 					viewsDispatch(updateVisibleFields(visibleFieldNames));
 				}}
-				sort={getSorting()}
+				sort={getTableSorting(sorts, visibleFields)}
 				visibleColumns={getVisibleFieldsMap(
 					schema.fields as Array<Field>,
 					visibleFields,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/sorting.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/sorting.ts
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import {TSort} from '../../utils/types';
+
+type SortableField = {
+	fieldName: string | string[];
+	sortFieldName?: string;
+};
+
+export type Sorting = {
+	column: React.Key;
+	direction: 'ascending' | 'descending';
+};
+
+export function getFieldSortKey(field: SortableField): string {
+	return field.sortFieldName ?? String(field.fieldName);
+}
+
+export function getTableSorting(
+	sorts: TSort[],
+	visibleFields: SortableField[]
+): Sorting | null {
+	const activeSort = sorts.find((sort) => sort.active);
+
+	if (!activeSort) {
+		return null;
+	}
+
+	const matchedField = visibleFields.find(
+		(field) => getFieldSortKey(field) === activeSort.key
+	);
+
+	return {
+		column: matchedField
+			? String(matchedField.fieldName)
+			: activeSort.key ?? '',
+		direction: activeSort.direction === 'desc' ? 'descending' : 'ascending',
+	};
+}
+
+export function getUpdatedSorts(
+	sorts: TSort[],
+	visibleFields: SortableField[],
+	sorting: Sorting | null
+): TSort[] {
+	const matchedField = visibleFields.find(
+		(field) => String(field.fieldName) === sorting?.column?.toString()
+	);
+
+	const sortKey = matchedField
+		? getFieldSortKey(matchedField)
+		: String(sorting?.column);
+
+	const updatedSorts: TSort[] = sorts.map((sort) =>
+		sort.key === sortKey
+			? {
+					...sort,
+					active: true,
+					direction:
+						sorting?.direction === 'ascending' ? 'asc' : 'desc',
+				}
+			: {
+					...sort,
+					active: false,
+				}
+	);
+
+	if (!sorts.find((sort) => sort.key === sortKey)) {
+		updatedSorts.push({
+			active: true,
+			direction: 'asc',
+			key: sortKey,
+		});
+	}
+
+	return updatedSorts;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/views/table/sorting.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/views/table/sorting.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {TSort} from '../../../src/main/resources/META-INF/resources/utils/types';
+import {
+	getFieldSortKey,
+	getTableSorting,
+	getUpdatedSorts,
+} from '../../../src/main/resources/META-INF/resources/views/table/sorting';
+
+describe('getFieldSortKey', () => {
+	it('prefers the sort field name when it is set', () => {
+		expect(
+			getFieldSortKey({
+				fieldName: 'type.label',
+				sortFieldName: 'type/label',
+			})
+		).toBe('type/label');
+	});
+
+	it('falls back to the field name when no sort field name is set', () => {
+		expect(getFieldSortKey({fieldName: 'title'})).toBe('title');
+	});
+
+	it('stringifies an array field name to a comma-joined value', () => {
+		expect(getFieldSortKey({fieldName: ['type', 'label']})).toBe(
+			'type,label'
+		);
+	});
+});
+
+describe('getTableSorting', () => {
+	it('maps an active sort keyed by the sort field name back to its column', () => {
+		const sorts: TSort[] = [
+			{active: false, direction: 'asc', key: 'title'},
+			{active: true, direction: 'asc', key: 'type/label'},
+		];
+		const visibleFields = [
+			{fieldName: 'title'},
+			{fieldName: 'type.label', sortFieldName: 'type/label'},
+		];
+
+		expect(getTableSorting(sorts, visibleFields)).toEqual({
+			column: 'type.label',
+			direction: 'ascending',
+		});
+	});
+
+	it('returns null when no sort is active', () => {
+		const sorts: TSort[] = [{active: false, key: 'title'}];
+
+		expect(getTableSorting(sorts, [{fieldName: 'title'}])).toBeNull();
+	});
+});
+
+describe('getUpdatedSorts', () => {
+	it('stores the sort field name as the key when a complex column is sorted', () => {
+		const sorts: TSort[] = [
+			{active: false, direction: 'asc', key: 'type/label', label: 'Type'},
+		];
+		const visibleFields = [
+			{fieldName: 'type.label', sortFieldName: 'type/label'},
+		];
+
+		const updatedSorts = getUpdatedSorts(sorts, visibleFields, {
+			column: 'type.label',
+			direction: 'ascending',
+		});
+
+		const activeSort = updatedSorts.find((sort) => sort.active);
+
+		expect(activeSort?.key).toBe('type/label');
+		expect(activeSort?.direction).toBe('asc');
+	});
+});

--- a/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
@@ -110,7 +110,7 @@ async function setupImportReportScenario(apiHelpers: DataApiHelpers) {
 
 test(
 	'Can filter, search and sort errors report entries',
-	{tag: '@LPD-68461'},
+	{tag: ['@LPD-68461', '@LPD-68626']},
 	async ({apiHelpers, exportImportPage}) => {
 		const {
 			objectDefinition1,
@@ -188,6 +188,16 @@ test(
 		values = await exportImportPage.getReportColumnValues(
 			'External Reference Code'
 		);
+		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
+
+		// Sort by Type
+
+		await exportImportPage.sortReportBy('Type');
+		values = await exportImportPage.getReportColumnValues('Type');
+		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+
+		await exportImportPage.sortReportBy('Type');
+		values = await exportImportPage.getReportColumnValues('Type');
 		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
 
 		// Search by Entity Type name


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98414
https://liferay.atlassian.net/browse/LPD-68626

## What Is Being Fixed

Clicking the "Type" column header in the import errors report to sort by it silently did nothing useful: `type` is a dot-path field (`type.label`), so the frontend serializes its `fieldName` as a JS array (`["type", "label"]`), and the sort key built from `String(fieldName)` came out comma-joined (`type,label`). `loadData.ts` treats any comma-containing sort key as ambiguous and truncates it to its first segment before building the OData query, so the request ended up sorting by the bare `type` identifier rather than the field's actual label.

## How It Is Being Fixed

`FDSTableSchemaField` gains an explicit `sortFieldName`, serialized only when the field is sortable and the value is set, so an `FDSView` can declare the real OData sort path for a field whose `fieldName` doesn't map to one directly. `ImportErrorsTableFDSView` sets `sortFieldName("type/label")` for the Type column, matching the OData nested-path syntax for the underlying `ComplexEntityField`/`StringEntityField` relationship. `Table.tsx` prefers `sortFieldName` over the raw `fieldName` both when computing the currently active sort (so the correct column still highlights) and when building the sort key on a header click — since the new key uses `/` instead of `,`, it passes through `loadData.ts` untouched. A Playwright test extends the existing import-report sort coverage to the Type column, and the `frontend-data-set-api` package version was bumped to reflect the new public API.

Following review feedback (Daniel Sanz), the same `sortFieldName` is now honored by the sort menu as well as the column header. Because the sort menu is populated by a separate `FDSSorts` component — linked to the view only by the shared `frontend.data.set.name` property — `SystemFDSSerializer.serializeSorts` reconciles each sort item's key against the view's table schema: when a key matches a column that defines a `sortFieldName`, it is rewritten to that path before serialization, so column-header and sort-menu sorting stay in sync automatically for every `FDSSorts`. The client sort-key logic was extracted from `Table.tsx` into a `sorting` module with Jest coverage, and `SystemFDSSerializerTest` covers the reconciliation.

## PR Check

**pr-check: PASS** — tested on `4774df0d3b97dccf66e93f8f0568c895a1ba7fcc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| JavaScript Unit Tests | PASS |

> **Note:** this pr-check run predates the follow-up reconciliation commits. The branch was since rebased and now heads at `3b5ae19`; a fresh pr-check for the new commits is still pending. Source formatting and the Java/Jest unit tests were re-run locally on the updated branch.

<!-- pr-check {"result": "success", "sha": "4774df0d3b97dccf66e93f8f0568c895a1ba7fcc"} -->
