### PR TITLE
LPD-96725 Select DTOConverters deterministically per entity type

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dto/v1_0/converter/AssetEntityDTOConverter.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dto/v1_0/converter/AssetEntityDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Ferrari
  */
 @Component(
-	property = "dto.class.name=com.liferay.asset.kernel.model.AssetEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.asset.kernel.model.AssetEntry"
+	},
 	service = DTOConverter.class
 )
 public class AssetEntityDTOConverter

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dto/v1_0/converter/DXPEntityDTOConverterImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dto/v1_0/converter/DXPEntityDTOConverterImpl.java
@@ -63,7 +63,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rachael Koestartyo
  */
 @Component(
-	property = "dto.class.name=com.liferay.analytics.dxp.entity.rest.dto.v1_0.DXPEntity",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.analytics.dxp.entity.rest.dto.v1_0.DXPEntity"
+	},
 	service = DTOConverter.class
 )
 public class DXPEntityDTOConverterImpl implements DXPEntityDTOConverter {

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/ChannelDTOConverter.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/ChannelDTOConverter.java
@@ -21,7 +21,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Ferrari
  */
 @Component(
-	property = "dto.class.name=AnalyticsChannel", service = DTOConverter.class
+	property = {"default=true", "dto.class.name=AnalyticsChannel"},
+	service = DTOConverter.class
 )
 public class ChannelDTOConverter
 	implements DTOConverter<AnalyticsChannel, Channel> {

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/DataSourceDTOConverter.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/DataSourceDTOConverter.java
@@ -16,7 +16,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Riccardo Ferrari
  */
 @Component(
-	property = "dto.class.name=AnalyticsDataSource",
+	property = {"default=true", "dto.class.name=AnalyticsDataSource"},
 	service = DTOConverter.class
 )
 public class DataSourceDTOConverter

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/SiteDTOConverter.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/dto/v1_0/converter/SiteDTOConverter.java
@@ -18,7 +18,9 @@ import org.osgi.service.component.annotations.Component;
  * @author Riccardo Ferrari
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Group",
+	property = {
+		"default=true", "dto.class.name=com.liferay.portal.kernel.model.Group"
+	},
 	service = DTOConverter.class
 )
 public class SiteDTOConverter implements DTOConverter<Group, Site> {

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
@@ -35,7 +35,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = "dto.class.name=com.liferay.change.tracking.model.CTCollection",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.change.tracking.model.CTCollection"
+	},
 	service = DTOConverter.class
 )
 public class CTCollectionDTOConverter

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -38,7 +38,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = "dto.class.name=com.liferay.change.tracking.model.CTEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.change.tracking.model.CTEntry"
+	},
 	service = DTOConverter.class
 )
 public class CTEntryDTOConverter

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTProcessDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTProcessDTOConverter.java
@@ -28,7 +28,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = "dto.class.name=com.liferay.change.tracking.model.CTProcess",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.change.tracking.model.CTProcess"
+	},
 	service = DTOConverter.class
 )
 public class CTProcessDTOConverter

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTRemoteDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTRemoteDTOConverter.java
@@ -15,7 +15,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = "dto.class.name=com.liferay.change.tracking.model.CTRemote",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.change.tracking.model.CTRemote"
+	},
 	service = DTOConverter.class
 )
 public class CTRemoteDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountAddressDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountAddressDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceAddress",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceAddress"
+	},
 	service = DTOConverter.class
 )
 public class AccountAddressDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountChannelEntryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountChannelEntryDTOConverter.java
@@ -38,7 +38,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.AccountChannelEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.AccountChannelEntry"
+	},
 	service = DTOConverter.class
 )
 public class AccountChannelEntryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountChannelShippingOptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountChannelShippingOptionDTOConverter.java
@@ -26,7 +26,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceShippingOptionAccountEntryRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceShippingOptionAccountEntryRel"
+	},
 	service = DTOConverter.class
 )
 public class AccountChannelShippingOptionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountMemberDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountMemberDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.account.model.AccountEntryUserRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.account.model.AccountEntryUserRel"
+	},
 	service = DTOConverter.class
 )
 public class AccountMemberDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountOrganizationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountOrganizationDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.account.model.AccountEntryOrganizationRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.account.model.AccountEntryOrganizationRel"
+	},
 	service = DTOConverter.class
 )
 public class AccountOrganizationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountRoleDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/dto/v1_0/converter/AccountRoleDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.UserGroupRole",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.portal.kernel.model.UserGroupRole"
+	},
 	service = DTOConverter.class
 )
 public class AccountRoleDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/AttachmentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/AttachmentDTOConverter.java
@@ -46,7 +46,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Igor Beslic
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPAttachmentFileEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPAttachmentFileEntry"
+	},
 	service = DTOConverter.class
 )
 public class AttachmentDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/CatalogDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/CatalogDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CommerceCatalog",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CommerceCatalog"
+	},
 	service = DTOConverter.class
 )
 public class CatalogDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/DiagramDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/DiagramDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramSetting",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramSetting"
+	},
 	service = DTOConverter.class
 )
 public class DiagramDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/GroupedProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/GroupedProductDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.type.grouped.model.CPDefinitionGroupedEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.type.grouped.model.CPDefinitionGroupedEntry"
+	},
 	service = DTOConverter.class
 )
 public class GroupedProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/LowStockActionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/LowStockActionDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.stock.activity.CommerceLowStockActivity",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.stock.activity.CommerceLowStockActivity"
+	},
 	service = DTOConverter.class
 )
 public class LowStockActionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/MappedProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/MappedProductDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramEntry"
+	},
 	service = DTOConverter.class
 )
 public class MappedProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionCategoryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionCategoryDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPOptionCategory",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPOptionCategory"
+	},
 	service = DTOConverter.class
 )
 public class OptionCategoryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPOption",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPOption"
+	},
 	service = DTOConverter.class
 )
 public class OptionDTOConverter implements DTOConverter<CPOption, Option> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionValueDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/OptionValueDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPOptionValue",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPOptionValue"
+	},
 	service = DTOConverter.class
 )
 public class OptionValueDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/PinDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/PinDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramPin",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.shop.by.diagram.model.CSDiagramPin"
+	},
 	service = DTOConverter.class
 )
 public class PinDTOConverter implements DTOConverter<CSDiagramEntry, Pin> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationDTOConverter.java
@@ -46,7 +46,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CPDefinitionInventory",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CPDefinitionInventory"
+	},
 	service = DTOConverter.class
 )
 public class ProductConfigurationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListAccountDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPConfigurationListRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPConfigurationListRel"
+	},
 	service = DTOConverter.class
 )
 public class ProductConfigurationListAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListChannelDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.inventory.model.CommerceChannelRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.inventory.model.CommerceChannelRel"
