### PR TITLE
LPD-42559 Require a related entry for a mandatory relationship field

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -7945,6 +7945,14 @@ public class ObjectEntryLocalServiceImpl
 					objectField.getName());
 			}
 		}
+		else if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+
+			if (GetterUtil.getLong(value) == 0) {
+				throw new ObjectEntryValuesException.Required(
+					objectField.getName());
+			}
+		}
 	}
 
 	private void _validateTextMaxLength(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -3169,8 +3169,9 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testAddObjectEntryWithObjectRelationshipInScopeDepot()
-		throws Exception {
+	public void testAddObjectEntryWithObjectRelationship() throws Exception {
+
+		// Depot scope
 
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -3206,7 +3207,7 @@ public class ObjectEntryLocalServiceTest {
 			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
 			StringPool.TRUE);
 
-		ObjectRelationship objectRelationship =
+		ObjectRelationship objectRelationship1 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectRelationshipLocalService, objectDefinition1,
 				objectDefinition2,
@@ -3225,7 +3226,7 @@ public class ObjectEntryLocalServiceTest {
 
 		ObjectField relationshipObjectField =
 			_objectFieldLocalService.fetchObjectField(
-				objectRelationship.getObjectFieldId2());
+				objectRelationship1.getObjectFieldId2());
 
 		Map<String, Serializable> values = Collections.singletonMap(
 			relationshipObjectField.getName(), objectEntry1.getObjectEntryId());
@@ -3252,6 +3253,32 @@ public class ObjectEntryLocalServiceTest {
 			() -> _addObjectEntry(
 				depotEntry2.getGroupId(),
 				objectDefinition2.getObjectDefinitionId(), values));
+
+		// Required relationship
+
+		ObjectDefinition objectDefinition3 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition objectDefinition4 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectRelationship objectRelationship2 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition3,
+				objectDefinition4);
+
+		ObjectField objectField = _objectFieldLocalService.updateRequired(
+			objectRelationship2.getObjectFieldId2(), true);
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field \"" +
+				objectField.getName() + "\"",
+			() -> _addObjectEntry(
+				objectDefinition4,
+				HashMapBuilder.<String, Serializable>put(
+					objectField.getName(), 0
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42559

## What Is Being Fixed

A required many-to-one relationship field on an object entry was not enforced. Creating an object entry with the relationship foreign key set to 0 (no related entry) succeeded instead of returning the expected "No value was provided for required object field" validation error, so a mandatory relationship could be left empty.

## How It Is Being Fixed

The required-field check in ObjectEntryLocalServiceImpl relied on Validator.isNull, which only treats a value of 0 as empty when the value is a java.lang.Long. A relationship foreign key arriving from JSON is deserialized as an Integer or BigDecimal, so a zero foreign key was considered provided and the mandatory relationship went unvalidated. The fix adds a Relationship business-type branch to the required-value validation that detects an empty foreign key with GetterUtil.getLong, mirroring how RelationshipObjectFieldBusinessType already treats a zero value as "no related entry". An integration test in ObjectEntryLocalServiceTest covers a required one-to-many relationship field created with a zero foreign key.

## PR Check

**pr-check: PASS** — tested on `356c3eea4c6c22df7786da6c51b63fdc63849156`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "356c3eea4c6c22df7786da6c51b63fdc63849156"} -->
