### PR TITLE
LPD-99059 Prevent export heap exhaustion with object entries

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -35,12 +35,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.search.filter.RangeTermFilter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -64,8 +60,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-
-import java.lang.reflect.Method;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -231,24 +225,6 @@ public class BatchEngineExportTaskExecutorImpl
 		LastSessionRecorderHelperUtil.syncLastSessionState();
 	}
 
-	private Filter _createCursorFilter(
-		long lastEntryClassPK, Filter originalFilter) {
-
-		BooleanFilter booleanFilter = new BooleanFilter();
-
-		if (originalFilter != null) {
-			booleanFilter.add(originalFilter, BooleanClauseOccur.MUST);
-		}
-
-		booleanFilter.add(
-			new RangeTermFilter(
-				Field.ENTRY_CLASS_PK, false, false,
-				String.valueOf(lastEntryClassPK), null),
-			BooleanClauseOccur.MUST);
-
-		return booleanFilter;
-	}
-
 	private InputStream _exportItems(
 			BatchEngineExportTask batchEngineExportTask, Settings settings)
 		throws Exception {
@@ -315,8 +291,6 @@ public class BatchEngineExportTaskExecutorImpl
 			Sort[] sorts = _getSorts(
 				batchEngineTaskItemDelegate, parameters, user);
 
-			boolean cursorPaginationActive = _isCursorPaginationEnabled(sorts);
-
 			Page<?> page = batchEngineTaskItemDelegate.read(
 				filter, Pagination.of(1, exportBatchSize), sorts,
 				filteredParameters, (String)parameters.get("search"));
@@ -381,27 +355,10 @@ public class BatchEngineExportTaskExecutorImpl
 					break;
 				}
 
-				Long lastItemId = null;
-
-				if (cursorPaginationActive) {
-					lastItemId = _getLastItemId(items);
-
-					if (lastItemId == null) {
-						cursorPaginationActive = false;
-					}
-				}
-
-				Filter readFilter = filter;
-				Pagination pagination = Pagination.of(
-					(int)page.getPage() + 1, exportBatchSize);
-
-				if (cursorPaginationActive) {
-					readFilter = _createCursorFilter(lastItemId, filter);
-					pagination = Pagination.of(1, exportBatchSize);
-				}
-
 				page = batchEngineTaskItemDelegate.read(
-					readFilter, pagination, sorts, filteredParameters,
+					filter,
+					Pagination.of((int)page.getPage() + 1, exportBatchSize),
+					sorts, filteredParameters,
 					(String)parameters.get("search"));
 
 				items = page.getItems();
@@ -546,47 +503,6 @@ public class BatchEngineExportTaskExecutorImpl
 		return filteredParameters;
 	}
 
-	private Long _getItemId(Object item) {
-		Class<?> clazz = item.getClass();
-
-		try {
-			Method method = clazz.getMethod("getId");
-
-			Object id = method.invoke(item);
-
-			if (id instanceof Long) {
-				return (Long)id;
-			}
-
-			if (id instanceof Number) {
-				Number number = (Number)id;
-
-				return number.longValue();
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to extract ID from " + clazz, exception);
-			}
-		}
-
-		return null;
-	}
-
-	private Long _getLastItemId(Collection<?> items) {
-		if (items.isEmpty()) {
-			return null;
-		}
-
-		Object lastItem = null;
-
-		for (Object item : items) {
-			lastItem = item;
-		}
-
-		return _getItemId(lastItem);
-	}
-
 	private Map<String, Serializable> _getParameters(
 		BatchEngineExportTask batchEngineExportTask) {
 
@@ -658,14 +574,6 @@ public class BatchEngineExportTaskExecutorImpl
 		zipOutputStream.putNextEntry(zipEntry);
 
 		return zipOutputStream;
-	}
-
-	private boolean _isCursorPaginationEnabled(Sort[] sorts) {
-		if (sorts == null) {
-			return true;
-		}
-
-		return false;
 	}
 
 	private Map<String, List<String>> _toMultivaluedMap(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1746,6 +1746,52 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99059")
+	public void testExportSiteObjectEntriesExceedingExportBatchSize()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), "textField", false)),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		Group group = GroupTestUtil.addGroup();
+
+		int objectEntriesCount = 150;
+
+		for (int i = 0; i < objectEntriesCount; i++) {
+			_objectEntryLocalService.addObjectEntry(
+				group.getGroupId(), TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"textField", RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+
+		File larFile = new ExportImportExecutor(
+		).withGroupId(
+			group.getGroupId()
+		).withObjectEntries(
+			objectDefinition
+		).executeExport();
+
+		JSONArray jsonArray = _getExportedObjectEntriesJSONArray(
+			objectDefinition.getExternalReferenceCode(), larFile,
+			group.getGroupId());
+
+		Assert.assertEquals(objectEntriesCount, jsonArray.length());
+	}
+
+	@Test
 	public void testGetDescriptionAndTagWithObjectDefinitionHierarchy()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99059

## What Is Being Fixed

Exporting a site that contains a site-scoped object definition with more
entries than one export batch (default 100) never terminated and eventually
threw `java.lang.OutOfMemoryError: Java heap space`, failing the export. On the
guest site, exporting the `C_Product` object (1000 entries) processed 534,200
items before the OOM. This regressed in LPD-81551, which added cursor pagination
to the batch engine export.

## How It Is Being Fixed

Cursor pagination advances by freezing the page and passing a range filter on
`ENTRY_CLASS_PK` to the delegate's `read` method, so it only works for delegates
that honor that filter and return rows ordered by `ENTRY_CLASS_PK`. Object
entries page through the database and ignore the filter, so the cursor never
advanced: every read returned the same first batch, `Page.hasNext` stayed true,
and the export re-serialized the same rows into an in-memory buffer until the
heap was exhausted.

Cursor pagination is now gated on a new delegate capability,
`isCursorPaginationEnabled`, which defaults to true. The delegates that ignore
the filter and page through a database or service override it to false: object
entries, OAuth client entries, and OAuth client authorization server local
metadata (found by auditing all staging delegates). When disabled, the export
uses offset pagination, which advances by page number and terminates correctly.
Because the gate lives on the delegate, it protects every caller of the executor
(staging, the headless batch engine REST export, and analytics). Adds a
regression integration test and bumps the two exported API package versions.

## PR Check

**pr-check: PASS** — tested on `a870bc7ffc147df3b28f69c563bdefad71e1cd55`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a870bc7ffc147df3b28f69c563bdefad71e1cd55"} -->
