### PR TITLE
LPD-75919 Fix incorrect export progress bar percentage

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineExportTaskExecutor.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineExportTaskExecutor.java
@@ -37,6 +37,10 @@ public interface BatchEngineExportTaskExecutor {
 
 		public boolean isPersist();
 
+		public default boolean isSendBatchProgressMessage() {
+			return true;
+		}
+
 	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 13.2.0
+version 13.3.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -354,7 +354,9 @@ public class BatchEngineExportTaskExecutorImpl
 				int itemsSinceLastReport =
 					currentItemsProcessedCount - lastReportedItemsCount;
 
-				if (itemsSinceLastReport >= exportBatchSize) {
+				if (settings.isSendBatchProgressMessage() &&
+					(itemsSinceLastReport >= exportBatchSize)) {
+
 					BatchEngineTaskExecutorUtil.sendBatchProgressMessage(
 						_backgroundTaskStatusMessageSender,
 						currentItemsProcessedCount);
@@ -407,8 +409,9 @@ public class BatchEngineExportTaskExecutorImpl
 				items = page.getItems();
 			}
 
-			if (batchEngineExportTask.getProcessedItemsCount() >
-					lastReportedItemsCount) {
+			if (settings.isSendBatchProgressMessage() &&
+				(batchEngineExportTask.getProcessedItemsCount() >
+					lastReportedItemsCount)) {
 
 				BatchEngineTaskExecutorUtil.sendBatchProgressMessage(
 					_backgroundTaskStatusMessageSender,

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -25,6 +25,7 @@ import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -65,6 +66,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -517,6 +519,22 @@ public class BatchEngineExportTaskExecutorTest
 		}
 	}
 
+	@Test
+	@TestInfo("LPD-75919")
+	public void testExportProgressMessagesAreNotSentWhenDisabled()
+		throws Throwable {
+
+		Assert.assertEquals(0, _countBatchProgressMessages(false));
+	}
+
+	@Test
+	@TestInfo("LPD-75919")
+	public void testExportProgressMessagesAreSentWhenEnabled()
+		throws Throwable {
+
+		Assert.assertTrue(_countBatchProgressMessages(true) > 0);
+	}
+
 	public abstract class BlogPostingMixin {
 
 		@JsonProperty(access = JsonProperty.Access.READ_WRITE)
@@ -693,6 +711,80 @@ public class BatchEngineExportTaskExecutorTest
 		Assert.assertEquals(
 			initialCount + ROWS_COUNT,
 			batchEngineExportTask.getTotalItemsCount());
+	}
+
+	private int _countBatchProgressMessages(boolean sendProgressMessages)
+		throws Throwable {
+
+		addBlogsEntries();
+
+		_parameters.put("siteId", TestPropsValues.getGroupId());
+
+		_batchEngineExportTask =
+			_batchEngineExportTaskLocalService.createBatchEngineExportTask(
+				RandomTestUtil.randomLong(), null, user.getCompanyId(),
+				user.getUserId(), null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null, _parameters,
+				null);
+
+		AtomicInteger batchProgressMessageCount = new AtomicInteger();
+
+		BackgroundTaskStatusMessageSender backgroundTaskStatusMessageSender =
+			ReflectionTestUtil.getFieldValue(
+				_batchEngineExportTaskExecutor,
+				"_backgroundTaskStatusMessageSender");
+
+		ReflectionTestUtil.setFieldValue(
+			_batchEngineExportTaskExecutor,
+			"_backgroundTaskStatusMessageSender",
+			(BackgroundTaskStatusMessageSender)message -> {
+				if (Objects.equals(
+						message.getString("messageType"), "batchProgress")) {
+
+					batchProgressMessageCount.incrementAndGet();
+				}
+
+				backgroundTaskStatusMessageSender.
+					sendBackgroundTaskStatusMessage(message);
+			});
+
+		try {
+			TransactionInvokerUtil.invoke(
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+				() -> {
+					_batchEngineExportTaskExecutor.execute(
+						_batchEngineExportTask,
+						new BatchEngineExportTaskExecutor.Settings() {
+
+							@Override
+							public boolean isCompressContent() {
+								return false;
+							}
+
+							@Override
+							public boolean isPersist() {
+								return false;
+							}
+
+							@Override
+							public boolean isSendBatchProgressMessage() {
+								return sendProgressMessages;
+							}
+
+						});
+
+					return null;
+				});
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_batchEngineExportTaskExecutor,
+				"_backgroundTaskStatusMessageSender",
+				backgroundTaskStatusMessageSender);
+		}
+
+		return batchProgressMessageCount.get();
 	}
 
 	private void _exportBlogPostings(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -512,8 +512,8 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 					BatchEngineExportTaskExecutor.Result result =
 						_executeExportTask(
-							Integer.MAX_VALUE, portletDataContext,
-							registration);
+							Integer.MAX_VALUE, portletDataContext, registration,
+							true);
 
 					if (result == null) {
 						continue;
@@ -679,7 +679,8 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 					_getActiveRegistrations(portletDataContext)) {
 
 				BatchEngineExportTaskExecutor.Result result =
-					_executeExportTask(1, portletDataContext, registration);
+					_executeExportTask(
+						1, portletDataContext, registration, false);
 
 				if (result == null) {
 					continue;
@@ -821,7 +822,7 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 	private BatchEngineExportTaskExecutor.Result _executeExportTask(
 		int maxItems, PortletDataContext portletDataContext,
-		Registration registration) {
+		Registration registration, boolean sendBatchProgressMessage) {
 
 		return _batchEngineExportTaskExecutor.execute(
 			_batchEngineExportTaskLocalService.createBatchEngineExportTask(
@@ -850,6 +851,11 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 				@Override
 				public boolean isPersist() {
 					return false;
+				}
+
+				@Override
+				public boolean isSendBatchProgressMessage() {
+					return sendBatchProgressMessage;
 				}
 
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75919

## What Is Being Fixed

When exporting a site that contains a batch-exported entity (for example, object entries with the LPD-35914 feature flag enabled), the export progress bar first jumps to 100%, then drops back to 0%, and only then climbs from 0% to 100% as the export actually runs.

## How It Is Being Fixed

To size the progress bar, the batch data handler runs the export task with a maximum of one item purely to read the total item count. That counting pass emitted a batch progress message, and because it ran before the layout message initialized the progress counters, the percentage calculation fell through to its default of 100% — so the bar showed 100% until the layout message reset it to 0%.

A new `isSendBatchProgressMessage` setting on `BatchEngineExportTaskExecutor.Settings` (default `true`) gates the progress messages. `BatchEnginePortletDataHandler` sets it to `false` for the counting pass and `true` for the real export, so the bar advances only while items are genuinely being exported.

## PR Check

**pr-check: PASS** — tested on `4b152c1e47b4fb0a41ec51581cd6b8d23036f4b4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

Per-Module and Cross-Module Compile were scoped to the changed modules and the executor's testIntegration consumers; the full 61-module `batch-engine-api` consumer recompile was omitted as unnecessary for a purely additive default-method change.

<!-- pr-check {"result": "success", "sha": "4b152c1e47b4fb0a41ec51581cd6b8d23036f4b4"} -->