+	},
 	service = DTOConverter.class
 )
 public class ProductConfigurationListChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductConfigurationListDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CPConfigurationList",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CPConfigurationList"
+	},
 	service = DTOConverter.class
 )
 public class ProductConfigurationListDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
@@ -46,6 +46,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Catalog",
+		"default=true",
 		"dto.class.name=com.liferay.commerce.product.model.CPDefinition",
 		"version=v1.0"
 	},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductGroupDTOConverter.java
@@ -23,6 +23,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Catalog",
+		"default=true",
 		"dto.class.name=com.liferay.commerce.pricing.model.CommercePricingClass",
 		"version=v1.0"
 	},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductGroupProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductGroupProductDTOConverter.java
@@ -28,7 +28,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.pricing.model.CommercePricingClassCPDefinitionRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.pricing.model.CommercePricingClassCPDefinitionRel"
+	},
 	service = DTOConverter.class
 )
 public class ProductGroupProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
@@ -30,7 +30,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPDefinitionOptionRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPDefinitionOptionRel"
+	},
 	service = DTOConverter.class
 )
 public class ProductOptionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductOptionValueDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductOptionValueDTOConverter.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPDefinitionOptionValueRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPDefinitionOptionValueRel"
+	},
 	service = DTOConverter.class
 )
 public class ProductOptionValueDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductShippingConfigurationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductShippingConfigurationDTOConverter.java
@@ -20,7 +20,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=ProductShippingConfiguration",
+	property = {"default=true", "dto.class.name=ProductShippingConfiguration"},
 	service = DTOConverter.class
 )
 public class ProductShippingConfigurationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPDefinitionSpecificationOptionValue",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPDefinitionSpecificationOptionValue"
+	},
 	service = DTOConverter.class
 )
 public class ProductSpecificationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSubscriptionConfigurationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSubscriptionConfigurationDTOConverter.java
@@ -18,7 +18,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=ProductSubscriptionConfiguration",
+	property = {
+		"default=true", "dto.class.name=ProductSubscriptionConfiguration"
+	},
 	service = DTOConverter.class
 )
 public class ProductSubscriptionConfigurationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductTaxConfigurationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductTaxConfigurationDTOConverter.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=ProductTaxConfiguration",
+	property = {"default=true", "dto.class.name=ProductTaxConfiguration"},
 	service = DTOConverter.class
 )
 public class ProductTaxConfigurationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductVirtualSettingsFileEntryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductVirtualSettingsFileEntryDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.type.virtual.model.CPDVirtualSettingFileEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.type.virtual.model.CPDVirtualSettingFileEntry"
+	},
 	service = DTOConverter.class
 )
 public class ProductVirtualSettingsFileEntryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/RelatedProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/RelatedProductDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPDefinitionLink",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPDefinitionLink"
+	},
 	service = DTOConverter.class
 )
 public class RelatedProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuDTOConverter.java
@@ -35,7 +35,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPInstance",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPInstance"
+	},
 	service = DTOConverter.class
 )
 public class SkuDTOConverter implements DTOConverter<CPInstance, Sku> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuUnitOfMeasureDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuUnitOfMeasureDTOConverter.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Stefano Motta
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPInstanceUnitOfMeasure",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPInstanceUnitOfMeasure"
+	},
 	service = DTOConverter.class
 )
 public class SkuUnitOfMeasureDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuVirtualSettingsDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SkuVirtualSettingsDTOConverter.java
@@ -37,7 +37,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Stefano Motta
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.SkuVirtualSettings",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.SkuVirtualSettings"
+	},
 	service = DTOConverter.class
 )
 public class SkuVirtualSettingsDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SpecificationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/SpecificationDTOConverter.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification"
+	},
 	service = DTOConverter.class
 )
 public class SpecificationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/AccountAddressChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/AccountAddressChannelDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CommerceChannelRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CommerceChannelRel"
+	},
 	service = DTOConverter.class
 )
 public class AccountAddressChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/CategoryDisplayPageDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/CategoryDisplayPageDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.CategoryDisplayPage",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.CategoryDisplayPage"
+	},
 	service = DTOConverter.class
 )
 public class CategoryDisplayPageDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ChannelAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ChannelAccountDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CommerceChannelAccountEntryRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CommerceChannelAccountEntryRel"
+	},
 	service = DTOConverter.class
 )
 public class ChannelAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ChannelDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CommerceChannel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CommerceChannel"
+	},
 	service = DTOConverter.class
 )
 public class ChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/DefaultCategoryDisplayPageDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/DefaultCategoryDisplayPageDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.DefaultCategoryDisplayPage",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.DefaultCategoryDisplayPage"
+	},
 	service = DTOConverter.class
 )
 public class DefaultCategoryDisplayPageDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/DefaultProductDisplayPageDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/DefaultProductDisplayPageDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.DefaultProductDisplayPage",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.DefaultProductDisplayPage"
+	},
 	service = DTOConverter.class
 )
 public class DefaultProductDisplayPageDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/PaymentMethodGroupRelOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/PaymentMethodGroupRelOrderTypeDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.payment.model.CommercePaymentMethodGroupRelQualifier-OrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.payment.model.CommercePaymentMethodGroupRelQualifier-OrderType"
+	},
 	service = DTOConverter.class
 )
 public class PaymentMethodGroupRelOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/PaymentMethodGroupRelTermDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/PaymentMethodGroupRelTermDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.payment.model.CommercePaymentMethodGroupRelQualifier-Term",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.payment.model.CommercePaymentMethodGroupRelQualifier-Term"
+	},
 	service = DTOConverter.class
 )
 public class PaymentMethodGroupRelTermDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ProductDisplayPageDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ProductDisplayPageDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ProductDisplayPage",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ProductDisplayPage"
+	},
 	service = DTOConverter.class
 )
 public class ProductDisplayPageDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ShippingFixedOptionOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ShippingFixedOptionOrderTypeDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.payment.model.CommerceShippingFixedOptionQualifier-OrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.payment.model.CommerceShippingFixedOptionQualifier-OrderType"
+	},
 	service = DTOConverter.class
 )
 public class ShippingFixedOptionOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ShippingFixedOptionTermDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/ShippingFixedOptionTermDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.payment.model.CommerceShippingFixedOptionQualifier-Term",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.payment.model.CommerceShippingFixedOptionQualifier-Term"
+	},
 	service = DTOConverter.class
 )
 public class ShippingFixedOptionTermDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/TaxCategoryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/dto/v1_0/converter/TaxCategoryDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPTaxCategory",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPTaxCategory"
