### PR TITLE
LPD-98332 Consolidate the private/public layout set fallback lookup

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -232,15 +232,8 @@ public class LayoutReferencesExportImportContentProcessor
 						url = urlWithoutLocale;
 					}
 					else {
-						Layout layout =
-							_layoutLocalService.fetchLayoutByFriendlyURL(
-								group.getGroupId(), false, urlWithoutLocale);
-
-						if (layout == null) {
-							layout =
-								_layoutLocalService.fetchLayoutByFriendlyURL(
-									group.getGroupId(), true, urlWithoutLocale);
-						}
+						Layout layout = _fetchLayoutByFriendlyURL(
+							group.getGroupId(), false, urlWithoutLocale);
 
 						if (layout != null) {
 							urlSB.append(localePath);
@@ -1034,14 +1027,8 @@ public class LayoutReferencesExportImportContentProcessor
 					url = urlWithoutLocale;
 				}
 				else {
-					Layout layout =
-						_layoutLocalService.fetchLayoutByFriendlyURL(
-							group.getGroupId(), false, urlWithoutLocale);
-
-					if (layout == null) {
-						layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-							group.getGroupId(), true, urlWithoutLocale);
-					}
+					Layout layout = _fetchLayoutByFriendlyURL(
+						group.getGroupId(), false, urlWithoutLocale);
 
 					if (layout != null) {
 						urlSB.append(localePath);
@@ -1119,13 +1106,8 @@ public class LayoutReferencesExportImportContentProcessor
 				privateLayout = layoutSet.isPrivateLayout();
 			}
 
-			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			Layout layout = _fetchLayoutByFriendlyURL(
 				groupId, privateLayout, url);
-
-			if (layout == null) {
-				layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-					groupId, !privateLayout, url);
-			}
 
 			if (layout != null) {
 				continue;
@@ -1196,6 +1178,20 @@ public class LayoutReferencesExportImportContentProcessor
 				throw exportImportContentValidationException;
 			}
 		}
+	}
+
+	private Layout _fetchLayoutByFriendlyURL(
+		long groupId, boolean privateLayout, String url) {
+
+		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, privateLayout, url);
+
+		if (layout != null) {
+			return layout;
+		}
+
+		return _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, !privateLayout, url);
 	}
 
 	private String _getPortalURL(String url, String portalURL)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98332

## What Is Being Fixed

`LayoutReferencesExportImportContentProcessor` duplicates the same "try the guessed layout set, then fall back to the opposite one" friendly URL lookup in three places: once in `replaceExportContentReferences`, and twice in `validateLayoutReferences`'s locale-handling and main branches (the third copy was added by LPD-97694). This pattern already needed a dedicated follow-up commit to keep in sync once before, back in 2022 (LPS-151464); a third copy reintroduces that same coordination risk if the logic ever needs to change again.

## How It Is Being Fixed

The duplicated lookup is extracted into a single private `_fetchLayoutByFriendlyURL(groupId, privateLayout, url)` helper that tries the requested layout set first and falls back to the opposite one only when the first lookup misses. All three call sites now delegate to it. This is a pure consolidation with no behavior change.

## Why Are There No Tests?

This is a pure refactor extracting duplicated logic into a private helper, with no behavior change. The existing LPD-97694 integration tests already cover the fallback behavior at all three call sites.

## PR Check

**pr-check: PASS** — tested on `f9cc3db8e19a7a1db9b8aa4e8eac8e1fa095a25c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f9cc3db8e19a7a1db9b8aa4e8eac8e1fa095a25c"} -->
