### PR TITLE
LPD-42559 Require a related entry for a mandatory relationship field

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -3254,6 +3254,48 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testAddObjectEntryWithRequiredRelationshipObjectField()
+		throws Exception {
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			_objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipFieldName);
+
+		_objectFieldLocalService.updateRequired(
+			objectField.getObjectFieldId(), true);
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field \"" +
+				_objectRelationshipFieldName + "\"",
+			() -> _addObjectEntry(
+				_objectDefinition2,
+				HashMapBuilder.<String, Object>put(
+					_objectRelationshipFieldName, 0
+				).build()));
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Object>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Object>put(
+				_objectRelationshipFieldName, objectEntry1.getId()
+			).build());
+
+		Assert.assertEquals(
+			GetterUtil.getLong(objectEntry1.getId()),
+			GetterUtil.getLong(
+				objectEntry2.getProperties(
+				).get(
+					_objectRelationshipFieldName
+				)));
+	}
+
+	@Test
 	public void testAddObjectEntryWithRichTextObjectField() throws Exception {
 		ObjectDefinition objectDefinition = _addObjectDefinition(
 			Collections.singletonList(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -174,12 +174,20 @@ public class RelationshipObjectFieldBusinessType
 			Object value = valueEntry.getValue();
 
 			if (value == null) {
+				if (objectField.isRequired()) {
+					return null;
+				}
+
 				return 0;
 			}
 
 			long valueLong = GetterUtil.getLong(value);
 
 			if (valueLong == 0) {
+				if (objectField.isRequired()) {
+					return null;
+				}
+
 				return value;
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42559

## What Is Being Fixed

A required many-to-one relationship field accepted a foreign key value of 0 (no related entry selected) instead of raising the expected validation error, so a mandatory relationship could be saved without a related entry.

## How It Is Being Fixed

The required-field check in the object service relies on Validator.isNull, which treats 0 as empty only when the value is a java.lang.Long. A relationship foreign key arriving from JSON is an Integer or BigDecimal, so a zero foreign key was considered provided and the mandatory relationship went unvalidated.

An earlier fix that added a foreign-key check directly to ObjectEntryLocalServiceImpl was merged and then reverted, because it also rejected the legitimate deferred-linking flow where the many-side entry is created first with foreign key 0 and linked to a newly created parent afterward (LPD-49175). This change instead resolves an empty foreign key to null in RelationshipObjectFieldBusinessType.getValue when the field is required, so the existing required-value check rejects it. Because the change is confined to the many-to-one value branch and to required fields, a nested new parent still resolves to 0 and is linked after the child is created, and clearing a non-required relationship with 0 keeps working.

## PR Check

**pr-check: PASS** — tested on `09b30bf5f21d4c0e49cc54c926d179e722fd1ccc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "09b30bf5f21d4c0e49cc54c926d179e722fd1ccc"} -->