+	},
 	service = DTOConverter.class
 )
 public class TaxCategoryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/ReplenishmentItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/ReplenishmentItemDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Crescenzo Rega
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.ReplenishmentItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.ReplenishmentItem"
+	},
 	service = DTOConverter.class
 )
 public class ReplenishmentItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseAccountDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Danny Situ
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseRel"
+	},
 	service = DTOConverter.class
 )
 public class WarehouseAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouse",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouse"
+	},
 	service = DTOConverter.class
 )
 public class WarehouseDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseItemDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseItem"
+	},
 	service = DTOConverter.class
 )
 public class WarehouseItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/dto/v1_0/converter/WarehouseOrderTypeDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Crescenzo Rega
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseRel-OrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.inventory.model.CommerceInventoryWarehouseRel-OrderType"
+	},
 	service = DTOConverter.class
 )
 public class WarehouseOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/BillingAddressDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/BillingAddressDTOConverter.java
@@ -21,7 +21,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=BillingAddress", service = DTOConverter.class
+	property = {"default=true", "dto.class.name=BillingAddress"},
+	service = DTOConverter.class
 )
 public class BillingAddressDTOConverter
 	implements DTOConverter<CommerceAddress, BillingAddress> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderDTOConverter.java
@@ -52,6 +52,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Order",
+		"default=true",
 		"dto.class.name=com.liferay.commerce.model.CommerceOrder",
 		"version=v1.0"
 	},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderItemDTOConverter.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Order",
+		"default=true",
 		"dto.class.name=com.liferay.commerce.model.CommerceOrderItem",
 		"version=v1.0"
 	},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderNoteDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderNoteDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceOrderNote",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceOrderNote"
+	},
 	service = DTOConverter.class
 )
 public class OrderNoteDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleAccountDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-Account",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-Account"
+	},
 	service = DTOConverter.class
 )
 public class OrderRuleAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleAccountGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleAccountGroupDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-AccountGroup",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-AccountGroup"
+	},
 	service = DTOConverter.class
 )
 public class OrderRuleAccountGroupDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleChannelDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-Channel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-Channel"
+	},
 	service = DTOConverter.class
 )
 public class OrderRuleChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.order.rule.model.COREntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.order.rule.model.COREntry"
+	},
 	service = DTOConverter.class
 )
 public class OrderRuleDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderRuleOrderTypeDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-OrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.order.rule.model.COREntryRel-OrderType"
+	},
 	service = DTOConverter.class
 )
 public class OrderRuleOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderTypeChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderTypeChannelDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceOrderTypeRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceOrderTypeRel"
+	},
 	service = DTOConverter.class
 )
 public class OrderTypeChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/OrderTypeDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceOrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceOrderType"
+	},
 	service = DTOConverter.class
 )
 public class OrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/ShippingAddressDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/ShippingAddressDTOConverter.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Order",
-		"dto.class.name=ShippingAddress", "version=v1.0"
+		"default=true", "dto.class.name=ShippingAddress", "version=v1.0"
 	},
 	service = DTOConverter.class
 )

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/TermDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/TermDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.term.model.CommerceTermEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.term.model.CommerceTermEntry"
+	},
 	service = DTOConverter.class
 )
 public class TermDTOConverter implements DTOConverter<CommerceTermEntry, Term> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/TermOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/converter/TermOrderTypeDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.term.model.CommerceTermEntryRel-OrderType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.term.model.CommerceTermEntryRel-OrderType"
+	},
 	service = DTOConverter.class
 )
 public class TermOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/src/main/java/com/liferay/headless/commerce/admin/payment/internal/dto/v1_0/converter/PaymentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/src/main/java/com/liferay/headless/commerce/admin/payment/internal/dto/v1_0/converter/PaymentDTOConverter.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Payment",
+		"default=true",
 		"dto.class.name=com.liferay.commerce.model.CommercePayment",
 		"version=v1.0"
 	},

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/AccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/AccountDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.account.model.AccountEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.account.model.AccountEntry"
+	},
 	service = DTOConverter.class
 )
 public class AccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountAccountDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountAccountRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountAccountRel"
+	},
 	service = DTOConverter.class
 )
 public class DiscountAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountAccountGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountAccountGroupDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountCommerceAccountGroupRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountCommerceAccountGroupRel"
+	},
 	service = DTOConverter.class
 )
 public class DiscountAccountGroupDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountCategoryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountCategoryDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Category",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Category"
+	},
 	service = DTOConverter.class
 )
 public class DiscountCategoryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountChannelDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceChannelRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceChannelRel"
+	},
 	service = DTOConverter.class
 )
 public class DiscountChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountDTOConverter.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscount",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscount"
+	},
 	service = DTOConverter.class
 )
 public class DiscountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountOrderTypeDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountOrderTypeRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountOrderTypeRel"
+	},
 	service = DTOConverter.class
 )
 public class DiscountOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountProductDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Product",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Product"
+	},
 	service = DTOConverter.class
 )
 public class DiscountProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountProductGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountProductGroupDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-ProductGroup",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-ProductGroup"
+	},
 	service = DTOConverter.class
 )
 public class DiscountProductGroupDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountRuleDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountRuleDTOConverter.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Alberti
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRule",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRule"
+	},
 	service = DTOConverter.class
 )
 public class DiscountRuleDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountSkuDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/DiscountSkuDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Sku",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel-Sku"
+	},
 	service = DTOConverter.class
 )
 public class DiscountSkuDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceEntryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceEntryDTOConverter.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceEntry"
+	},
 	service = DTOConverter.class
 )
 public class PriceEntryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListAccountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListAccountDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListAccountRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListAccountRel"
+	},
 	service = DTOConverter.class
 )
 public class PriceListAccountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListAccountGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListAccountGroupDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListCommerceAccountGroupRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListCommerceAccountGroupRel"
+	},
 	service = DTOConverter.class
 )
 public class PriceListAccountGroupDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListChannelDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListChannelRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListChannelRel"
+	},
 	service = DTOConverter.class
 )
 public class PriceListChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceList",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceList"
+	},
 	service = DTOConverter.class
 )
 public class PriceListDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListDiscountDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListDiscountDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListDiscountRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListDiscountRel"
+	},
 	service = DTOConverter.class
 )
 public class PriceListDiscountDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListOrderTypeDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceListOrderTypeDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListOrderTypeRel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommercePriceListOrderTypeRel"
+	},
 	service = DTOConverter.class
 )
 public class PriceListOrderTypeDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierCategoryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierCategoryDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-Category",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-Category"
+	},
 	service = DTOConverter.class
 )
 public class PriceModifierCategoryDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifier",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifier"
+	},
 	service = DTOConverter.class
 )
 public class PriceModifierDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierProductDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-Product",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-Product"
