### PR TITLE
LPD-87027 Look up the CT settings configuration helper lazily

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -587,7 +588,11 @@ public class SitesImpl implements Sites {
 					"import, or staging process is in progress");
 		}
 
-		if (_ctSettingsConfigurationHelper.isEnabled(
+		CTSettingsConfigurationHelper ctSettingsConfigurationHelper =
+			_ctSettingsConfigurationHelperSnapshot.get();
+
+		if ((ctSettingsConfigurationHelper != null) &&
+			ctSettingsConfigurationHelper.isEnabled(
 				layoutSetPrototype.getCompanyId())) {
 
 			throw new IllegalStateException(
@@ -1161,11 +1166,12 @@ public class SitesImpl implements Sites {
 
 	private static final Log _log = LogFactoryUtil.getLog(SitesImpl.class);
 
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
+	private static final Snapshot<CTSettingsConfigurationHelper>
+		_ctSettingsConfigurationHelperSnapshot = new Snapshot<>(
+			SitesImpl.class, CTSettingsConfigurationHelper.class);
 
 	@Reference
-	private CTSettingsConfigurationHelper _ctSettingsConfigurationHelper;
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ExportImportConfigurationLocalService


### PR DESCRIPTION
### What

Fixes [LPD-99220](https://liferay.atlassian.net/browse/LPD-99220) — the 2026.q2.9 EE Package Tester failures investigated in [LPD-98932](https://liferay.atlassian.net/browse/LPD-98932) — by removing the mandatory DS activation edge that [`c0473bc`](https://github.com/liferay/liferay-portal/commit/c0473bcd99aa734e32ece5782b92d0822be5a8cf) (LPD-87027, backported to the release as [`a61cb2bf`](https://github.com/liferay/liferay-portal-ee/commit/a61cb2bf219e2327b25e6bd1fc71e4a797d823be)) introduced from `SitesImpl` to `change-tracking-web`.

### Root cause chain (from the CI server logs)

In the q2.9 package runs, the `layout-service` `LayoutLocalServiceWrapper` — the only real implementation of `LayoutLocalService.copyLayoutContent` — never gets spliced into the service proxy chain, so every call falls through to the portal-impl stub and throws `UnsupportedOperationException` for the whole JVM lifetime. That breaks the welcome initializer at portal instance registration, site creation from site initializers (the `site.siteInitializer.spec.ts` 400s), widget-to-content page conversion, and headless page creation (~56 failing cases). `DefaultLayoutUtilityPageEntryException` is a downstream symptom.

The wrapper's activation is gated on `Sites`, and `c0473bc` made `SitesImpl` wait for `change-tracking-web` (one of the last bundles to start) through a mandatory static `@Reference` to `CTSettingsConfigurationHelper`. q2.6/q2.7/q2.8 packages (without the commit) pass; both q2.9 builds (first with it) fail deterministically. The failure does not reproduce locally on the identical artifact (fresh DB, PostgreSQL 16.3, CI properties) — consistent with an environment-sensitive activation-order issue; the failing state is fully evidenced in the CI logs.

### Fix

Replace the mandatory `@Reference` with a lazy `Snapshot` lookup (standard pattern, precedent in `site-impl` itself), restoring the pre-LPD-87027 activation graph. The Publications guard is skipped when the helper is not yet available (fail-open, per feature-owner review).

### Runtime validation on the failing artifact

Differential experiment on the actual 2026.q2.9 candidate package (`2026.q2.9-1784575616`), same Gogo commands before and after swapping in the patched `site-impl` jar:

| Step | Stock jar (`@Reference`) | Patched jar (`Snapshot`) |
| --- | --- | --- |
| `scr:info SitesImpl` | ACTIVE, lists `_ctSettingsConfigurationHelper` (1..1 static) | ACTIVE, **reference gone from the DS descriptor** |
| `scr:disable` `CTSettingsConfigurationHelperImpl` | `SitesImpl` → UNSATISFIED REFERENCE → `LayoutLocalServiceWrapper` → UNSATISFIED REFERENCE | `SitesImpl` **stays ACTIVE**, wrapper **stays ACTIVE** |
| `POST /o/headless-admin-site/v1.0/sites` (masterclass initializer) with change-tracking-web down | degraded (404, resource cascade) | **200** |

```
scr:disable com.liferay.change.tracking.web.internal.configuration.helper.CTSettingsConfigurationHelperImpl
scr:info com.liferay.site.internal.util.SitesImpl
scr:info com.liferay.layout.internal.service.LayoutLocalServiceWrapper
```

Final validation: EE Package Tester re-run with the fix (RM process via LPD-98078).

---

**pr-check: PASS** — tested on `c93f3fb3aede5af68112c8a1119982aaded972cd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"PASS","sha":"c93f3fb3aede5af68112c8a1119982aaded972cd"} -->
