### PR TITLE
LPD-98887 Stabilize the instance comments and ratings Playwright test

### DIFF
--- a/modules/test/playwright/tests/export-import-web/revamp/instance.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/revamp/instance.export.spec.ts
@@ -50,16 +50,27 @@ test(
 	'Cannot select comments and ratings at instance level',
 	{tag: '@LPD-57655'},
 	async ({
+		apiHelpers,
 		exportImportDataSelectionPage,
 		exportImportPage,
 		globalMenuPage,
 		page,
 	}) => {
+		const listTypeDefinition =
+			await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
+
+		apiHelpers.data.push({
+			id: listTypeDefinition.id,
+			type: 'listTypeDefinition',
+		});
+
 		await globalMenuPage.goToApplications('Export');
 
 		await exportImportPage.clickNew();
 
 		await exportImportDataSelectionPage.expandSection('Content & Data');
+
+		await page.getByRole('checkbox', {name: 'Content & Data'}).check();
 
 		await expect(page.getByText('Comments and Ratings')).toBeHidden();
 	}


### PR DESCRIPTION
### What

Stabilizes the flaky instance-level `Cannot select comments and ratings at instance level` Playwright test for the Export/Import revamp (feature flag `LPD-57655`).

### Root cause

At instance level the **Content & Data** section only renders when a picklist populates it. The test expanded that section and asserted the "Comments and Ratings" footer was hidden, but in a CI bundle with no picklists the section — and its `Expand Content & Data` control — never rendered, so `expandSection('Content & Data')` timed out. It passed locally only because the dev bundle happened to carry the system picklists.

### Fix

The test now seeds its own data instead of depending on ambient state:

- Creates a list type definition through `apiHelpers` (tracked and auto-deleted by the `dataApiHelpers` fixture, so no manual teardown), which makes **Content & Data** render deterministically.
- Selects the section so a content selection exists — the footer's precondition. Without a selection the footer would be hidden at every scope, so the assertion would pass trivially; with one, the footer would appear at site level, making the instance-level assertion meaningful.
- Asserts the "Comments and Ratings" footer stays hidden, proving the rule end to end (group scope → display context → JSP → React → DOM).

### Layer mapping (1:1)

| Before | After |
| --- | --- |
| `instance.export.spec.ts` › `Cannot select comments and ratings at instance level` (flaky: depended on ambient picklists) | same test, seeding its own list type definition and selecting the section |

---

**pr-check: PASS** — tested on `dd96c74857557aead085eccd073d5f194f558228`

Only the Playwright spec changed. Playwright execution is out of scope for pr-check; the test was verified manually against a local master bundle (`1 passed`, 23s).

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result":"success","sha":"dd96c74857557aead085eccd073d5f194f558228"} -->