+	},
 	service = DTOConverter.class
 )
 public class PriceModifierProductDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierProductGroupDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/PriceModifierProductGroupDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-ProductGroup",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.pricing.model.CommercePriceModifierRel-ProductGroup"
+	},
 	service = DTOConverter.class
 )
 public class PriceModifierProductGroupDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/TierPriceDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/dto/v2_0/converter/TierPriceDTOConverter.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.price.list.model.CommerceTierPriceEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.price.list.model.CommerceTierPriceEntry"
+	},
 	service = DTOConverter.class
 )
 public class TierPriceDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/converter/ShipmentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/converter/ShipmentDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceShipment",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceShipment"
+	},
 	service = DTOConverter.class
 )
 public class ShipmentDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/converter/ShipmentItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/converter/ShipmentItemDTOConverter.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.model.CommerceShipmentItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.model.CommerceShipmentItem"
+	},
 	service = DTOConverter.class
 )
 public class ShipmentItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/dto/v1_0/converter/MeasurementUnitDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/dto/v1_0/converter/MeasurementUnitDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Crescenzo Rega
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPMeasurementUnit",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.product.model.CPMeasurementUnit"
+	},
 	service = DTOConverter.class
 )
 public class MeasurementUnitDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/AddressDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/AddressDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Address",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Address"
+	},
 	service = DTOConverter.class
 )
 public class AddressDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/AttachmentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/AttachmentDTOConverter.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Stefano Motta
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Attachment",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Attachment"
+	},
 	service = DTOConverter.class
 )
 public class AttachmentDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartDTOConverter.java
@@ -74,7 +74,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Cart",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Cart"
+	},
 	service = DTOConverter.class
 )
 public class CartDTOConverter implements DTOConverter<CommerceOrder, Cart> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartItemDTOConverter.java
@@ -53,7 +53,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartItem"
+	},
 	service = DTOConverter.class
 )
 public class CartItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartTransitionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/dto/v1_0/converter/CartTransitionDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartTransition",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartTransition"
+	},
 	service = DTOConverter.class
 )
 public class CartTransitionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/AttachmentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/AttachmentDTOConverter.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=CPAttachmentFileEntry",
+	property = {"default=true", "dto.class.name=CPAttachmentFileEntry"},
 	service = DTOConverter.class
 )
 public class AttachmentDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/CategoryDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/CategoryDTOConverter.java
@@ -20,7 +20,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=AssetCategory", service = DTOConverter.class
+	property = {"default=true", "dto.class.name=AssetCategory"},
+	service = DTOConverter.class
 )
 public class CategoryDTOConverter
 	implements DTOConverter<AssetCategory, Category> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ChannelDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ChannelDTOConverter.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Crescenzo Rega
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Channel",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Channel"
+	},
 	service = DTOConverter.class
 )
 public class ChannelDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/CurrencyDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/CurrencyDTOConverter.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Michele Vigilante
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Currency",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Currency"
+	},
 	service = DTOConverter.class
 )
 public class CurrencyDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
@@ -34,7 +34,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=CPDefinition", service = DTOConverter.class
+	property = {"default=true", "dto.class.name=CPDefinition"},
+	service = DTOConverter.class
 )
 public class ProductDTOConverter
 	implements DTOConverter<CPDefinition, Product> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=CPDefinitionOptionRel",
+	property = {"default=true", "dto.class.name=CPDefinitionOptionRel"},
 	service = DTOConverter.class
 )
 public class ProductOptionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionValueDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionValueDTOConverter.java
@@ -78,7 +78,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=CPDefinitionOptionValueRel",
+	property = {"default=true", "dto.class.name=CPDefinitionOptionValueRel"},
 	service = DTOConverter.class
 )
 public class ProductOptionValueDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
@@ -22,7 +22,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=CPDefinitionSpecificationOptionValue",
+	property = {
+		"default=true", "dto.class.name=CPDefinitionSpecificationOptionValue"
+	},
 	service = DTOConverter.class
 )
 public class ProductSpecificationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/RelatedProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/RelatedProductDTOConverter.java
@@ -19,7 +19,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=CPDefinitionLink", service = DTOConverter.class
+	property = {"default=true", "dto.class.name=CPDefinitionLink"},
+	service = DTOConverter.class
 )
 public class RelatedProductDTOConverter
 	implements DTOConverter<CPDefinitionLink, RelatedProduct> {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/SkuDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/SkuDTOConverter.java
@@ -86,7 +86,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  * @author Alessio Antonio Rendina
  */
-@Component(property = "dto.class.name=CPSku", service = DTOConverter.class)
+@Component(
+	property = {"default=true", "dto.class.name=CPSku"},
+	service = DTOConverter.class
+)
 public class SkuDTOConverter implements DTOConverter<CPInstance, Sku> {
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/WishListDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/WishListDTOConverter.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mahmoud Azzam
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.WishList",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.WishList"
+	},
 	service = DTOConverter.class
 )
 public class WishListDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/WishListItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/WishListItemDTOConverter.java
@@ -34,7 +34,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mahmoud Azzam
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.WishListItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.WishListItem"
+	},
 	service = DTOConverter.class
 )
 public class WishListItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/OrderTransitionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/OrderTransitionDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.OrderTransition",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.OrderTransition"
+	},
 	service = DTOConverter.class
 )
 public class OrderTransitionDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderAddressDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderAddressDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderAddress",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderAddress"
+	},
 	service = DTOConverter.class
 )
 public class PlacedOrderAddressDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderCommentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderCommentDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderComment",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderComment"
+	},
 	service = DTOConverter.class
 )
 public class PlacedOrderCommentDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderDTOConverter.java
@@ -60,7 +60,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gianmarco Brunialti Masera
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrder",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrder"
+	},
 	service = DTOConverter.class
 )
 public class PlacedOrderDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderItemDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderItemDTOConverter.java
@@ -60,7 +60,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderItem"
+	},
 	service = DTOConverter.class
 )
 public class PlacedOrderItemDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderItemShipmentDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/dto/v1_0/converter/PlacedOrderItemShipmentDTOConverter.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Andrea Sbarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderItemShipment",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.commerce.delivery.order.dto.v1_0.PlacedOrderItemShipment"
+	},
 	service = DTOConverter.class
 )
 public class PlacedOrderItemShipmentDTOConverter

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/dto/v1_0/converter/CountryResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/dto/v1_0/converter/CountryResourceDTOConverter.java
@@ -29,7 +29,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Drew Brokke
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Country",
+	property = {
+		"default=true", "dto.class.name=com.liferay.portal.kernel.model.Country"
+	},
 	service = DTOConverter.class
 )
 public class CountryResourceDTOConverter

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/dto/v1_0/converter/RegionResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/dto/v1_0/converter/RegionResourceDTOConverter.java
@@ -24,7 +24,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Region",
+	property = {
+		"default=true", "dto.class.name=com.liferay.portal.kernel.model.Region"
+	},
 	service = DTOConverter.class
 )
 public class RegionResourceDTOConverter

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
@@ -40,7 +40,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.fragment.model.FragmentEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.fragment.model.FragmentEntry"
+	},
 	service = DTOConverter.class
 )
 public class FragmentDTOConverter

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentSetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentSetDTOConverter.java
@@ -17,7 +17,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.fragment.model.FragmentCollection",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.fragment.model.FragmentCollection"
+	},
 	service = DTOConverter.class
 )
 public class FragmentSetDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/CollectionDisplayPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/CollectionDisplayPageElementDefinitionDTOConverter.java
@@ -47,7 +47,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class CollectionDisplayPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/ContainerPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/ContainerPageElementDefinitionDTOConverter.java
@@ -32,7 +32,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class ContainerPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DisplayPageTemplateFolderDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DisplayPageTemplateFolderDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Bárbara Cabrera
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.LayoutPageTemplateCollection",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.portal.kernel.model.LayoutPageTemplateCollection"
+	},
 	service = DTOConverter.class
 )
 public class DisplayPageTemplateFolderDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DropZonePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DropZonePageElementDefinitionDTOConverter.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mikel Lorza
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.DropZoneLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.DropZoneLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class DropZonePageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormContainerPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormContainerPageElementDefinitionDTOConverter.java
@@ -51,7 +51,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.FormStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.FormStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class FormContainerPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormRelationshipPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormRelationshipPageElementDefinitionDTOConverter.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier Moral
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.FormRelationshipStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.FormRelationshipStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class FormRelationshipPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormStepContainerPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormStepContainerPageElementDefinitionDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.FormStepContainerStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.FormStepContainerStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class FormStepContainerPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentConfigurationFieldValueDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentConfigurationFieldValueDTOConverter.java
@@ -69,7 +69,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Lourdes Fernández Besada
  */
 @Component(
-	property = "dto.class.name=com.liferay.fragment.util.configuration.FragmentConfigurationField",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.fragment.util.configuration.FragmentConfigurationField"
+	},
 	service = DTOConverter.class
 )
 public class FragmentConfigurationFieldValueDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentDropZonePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentDropZonePageElementDefinitionDTOConverter.java
@@ -17,7 +17,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class FragmentDropZonePageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/GridPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/GridPageElementDefinitionDTOConverter.java
@@ -35,7 +35,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.RowStyledLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.RowStyledLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class GridPageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/ModulePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/ModulePageElementDefinitionDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.ColumnLayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.ColumnLayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class ModulePageElementDefinitionDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
@@ -30,7 +30,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel",
+	property = {
+		"default=true",
+		"dto.class.name=import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel"
+	},
 	service = DTOConverter.class
 )
 public class PageExperienceDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"default=true",
-		"dto.class.name=import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel"
+		"dto.class.name=com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel"
 	},
 	service = DTOConverter.class
 )

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageTemplateSetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageTemplateSetDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier Moral
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.page.template.model.LayoutPageTemplateCollection",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.page.template.model.LayoutPageTemplateCollection"
+	},
 	service = DTOConverter.class
 )
 public class PageTemplateSetDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/StyleBookDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/StyleBookDTOConverter.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Thiago Buarque
  */
 @Component(
-	property = "dto.class.name=com.liferay.style.book.model.StyleBookEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.style.book.model.StyleBookEntry"
+	},
 	service = DTOConverter.class
 )
 public class StyleBookDTOConverter

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/UtilityPageDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/UtilityPageDTOConverter.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.utility.page.model.LayoutUtilityPageEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.utility.page.model.LayoutUtilityPageEntry"
+	},
 	service = DTOConverter.class
 )
 public class UtilityPageDTOConverter

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/KeywordDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/KeywordDTOConverter.java
@@ -32,7 +32,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Víctor Galán
  */
 @Component(
-	property = "dto.class.name=com.liferay.asset.kernel.model.AssetTag",
+	property = {
+		"default=true", "dto.class.name=com.liferay.asset.kernel.model.AssetTag"
+	},
 	service = DTOConverter.class
 )
 public class KeywordDTOConverter implements DTOConverter<AssetTag, Keyword> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.Taxonomy",
+		"application.name=Liferay.Headless.Admin.Taxonomy", "default=true",
 		"dto.class.name=com.liferay.asset.kernel.model.AssetCategory",
 		"version=v1.0"
 	},

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountGroupResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountGroupResourceDTOConverter.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.account.model.AccountGroup"
 	},
 	service = DTOConverter.class

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/AccountResourceDTOConverter.java
@@ -76,7 +76,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.account.model.AccountEntry", "version=v1.0"
 	},
 	service = DTOConverter.class

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/OrganizationResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/OrganizationResourceDTOConverter.java
@@ -80,7 +80,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.portal.kernel.model.Organization",
 		"version=v1.0"
 	},

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/PostalAddressDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/PostalAddressDTOConverter.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.portal.kernel.model.Address", "version=v1.0"
 	},
 	service = DTOConverter.class

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/RoleDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/RoleDTOConverter.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.portal.kernel.model.Role", "version=v1.0"
 	},
 	service = DTOConverter.class

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(
-	property = "dto.class.name=com.liferay.segments.model.SegmentsEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.segments.model.SegmentsEntry"
+	},
 	service = DTOConverter.class
 )
 public class SegmentDTOConverter

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -66,7 +66,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mikel Lorza
  */
 @Component(
-	property = "dto.class.name=com.liferay.sharing.model.SharingEntry",
+	property = {
+		"default=true", "dto.class.name=com.liferay.sharing.model.SharingEntry"
+	},
 	service = DTOConverter.class
 )
 public class SharedAssetDTOConverter

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserGroupResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserGroupResourceDTOConverter.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
+		"default=true",
 		"dto.class.name=com.liferay.portal.kernel.model.UserGroup",
 		"service.ranking:Integer=" + Integer.MAX_VALUE
 	},

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserResourceDTOConverter.java
@@ -89,7 +89,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.User",
+		"application.name=Liferay.Headless.Admin.User", "default=true",
 		"dto.class.name=com.liferay.portal.kernel.model.User",
 		"service.ranking:Integer=" + Integer.MAX_VALUE, "version=v1.0"
 	},

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/dto/v1_0/converter/WorkflowTaskDTOConverter.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/dto/v1_0/converter/WorkflowTaskDTOConverter.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.Admin.Workflow",
+		"application.name=Liferay.Headless.Admin.Workflow", "default=true",
 		"dto.class.name=com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken",
 		"version=v1.0"
 	},

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -49,7 +49,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Roberto Díaz
  */
 @Component(
-	property = "dto.class.name=com.liferay.depot.model.DepotEntry",
+	property = {
+		"default=true", "dto.class.name=com.liferay.depot.model.DepotEntry"
+	},
 	service = DTOConverter.class
 )
 public class AssetLibraryDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
@@ -53,7 +53,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.blogs.model.BlogsEntry",
+	property = {
+		"default=true", "dto.class.name=com.liferay.blogs.model.BlogsEntry"
+	},
 	service = DTOConverter.class
 )
 public class BlogPostingDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -88,7 +88,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.document.library.kernel.model.DLFileEntry"
+	},
 	service = DTOConverter.class
 )
 public class DocumentDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDataDefinitionTypeDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDataDefinitionTypeDTOConverter.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mikel Lorza
  */
 @Component(
-	property = "dto.class.name=com.liferay.document.library.kernel.model.DLFileEntryType",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.document.library.kernel.model.DLFileEntryType"
+	},
 	service = DTOConverter.class
 )
 public class DocumentDataDefinitionTypeDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentFolderDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentFolderDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.document.library.kernel.model.DLFolder"
+	},
 	service = DTOConverter.class
 )
 public class DocumentFolderDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentMetadataSetDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentMetadataSetDTOConverter.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sam Ziemer
  */
 @Component(
-	property = "dto.class.name=com.liferay.dynamic.data.mapping.model.DDMStructure",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.dynamic.data.mapping.model.DDMStructure"
+	},
 	service = DTOConverter.class
 )
 public class DocumentMetadataSetDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentShortcutDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentShortcutDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sam Ziemer
  */
 @Component(
-	property = "dto.class.name=com.liferay.document.library.kernel.model.DLFileShortcut",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.document.library.kernel.model.DLFileShortcut"
+	},
 	service = DTOConverter.class
 )
 public class DocumentShortcutDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/ExperienceDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/ExperienceDTOConverter.java
@@ -23,7 +23,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(
-	property = "dto.class.name=com.liferay.segments.model.SegmentsExperience",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.segments.model.SegmentsExperience"
+	},
 	service = DTOConverter.class
 )
 public class ExperienceDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/KnowledgeBaseArticleDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/KnowledgeBaseArticleDTOConverter.java
@@ -41,7 +41,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.knowledge.base.model.KBArticle",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.knowledge.base.model.KBArticle"
+	},
 	service = DTOConverter.class
 )
 public class KnowledgeBaseArticleDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardMessageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardMessageDTOConverter.java
@@ -39,7 +39,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rubén Pulido
  */
 @Component(
-	property = "dto.class.name=com.liferay.message.boards.model.MBMessage",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.message.boards.model.MBMessage"
+	},
 	service = DTOConverter.class
 )
 public class MessageBoardMessageDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardSectionDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardSectionDTOConverter.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier Gamarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.message.boards.model.MBCategory",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.message.boards.model.MBCategory"
+	},
 	service = DTOConverter.class
 )
 public class MessageBoardSectionDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
@@ -46,7 +46,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier Gamarra
  */
 @Component(
-	property = "dto.class.name=com.liferay.message.boards.model.MBThread",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.message.boards.model.MBThread"
+	},
 	service = DTOConverter.class
 )
 public class MessageBoardThreadDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageDefinitionDTOConverter.java
@@ -59,7 +59,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier de Arcos
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.LayoutStructure",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.LayoutStructure"
+	},
 	service = DTOConverter.class
 )
 public class PageDefinitionDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageElementDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageElementDTOConverter.java
@@ -66,7 +66,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier de Arcos
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.LayoutStructureItem",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.LayoutStructureItem"
+	},
 	service = DTOConverter.class
 )
 public class PageElementDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageRuleDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/PageRuleDTOConverter.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Lourdes Fernández Besada
  */
 @Component(
-	property = "dto.class.name=com.liferay.layout.util.structure.LayoutStructureRule",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.layout.util.structure.LayoutStructureRule"
+	},
 	service = DTOConverter.class
 )
 public class PageRuleDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -71,7 +71,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Layout",
+	property = {
+		"default=true", "dto.class.name=com.liferay.portal.kernel.model.Layout"
+	},
 	service = DTOConverter.class
 )
 public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
@@ -72,7 +72,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Víctor Galán
  */
 @Component(
-	property = "dto.class.name=com.liferay.journal.model.JournalArticle",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.journal.model.JournalArticle"
+	},
 	service = DTOConverter.class
 )
 public class StructuredContentDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentFolderDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentFolderDTOConverter.java
@@ -30,7 +30,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Víctor Galán
  */
 @Component(
-	property = "dto.class.name=com.liferay.journal.model.JournalFolder",
+	property = {
+		"default=true", "dto.class.name=com.liferay.journal.model.JournalFolder"
+	},
 	service = DTOConverter.class
 )
 public class StructuredContentFolderDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiNodeDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiNodeDTOConverter.java
@@ -21,7 +21,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Luis Miguel Barcos
  */
 @Component(
-	property = "dto.class.name=com.liferay.wiki.model.WikiNode",
+	property = {
+		"default=true", "dto.class.name=com.liferay.wiki.model.WikiNode"
+	},
 	service = DTOConverter.class
 )
 public class WikiNodeDTOConverter

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiPageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/WikiPageDTOConverter.java
@@ -40,7 +40,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Luis Miguel Barcos
  */
 @Component(
-	property = "dto.class.name=com.liferay.wiki.model.WikiPage",
+	property = {
+		"default=true", "dto.class.name=com.liferay.wiki.model.WikiPage"
+	},
 	service = DTOConverter.class
 )
 public class WikiPageDTOConverter

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/dto/v1_0/converter/InvitedMemberDTOConverter.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/dto/v1_0/converter/InvitedMemberDTOConverter.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.DSR",
+		"application.name=Liferay.Headless.DSR", "default=true",
 		"dto.class.name=com.liferay.headless.dsr.dto.v1_0.InvitedMember",
 		"version=v1.0"
 	},

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/dto/v1_0/converter/UserAccountDTOConverter.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/dto/v1_0/converter/UserAccountDTOConverter.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"application.name=Liferay.Headless.DSR",
+		"application.name=Liferay.Headless.DSR", "default=true",
 		"dto.class.name=com.liferay.headless.dsr.dto.v1_0.UserAccount",
 		"version=v1.0"
 	},

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mikel Lorza
  */
 @Component(
-	property = "dto.class.name=com.liferay.headless.object.dto.v1_0.Collaborator",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.headless.object.dto.v1_0.Collaborator"
+	},
 	service = DTOConverter.class
 )
 public class CollaboratorDTOConverter

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
@@ -41,7 +41,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alicia García
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectEntryFolder",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.object.model.ObjectEntryFolder"
+	},
 	service = DTOConverter.class
 )
 public class ObjectEntryFolderDTOConverter

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/dto/v1_0/converter/UserNotificationDTOConverter.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/dto/v1_0/converter/UserNotificationDTOConverter.java
@@ -33,7 +33,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Carlos Correa
  */
 @Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.UserNotificationEvent",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.portal.kernel.model.UserNotificationEvent"
+	},
 	service = DTOConverter.class
 )
 public class UserNotificationDTOConverter

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectDefinitionDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectDefinitionDTOConverter.java
@@ -37,7 +37,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectDefinition",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.object.model.ObjectDefinition"
+	},
 	service = DTOConverter.class
 )
 public class ObjectDefinitionDTOConverter

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
@@ -36,7 +36,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Feliphe Marinho
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectField",
+	property = {
+		"default=true", "dto.class.name=com.liferay.object.model.ObjectField"
+	},
 	service = DTOConverter.class
 )
 public class ObjectFieldDTOConverter

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectRelationshipDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectRelationshipDTOConverter.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectRelationship",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.object.model.ObjectRelationship"
+	},
 	service = DTOConverter.class
 )
 public class ObjectRelationshipDTOConverter

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectValidationRuleDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectValidationRuleDTOConverter.java
@@ -27,7 +27,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Gabriel Albuquerque
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectValidationRule",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.object.model.ObjectValidationRule"
+	},
 	service = DTOConverter.class
 )
 public class ObjectValidationRuleDTOConverter

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectViewDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectViewDTOConverter.java
@@ -29,7 +29,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Feliphe Marinho
  */
 @Component(
-	property = "dto.class.name=com.liferay.object.model.ObjectView",
+	property = {
+		"default=true", "dto.class.name=com.liferay.object.model.ObjectView"
+	},
 	service = DTOConverter.class
 )
 public class ObjectViewDTOConverter

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -132,7 +132,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"dto.class.name=com.liferay.object.model.ObjectEntry",
+		"default=true", "dto.class.name=com.liferay.object.model.ObjectEntry",
 		"service.ranking:Integer=100"
 	},
 	service = DTOConverter.class

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/dto/converter/DTOConverterRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/dto/converter/DTOConverterRegistryImpl.java
@@ -9,16 +9,21 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 
+import java.util.List;
 import java.util.Set;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Rubén Pulido
@@ -34,20 +39,20 @@ public class DTOConverterRegistryImpl implements DTOConverterRegistry {
 
 	@Override
 	public DTOConverter<?, ?> getDTOConverter(String dtoClassName) {
-		return _serviceTrackerMap.getService(dtoClassName);
+		return _getDTOConverter(dtoClassName);
 	}
 
 	@Override
 	public DTOConverter<?, ?> getDTOConverter(
 		String applicationName, String dtoClassName, String version) {
 
-		return _serviceTrackerMap.getService(
+		return _getDTOConverter(
 			_getKey(applicationName, dtoClassName, version));
 	}
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
 			bundleContext,
 			(Class<DTOConverter<?, ?>>)(Class<?>)DTOConverter.class,
 			"(dto.class.name=*)",
@@ -68,12 +73,44 @@ public class DTOConverterRegistryImpl implements DTOConverterRegistry {
 					emitter.emit(
 						_getKey(applicationName, dtoClassName, version));
 				}
-			});
+			},
+			new DTOConverterServiceTrackerCustomizer(bundleContext));
 	}
 
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private DTOConverter<?, ?> _getDTOConverter(String key) {
+		List<DTOConverterHolder> dtoConverterHolders =
+			_serviceTrackerMap.getService(key);
+
+		if (ListUtil.isEmpty(dtoConverterHolders)) {
+			return null;
+		}
+
+		if (dtoConverterHolders.size() == 1) {
+			DTOConverterHolder dtoConverterHolder = dtoConverterHolders.get(0);
+
+			return dtoConverterHolder.getDTOConverter();
+		}
+
+		DTOConverter<?, ?> defaultDTOConverter = null;
+
+		for (DTOConverterHolder dtoConverterHolder : dtoConverterHolders) {
+			if (!dtoConverterHolder.isDefault()) {
+				continue;
+			}
+
+			if (defaultDTOConverter != null) {
+				return null;
+			}
+
+			defaultDTOConverter = dtoConverterHolder.getDTOConverter();
+		}
+
+		return defaultDTOConverter;
 	}
 
 	private String _getKey(
@@ -84,6 +121,66 @@ public class DTOConverterRegistryImpl implements DTOConverterRegistry {
 			version);
 	}
 
-	private ServiceTrackerMap<String, DTOConverter<?, ?>> _serviceTrackerMap;
+	private ServiceTrackerMap<String, List<DTOConverterHolder>>
+		_serviceTrackerMap;
+
+	private static class DTOConverterHolder {
+
+		public DTOConverterHolder(
+			boolean defaultDTOConverter, DTOConverter<?, ?> dtoConverter) {
+
+			_defaultDTOConverter = defaultDTOConverter;
+			_dtoConverter = dtoConverter;
+		}
+
+		public DTOConverter<?, ?> getDTOConverter() {
+			return _dtoConverter;
+		}
+
+		public boolean isDefault() {
+			return _defaultDTOConverter;
+		}
+
+		private final boolean _defaultDTOConverter;
+		private final DTOConverter<?, ?> _dtoConverter;
+
+	}
+
+	private static class DTOConverterServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<DTOConverter<?, ?>, DTOConverterHolder> {
+
+		public DTOConverterServiceTrackerCustomizer(
+			BundleContext bundleContext) {
+
+			_bundleContext = bundleContext;
+		}
+
+		@Override
+		public DTOConverterHolder addingService(
+			ServiceReference<DTOConverter<?, ?>> serviceReference) {
+
+			return new DTOConverterHolder(
+				GetterUtil.getBoolean(serviceReference.getProperty("default")),
+				_bundleContext.getService(serviceReference));
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<DTOConverter<?, ?>> serviceReference,
+			DTOConverterHolder dtoConverterHolder) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<DTOConverter<?, ?>> serviceReference,
+			DTOConverterHolder dtoConverterHolder) {
+
+			_bundleContext.ungetService(serviceReference);
+		}
+
+		private final BundleContext _bundleContext;
+
+	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/dto/converter/test/DTOConverterRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/dto/converter/test/DTOConverterRegistryTest.java
@@ -91,6 +91,45 @@ public class DTOConverterRegistryTest {
 	}
 
 	@Test
+	public void testGetDTOConverterWithDefaultProperty() throws Exception {
+		String dtoClassName = RandomTestUtil.randomString();
+
+		DTOConverter<?, ?> defaultDTOConverter = new TestDTOConverter();
+		DTOConverter<?, ?> nondefaultDTOConverter = new TestDTOConverter();
+
+		try (AutoCloseable autoCloseable1 = _registerDTOConverter(
+				null, dtoClassName, nondefaultDTOConverter, null);
+			AutoCloseable autoCloseable2 = _registerDefaultDTOConverter(
+				dtoClassName, defaultDTOConverter)) {
+
+			Assert.assertSame(
+				defaultDTOConverter,
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		}
+	}
+
+	@Test
+	public void testGetDTOConverterWithDefaultPropertyOverridesServiceRanking()
+		throws Exception {
+
+		String dtoClassName = RandomTestUtil.randomString();
+
+		DTOConverter<?, ?> defaultDTOConverter = new TestDTOConverter();
+		DTOConverter<?, ?> highRankingDTOConverter = new TestDTOConverter();
+
+		try (AutoCloseable autoCloseable1 =
+				_registerDTOConverterWithServiceRanking(
+					dtoClassName, highRankingDTOConverter, Integer.MAX_VALUE);
+			AutoCloseable autoCloseable2 = _registerDefaultDTOConverter(
+				dtoClassName, defaultDTOConverter)) {
+
+			Assert.assertSame(
+				defaultDTOConverter,
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		}
+	}
+
+	@Test
 	public void testGetDTOConverterWithDTOClassNameProperty() throws Exception {
 		String dtoClassName = RandomTestUtil.randomString();
 
@@ -107,6 +146,54 @@ public class DTOConverterRegistryTest {
 		}
 	}
 
+	@Test
+	public void testGetDTOConverterWithMultipleConvertersAndMultipleDefaults()
+		throws Exception {
+
+		String dtoClassName = RandomTestUtil.randomString();
+
+		try (AutoCloseable autoCloseable1 = _registerDefaultDTOConverter(
+				dtoClassName, new TestDTOConverter());
+			AutoCloseable autoCloseable2 = _registerDefaultDTOConverter(
+				dtoClassName, new TestDTOConverter())) {
+
+			Assert.assertNull(
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		}
+	}
+
+	@Test
+	public void testGetDTOConverterWithMultipleConvertersAndNoDefault()
+		throws Exception {
+
+		String dtoClassName = RandomTestUtil.randomString();
+
+		try (AutoCloseable autoCloseable1 = _registerDTOConverter(
+				null, dtoClassName, new TestDTOConverter(), null);
+			AutoCloseable autoCloseable2 = _registerDTOConverter(
+				null, dtoClassName, new TestDTOConverter(), null)) {
+
+			Assert.assertNull(
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		}
+	}
+
+	private AutoCloseable _registerDefaultDTOConverter(
+		String dtoClassName, DTOConverter<?, ?> dtoConverter) {
+
+		ServiceRegistration<DTOConverter<?, ?>> serviceRegistration =
+			_bundleContext.registerService(
+				(Class<DTOConverter<?, ?>>)(Class<?>)DTOConverter.class,
+				dtoConverter,
+				HashMapDictionaryBuilder.put(
+					"default", "true"
+				).put(
+					"dto.class.name", dtoClassName
+				).build());
+
+		return serviceRegistration::unregister;
+	}
+
 	private AutoCloseable _registerDTOConverter(
 		String applicationName, String dtoClassName,
 		DTOConverter<?, ?> dtoConverter, String version) {
@@ -121,6 +208,23 @@ public class DTOConverterRegistryTest {
 					"dto.class.name", dtoClassName
 				).put(
 					"version", () -> version
+				).build());
+
+		return serviceRegistration::unregister;
+	}
+
+	private AutoCloseable _registerDTOConverterWithServiceRanking(
+		String dtoClassName, DTOConverter<?, ?> dtoConverter,
+		int serviceRanking) {
+
+		ServiceRegistration<DTOConverter<?, ?>> serviceRegistration =
+			_bundleContext.registerService(
+				(Class<DTOConverter<?, ?>>)(Class<?>)DTOConverter.class,
+				dtoConverter,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"dto.class.name", dtoClassName
+				).put(
+					"service.ranking", serviceRanking
 				).build());
 
 		return serviceRegistration::unregister;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/dto/v1_0/converter/SkuForecastDTOConverter.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/dto/v1_0/converter/SkuForecastDTOConverter.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Riccardo Ferrari
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.machine.learning.forecast.SkuCommerceMLForecast",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.commerce.machine.learning.forecast.SkuCommerceMLForecast"
+	},
 	service = DTOConverter.class
 )
 public class SkuForecastDTOConverter

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPBlueprintDTOConverter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPBlueprintDTOConverter.java
@@ -54,7 +54,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	enabled = false,
-	property = "dto.class.name=com.liferay.search.experiences.model.SXPBlueprint",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.search.experiences.model.SXPBlueprint"
+	},
 	service = DTOConverter.class
 )
 public class SXPBlueprintDTOConverter

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPElementDTOConverter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPElementDTOConverter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	enabled = false,
-	property = "dto.class.name=com.liferay.search.experiences.model.SXPElement",
+	property = {
+		"default=true",
+		"dto.class.name=com.liferay.search.experiences.model.SXPElement"
+	},
 	service = DTOConverter.class
 )
 public class SXPElementDTOConverter


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96725

Supersedes https://github.com/liferay-headless/liferay-portal/pull/3989 together with https://github.com/liferay-headless/liferay-portal/pull/4076, which carries the LPD-96726 search changes.

## What Is Being Fixed

When several DTOConverters were registered for the same entity type, the registry picked one arbitrarily, so an embedded item could be serialized with the wrong DTO depending on registration order.

## How It Is Being Fixed

The DTOConverter registry now tracks every converter registered for an entity type and resolves the one marked with the `default=true` component property; when a type has several converters and no single default, it returns null instead of an arbitrary winner. A default DTOConverter is marked for each entity type.

## Pending Review

The `default=true` marking left two entity types in a half-marked state that should be normalized (both resolve to null today, like their all-marked sibling groups, but the inconsistency is misleading):

- `CommerceInventoryWarehouseRel`: 2 of its 3 converters are marked; `WarehouseAccountGroupDTOConverter` is not.
- `CommerceDiscountRel`: the four v2_0 converters are marked; the two v1_0 ones (`DiscountCategoryDTOConverter`, `DiscountProductDTOConverter`) are not.

Additionally, `LayoutPageTemplateEntry` has four converters and none marked as default, which is deliberate (the right DTO depends on the entry subtype), but it means search results of that type carry no `itemURL`/`embedded`; worth confirming during review.

## PR Check

**pr-check: SKIPPED** — left pending on purpose; it will be run and published on this PR later.

<!-- pr-check {"reason": "left pending on purpose; it will be run and published on this PR later", "result": "skipped", "sha": "ce3e29c2f42d4e82cea9b4f39070456ba670d089"} -->
