### PR TITLE
LPD-68399 Generate batch methods correctly for entities ending in digits

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/rest-config.yaml
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.AI.Hub.Cell.REST
 author: Feliphe Marinho
 clientDir: ../ai-hub-cell-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Analytics.CMS.REST
 author: Rachael Koestartyo
 clientDir: ../analytics-cms-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/analytics/analytics-dxp-entity-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-dxp-entity-rest-impl/rest-config.yaml
@@ -1,7 +1,7 @@
 apiDir: ../analytics-dxp-entity-rest-api/src/main/java
 apiPackagePath: com.liferay.analytics.dxp.entity.rest
 author: Marcos Martins, Rachael Koestartyo, Riccardo Ferrari
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 liferayEnterpriseApp: true

--- a/modules/apps/analytics/analytics-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Analytics.REST
 author: Ivica Cardic
 clientDir: ../analytics-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Analytyics.Settings.REST
 author: Riccardo Ferrari
 clientDir: ../analytics-settings-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 javaEEPackage: jakarta

--- a/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Batch.Planner.REST
 author: Matija Petanjek
 clientDir: ../batch-planner-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Bulk.REST
 author: Alejandro Tardín
 clientDir: ../bulk-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 javaEEPackage: jakarta

--- a/modules/apps/captcha/captcha-rest-impl/rest-config.yaml
+++ b/modules/apps/captcha/captcha-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Captcha.REST
 author: Loc Pham
 clientDir: ../captcha-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Change.Tracking.REST
 author: David Truong
 clientDir: ../change-tracking-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateClientJS: true
 javaEEPackage: jakarta

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Account
 author: Alessio Antonio Rendina
 clientDir: ../headless-commerce-admin-account-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-account-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Catalog
 author: Zoltán Takács
 clientDir: ../headless-commerce-admin-catalog-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Channel
 author: Andrea Sbarra
 clientDir: ../headless-commerce-admin-channel-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: false
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Inventory
 author: Alessio Antonio Rendina
 clientDir: ../headless-commerce-admin-inventory-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-inventory-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Order
 author: Alessio Antonio Rendina
 clientDir: ../headless-commerce-admin-order-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-order-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Payment
 author: Alessio Antonio Rendina
 clientDir: ../headless-commerce-admin-payment-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: true
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-payment-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Pricing
 author: Zoltán Takács
 clientDir: ../headless-commerce-admin-pricing-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-pricing-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Shipment
 author: Andrea Sbarra
 clientDir: ../headless-commerce-admin-shipment-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-shipment-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Admin.Site.Setting
 author: Zoltán Takács
 clientDir: ../headless-commerce-admin-site-setting-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-admin-site-setting-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Delivery.Cart
 author: Andrea Sbarra
 clientDir: ../headless-commerce-delivery-cart-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-delivery-cart-test/src/testIntegration/java

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Delivery.Catalog
 author: Andrea Sbarra
 clientDir: ../headless-commerce-delivery-catalog-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Delivery.Order
 author: Andrea Sbarra
 clientDir: ../headless-commerce-delivery-order-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 javaEEPackage: jakarta
 testDir: ../headless-commerce-delivery-order-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Cookies.REST
 author: Christopher Kian
 clientDir: ../cookies-rest-client/src/main/java
-compatibilityVersion: 14
+compatibilityVersion: 16
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: true
 generateBatch: false

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Data.Engine.REST
 author: Jeyvison Nascimento
 clientDir: ../data-engine-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../data-engine-rest-test/src/testIntegration/java

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Digital.Signature.REST
 author: José Abelenda
 clientDir: ../digital-signature-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../digital-signature-rest-test/src/testIntegration/java

--- a/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
+++ b/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Dispatch.REST
 author: Nilton Vieira
 clientDir: ../dispatch-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../dispatch-rest-test/src/testIntegration/java

--- a/modules/apps/export-import/export-import-rest-impl/rest-config.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Export.Import.REST
 author: Petteri Karttunen
 clientDir: ../export-import-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Address
 author: Drew Brokke
 clientDir: ../headless-admin-address-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-address-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Configuration
 author: Thiago Buarque
 clientDir: ../headless-admin-configuration-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Javier Gamarra
 changeTrackingEnabled: true
 clientDir: ../headless-admin-content-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 graphQLNamespace: admin

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Fragment
 author: Rubén Pulido
 clientDir: ../headless-admin-fragment-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.List.Type
 author: Gabriel Albuquerque
 clientDir: ../headless-admin-list-type-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-list-type-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-server/headless-admin-server-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-server/headless-admin-server-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Server
 author: Luis Ortiz
 clientDir: ../headless-admin-server-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Site
 author: Rubén Pulido
 clientDir: ../headless-admin-site-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Javier Gamarra
 changeTrackingEnabled: true
 clientDir: ../headless-admin-taxonomy-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateActionProviders: true
 generateClientJS: true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: Liferay.Headless.Admin.User
 author: Javier Gamarra
 clientDir: ../headless-admin-user-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 javaEEPackage: jakarta
 testDir: ../headless-admin-user-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
@@ -6,6 +6,6 @@ application:
     name: Liferay.Headless.Admin.Workflow
 author: Javier Gamarra
 clientDir: ../headless-admin-workflow-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 javaEEPackage: jakarta
 testDir: ../headless-admin-workflow-test/src/testIntegration/java

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Asset.Library
 author: Roberto Díaz
 clientDir: ../headless-asset-library-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Batch.Engine
 author: Ivica Cardic
 clientDir: ../headless-batch-engine-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Carolina Barbosa
 changeTrackingEnabled: true
 clientDir: ../headless-cmp-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generatePermissions: true

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Crescenzo Rega
 changeTrackingEnabled: true
 clientDir: ../headless-cms-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generatePermissions: true

--- a/modules/apps/headless/headless-data-mask/headless-data-mask-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-data-mask/headless-data-mask-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Data.Mask
 author: Jose Luis Navarro
 clientDir: ../headless-data-mask-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Javier Gamarra
 changeTrackingEnabled: true
 clientDir: ../headless-delivery-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-delivery-test/src/testIntegration/java

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Stefano Motta
 changeTrackingEnabled: true
 clientDir: ../headless-dsr-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: true
 generateBatch: false

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Form
 author: Javier Gamarra
 clientDir: ../headless-form-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-form-test/src/testIntegration/java

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Alicia García
 changeTrackingEnabled: true
 clientDir: ../headless-object-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generatePermissions: true
 javaEEPackage: jakarta

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Portal.Instances
 author: Alberto Chaparro
 clientDir: ../headless-portal-instances-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Site
 author: Rubén Pulido
 clientDir: ../headless-site-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.User.Notification
 author: Carlos Correa
 clientDir: ../headless-user-notification-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-user-notification-test/src/testIntegration/java

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-config.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.MCP.Server
 author: Alejandro Tardín
 clientDir: ../mcp-server-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/notification/notification-rest-impl/rest-config.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Notification.REST
 author: Gabriel Albuquerque
 clientDir: ../notification-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../notification-rest-test/src/testIntegration/java

--- a/modules/apps/oauth-client/oauth-client-rest-impl/rest-config.yaml
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.OAuth.Client.REST
 author: Manuele Castro
 clientDir: ../oauth-client-rest-client/src/main/java
-compatibilityVersion: 14
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientASLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientASLocalMetadataResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.oauth.client.rest.internal.resource.v1_0;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientASLocalMetadata;
 import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientASLocalMetadataResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
@@ -501,6 +502,15 @@ public abstract class BaseOAuthClientASLocalMetadataResourceImpl
 			@Override
 			public Locale getPreferredLocale() {
 				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
 			}
 
 		};
@@ -1083,4 +1093,4 @@ public abstract class BaseOAuthClientASLocalMetadataResourceImpl
 		LogFactoryUtil.getLog(BaseOAuthClientASLocalMetadataResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-400297945
+// LIFERAY-REST-BUILDER-HASH:1398259052

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientEntryResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientEntryResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.oauth.client.rest.internal.resource.v1_0;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientEntry;
 import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientEntryResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
@@ -462,6 +463,15 @@ public abstract class BaseOAuthClientEntryResourceImpl
 			@Override
 			public Locale getPreferredLocale() {
 				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
 			}
 
 		};
@@ -1040,4 +1050,4 @@ public abstract class BaseOAuthClientEntryResourceImpl
 		LogFactoryUtil.getLog(BaseOAuthClientEntryResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-450878247
+// LIFERAY-REST-BUILDER-HASH:-1131900586

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientPRLocalMetadataResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.oauth.client.rest.internal.resource.v1_0;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
 import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientPRLocalMetadataResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
@@ -501,6 +502,15 @@ public abstract class BaseOAuthClientPRLocalMetadataResourceImpl
 			@Override
 			public Locale getPreferredLocale() {
 				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
 			}
 
 		};
@@ -1083,4 +1093,4 @@ public abstract class BaseOAuthClientPRLocalMetadataResourceImpl
 		LogFactoryUtil.getLog(BaseOAuthClientPRLocalMetadataResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1209371799
+// LIFERAY-REST-BUILDER-HASH:-1130022756

--- a/modules/apps/object/object-admin-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Object.Admin.REST
 author: Javier Gamarra
 clientDir: ../object-admin-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateClientJS: true
 javaEEPackage: jakarta

--- a/modules/apps/object/object-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-rest-impl/rest-config.yaml
@@ -1,7 +1,7 @@
 apiDir: ../object-rest-api/src/main/java
 apiPackagePath: com.liferay.object.rest
 author: Javier Gamarra
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateOpenAPI: false
 javaEEPackage: jakarta

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Portal.Language.REST
 author: Thiago Buarque
 clientDir: ../portal-language-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Petteri Karttunen
 changeTrackingEnabled: true
 clientDir: ../portal-search-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../portal-search-rest-test/src/testIntegration/java

--- a/modules/apps/portal-security-audit/portal-security-audit-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-security-audit/portal-security-audit-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Audit.REST
 author: Rafael Praxedes
 clientDir: ../portal-security-audit-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/apps/site/site-dsr-analytics-rest-impl/rest-config.yaml
+++ b/modules/apps/site/site-dsr-analytics-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Site.DSR.Analytics.REST
 author: Gianmarco Brunialti
 clientDir: ../site-dsr-analytics-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false

--- a/modules/dxp/apps/analytics/analytics-reports-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Analytics.Reports.REST
 author: Marcos Martins
 clientDir: ../analytics-reports-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateBatch: false
 javaEEPackage: jakarta

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
@@ -5,7 +5,7 @@ application:
     className: HeadlessCommercePunchOutApplication
     name: Liferay.Headless.Commerce.PunchOut
 author: Jaclyn Ong
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: false
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Commerce.Machine.Learning
 author: Riccardo Ferrari
 clientDir: ../headless-commerce-machine-learning-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableSchemaPropertyName: true
 javaEEPackage: jakarta
 testDir: ../headless-commerce-machine-learning-test/src/testIntegration/java

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.OSB.Testray.REST
 author: José Abelenda
 clientDir: ../osb-testray-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../osb-testray-rest-test/src/testIntegration/java

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Portal.Workflow.Metrics.REST
 author: Rafael Praxedes
 clientDir: ../portal-workflow-metrics-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../portal-workflow-metrics-rest-test/src/testIntegration/java

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Saml.Admin.REST
 author: Stian Sigvartsen
 clientDir: ../saml-admin-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../saml-admin-rest-test/src/testIntegration/java

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Scim.REST
 author: Olivér Kecskeméty
 clientDir: ../scim-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: false
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Search.Experiences.REST
 author: Brian Wing Shun Chan
 clientDir: ../search-experiences-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../search-experiences-rest-test/src/testIntegration/java

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Segments.Asah.REST
 author: Javier Gamarra
 clientDir: ../segments-asah-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../segments-asah-rest-test/src/testIntegration/java

--- a/modules/dxp/apps/seo-studio/seo-studio-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/seo-studio/seo-studio-rest-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.SEO.Studio.REST
 author: Brooke Dalton
 clientDir: ../seo-studio-rest-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity1Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity1Resource.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -50,6 +51,10 @@ public interface EntityModelResourceTestEntity1Resource {
 
 	public Page<EntityModelResourceTestEntity1>
 			getEntityModelResourceTestEntities1Page()
+		throws Exception;
+
+	public Response postEntityModelResourceTestEntities1PageExportBatch(
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -148,4 +153,4 @@ public interface EntityModelResourceTestEntity1Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-265995752
+// LIFERAY-REST-BUILDER-HASH:1500280967

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity2Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity2Resource.java
@@ -45,9 +45,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface EntityModelResourceTestEntity2Resource {
 
-	public EntityModelResourceTestEntity2
-			getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
-				Long entityModelResourceTestEntity2Id)
+	public EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2(
+			Long entityModelResourceTestEntity2Id)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -138,4 +137,4 @@ public interface EntityModelResourceTestEntity2Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1525313680
+// LIFERAY-REST-BUILDER-HASH:-467528347

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity2API.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity2API.ts
@@ -31,7 +31,7 @@ export class EntityModelResourceTestEntity2API {
 				 * @param entityModelResourceTestEntity2Id
 		 * @param headers Optional custom request headers
 		 */
-		public async getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
+		public async getEntityModelResourceTestEntity2(
 						entityModelResourceTestEntity2Id: number,
 			headers?: {[name: string]: string},
 		): Promise<{
@@ -46,7 +46,7 @@ export class EntityModelResourceTestEntity2API {
 			const queryParameters: any = {};
 
 						if (entityModelResourceTestEntity2Id === null || entityModelResourceTestEntity2Id === undefined) {
-							throw new Error("Required parameter entityModelResourceTestEntity2Id was null or undefined when calling getEntityModelResourceTestEntities2EntityModelResourceTestEntity2.");
+							throw new Error("Required parameter entityModelResourceTestEntity2Id was null or undefined when calling getEntityModelResourceTestEntity2.");
 						}
 
 			const queryString = Object.keys(queryParameters).length ?

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity1Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity1Resource.java
@@ -41,6 +41,15 @@ public interface EntityModelResourceTestEntity1Resource {
 			getEntityModelResourceTestEntities1PageHttpResponse()
 		throws Exception;
 
+	public void postEntityModelResourceTestEntities1PageExportBatch(
+			String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postEntityModelResourceTestEntities1PageExportBatchHttpResponse(
+				String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -255,6 +264,117 @@ public interface EntityModelResourceTestEntity1Resource {
 			return httpInvoker.invoke();
 		}
 
+		public void postEntityModelResourceTestEntities1PageExportBatch(
+				String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postEntityModelResourceTestEntities1PageExportBatchHttpResponse(
+					callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postEntityModelResourceTestEntities1PageExportBatchHttpResponse(
+					String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities1/export-batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		private EntityModelResourceTestEntity1ResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -267,4 +387,4 @@ public interface EntityModelResourceTestEntity1Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2129223156
+// LIFERAY-REST-BUILDER-HASH:-839234406

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity2Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity2Resource.java
@@ -31,13 +31,12 @@ public interface EntityModelResourceTestEntity2Resource {
 		return new Builder();
 	}
 
-	public EntityModelResourceTestEntity2
-			getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
-				Long entityModelResourceTestEntity2Id)
+	public EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2(
+			Long entityModelResourceTestEntity2Id)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getEntityModelResourceTestEntities2EntityModelResourceTestEntity2HttpResponse(
+			getEntityModelResourceTestEntity2HttpResponse(
 				Long entityModelResourceTestEntity2Id)
 		throws Exception;
 
@@ -150,13 +149,12 @@ public interface EntityModelResourceTestEntity2Resource {
 	public static class EntityModelResourceTestEntity2ResourceImpl
 		implements EntityModelResourceTestEntity2Resource {
 
-		public EntityModelResourceTestEntity2
-				getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
-					Long entityModelResourceTestEntity2Id)
+		public EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2(
+				Long entityModelResourceTestEntity2Id)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getEntityModelResourceTestEntities2EntityModelResourceTestEntity2HttpResponse(
+				getEntityModelResourceTestEntity2HttpResponse(
 					entityModelResourceTestEntity2Id);
 
 			String content = httpResponse.getContent();
@@ -220,7 +218,7 @@ public interface EntityModelResourceTestEntity2Resource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getEntityModelResourceTestEntities2EntityModelResourceTestEntity2HttpResponse(
+				getEntityModelResourceTestEntity2HttpResponse(
 					Long entityModelResourceTestEntity2Id)
 			throws Exception {
 
@@ -274,4 +272,4 @@ public interface EntityModelResourceTestEntity2Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:846905044
+// LIFERAY-REST-BUILDER-HASH:-191760289

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
@@ -7,7 +7,7 @@ application:
 author: Alejandro Tardín
 changeTrackingEnabled: true
 clientDir: ../portal-tools-rest-builder-test-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 generateClientJS: true
 generateGraphQL: true

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -1371,7 +1371,7 @@ paths:
         get:
             description:
                 "Retrieve a EntityModelResourceTestEntity2 item. (EntityModelResource and VulcanBatchEngineTaskItemDelegate interfaces will not be implemented automatically)"
-            operationId: getEntityModelResourceTestEntities2EntityModelResourceTestEntity2
+            operationId: getEntityModelResourceTestEntity2
             parameters:
                 -   in: path
                     name: entityModelResourceTestEntity2Id

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
@@ -27,6 +27,7 @@ import com.liferay.portal.tools.rest.builder.test.resource.v1_0.CompanyTestEntit
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.ERCAssetLibraryTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.ERCScopedTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.ERCSiteTestEntityResource;
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.EntityModelResourceTestEntity1Resource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.FilterResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.MultipartTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.SchemaResource;
@@ -111,6 +112,15 @@ public class Mutation {
 
 		_ercSiteTestEntityResourceComponentServiceObjects =
 			ercSiteTestEntityResourceComponentServiceObjects;
+	}
+
+	public static void
+		setEntityModelResourceTestEntity1ResourceComponentServiceObjects(
+			ComponentServiceObjects<EntityModelResourceTestEntity1Resource>
+				entityModelResourceTestEntity1ResourceComponentServiceObjects) {
+
+		_entityModelResourceTestEntity1ResourceComponentServiceObjects =
+			entityModelResourceTestEntity1ResourceComponentServiceObjects;
 	}
 
 	public static void setFilterResourceComponentServiceObjects(
@@ -977,6 +987,22 @@ public class Mutation {
 
 				return paginationPage.getItems();
 			});
+	}
+
+	@GraphQLField
+	public Response createEntityModelResourceTestEntities1PageExportBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_entityModelResourceTestEntity1ResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			entityModelResourceTestEntity1Resource ->
+				entityModelResourceTestEntity1Resource.
+					postEntityModelResourceTestEntities1PageExportBatch(
+						callbackURL, contentType, fieldNames));
 	}
 
 	@GraphQLField
@@ -1907,6 +1933,34 @@ public class Mutation {
 			_vulcanBatchEngineImportTaskResource);
 	}
 
+	private void _populateResourceContext(
+			EntityModelResourceTestEntity1Resource
+				entityModelResourceTestEntity1Resource)
+		throws Exception {
+
+		entityModelResourceTestEntity1Resource.setContextAcceptLanguage(
+			_acceptLanguage);
+		entityModelResourceTestEntity1Resource.setContextCompany(_company);
+		entityModelResourceTestEntity1Resource.setContextHttpServletRequest(
+			_httpServletRequest);
+		entityModelResourceTestEntity1Resource.setContextHttpServletResponse(
+			_httpServletResponse);
+		entityModelResourceTestEntity1Resource.setContextUriInfo(_uriInfo);
+		entityModelResourceTestEntity1Resource.setContextUser(_user);
+		entityModelResourceTestEntity1Resource.setGroupLocalService(
+			_groupLocalService);
+		entityModelResourceTestEntity1Resource.setRoleLocalService(
+			_roleLocalService);
+
+		entityModelResourceTestEntity1Resource.
+			setVulcanBatchEngineExportTaskResource(
+				_vulcanBatchEngineExportTaskResource);
+
+		entityModelResourceTestEntity1Resource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
+	}
+
 	private void _populateResourceContext(FilterResource filterResource)
 		throws Exception {
 
@@ -2089,6 +2143,9 @@ public class Mutation {
 		_ercScopedTestEntityResourceComponentServiceObjects;
 	private static ComponentServiceObjects<ERCSiteTestEntityResource>
 		_ercSiteTestEntityResourceComponentServiceObjects;
+	private static ComponentServiceObjects
+		<EntityModelResourceTestEntity1Resource>
+			_entityModelResourceTestEntity1ResourceComponentServiceObjects;
 	private static ComponentServiceObjects<FilterResource>
 		_filterResourceComponentServiceObjects;
 	private static ComponentServiceObjects<MultipartTestEntityResource>
@@ -2126,4 +2183,4 @@ public class Mutation {
 		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2074290579
+// LIFERAY-REST-BUILDER-HASH:1933774722

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
@@ -682,15 +682,14 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {entityModelResourceTestEntities2EntityModelResourceTestEntity2(entityModelResourceTestEntity2Id: ___){id, name}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {entityModelResourceTestEntity2(entityModelResourceTestEntity2Id: ___){id, name}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieve a EntityModelResourceTestEntity2 item. (EntityModelResource and VulcanBatchEngineTaskItemDelegate interfaces will not be implemented automatically)"
 	)
-	public EntityModelResourceTestEntity2
-			entityModelResourceTestEntities2EntityModelResourceTestEntity2(
-				@GraphQLName("entityModelResourceTestEntity2Id") Long
-					entityModelResourceTestEntity2Id)
+	public EntityModelResourceTestEntity2 entityModelResourceTestEntity2(
+			@GraphQLName("entityModelResourceTestEntity2Id") Long
+				entityModelResourceTestEntity2Id)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -698,7 +697,7 @@ public class Query {
 			this::_populateResourceContext,
 			entityModelResourceTestEntity2Resource ->
 				entityModelResourceTestEntity2Resource.
-					getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
+					getEntityModelResourceTestEntity2(
 						entityModelResourceTestEntity2Id));
 	}
 
@@ -2150,4 +2149,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2136133290
+// LIFERAY-REST-BUILDER-HASH:913081705

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -78,6 +78,9 @@ public class ServletDataImpl implements ServletData {
 			_ercScopedTestEntityResourceComponentServiceObjects);
 		Mutation.setERCSiteTestEntityResourceComponentServiceObjects(
 			_ercSiteTestEntityResourceComponentServiceObjects);
+		Mutation.
+			setEntityModelResourceTestEntity1ResourceComponentServiceObjects(
+				_entityModelResourceTestEntity1ResourceComponentServiceObjects);
 		Mutation.setFilterResourceComponentServiceObjects(
 			_filterResourceComponentServiceObjects);
 		Mutation.setMultipartTestEntityResourceComponentServiceObjects(
@@ -387,6 +390,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ERCSiteTestEntityResourceImpl.class,
 							"putSiteERCSiteTestEntityPermissionsPage"));
+					put(
+						"mutation#createEntityModelResourceTestEntities1PageExportBatch",
+						new ObjectValuePair<>(
+							EntityModelResourceTestEntity1ResourceImpl.class,
+							"postEntityModelResourceTestEntities1PageExportBatch"));
 					put(
 						"mutation#createFiltersPageExportBatch",
 						new ObjectValuePair<>(
@@ -744,10 +752,10 @@ public class ServletDataImpl implements ServletData {
 							EntityModelResourceTestEntity1ResourceImpl.class,
 							"getEntityModelResourceTestEntities1Page"));
 					put(
-						"query#entityModelResourceTestEntities2EntityModelResourceTestEntity2",
+						"query#entityModelResourceTestEntity2",
 						new ObjectValuePair<>(
 							EntityModelResourceTestEntity2ResourceImpl.class,
-							"getEntityModelResourceTestEntities2EntityModelResourceTestEntity2"));
+							"getEntityModelResourceTestEntity2"));
 					put(
 						"query#filters",
 						new ObjectValuePair<>(
@@ -896,6 +904,10 @@ public class ServletDataImpl implements ServletData {
 		_ercSiteTestEntityResourceComponentServiceObjects;
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<EntityModelResourceTestEntity1Resource>
+		_entityModelResourceTestEntity1ResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<FilterResource>
 		_filterResourceComponentServiceObjects;
 
@@ -928,10 +940,6 @@ public class ServletDataImpl implements ServletData {
 		_testEntityResourceComponentServiceObjects;
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
-	private ComponentServiceObjects<EntityModelResourceTestEntity1Resource>
-		_entityModelResourceTestEntity1ResourceComponentServiceObjects;
-
-	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<EntityModelResourceTestEntity2Resource>
 		_entityModelResourceTestEntity2ResourceComponentServiceObjects;
 
@@ -940,4 +948,4 @@ public class ServletDataImpl implements ServletData {
 		_testEntityAddressResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:129083861
+// LIFERAY-REST-BUILDER-HASH:-1186725564

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity1ResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity1ResourceImpl.java
@@ -47,6 +47,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.io.Serializable;
@@ -95,11 +96,76 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities1/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "EntityModelResourceTestEntity1"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/entity-model-resource-test-entities1/export-batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postEntityModelResourceTestEntities1PageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				EntityModelResourceTestEntity1.class.getName(), callbackURL,
+				contentType, fieldNames)
+		).build();
+	}
+
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
 			Collection<EntityModelResourceTestEntity1>
-				entityModelResourceTestEntity1s,
+				entityModelResourceTestEntities1,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -110,7 +176,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 	@Override
 	public void delete(
 			Collection<EntityModelResourceTestEntity1>
-				entityModelResourceTestEntity1s,
+				entityModelResourceTestEntities1,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -150,8 +216,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return getEntityModelResourceTestEntities1Page();
 	}
 
 	@Override
@@ -188,7 +253,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 	@Override
 	public void update(
 			Collection<EntityModelResourceTestEntity1>
-				entityModelResourceTestEntity1s,
+				entityModelResourceTestEntities1,
 			Map<String, Serializable> parameters)
 		throws Exception {
 
@@ -764,4 +829,4 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 			BaseEntityModelResourceTestEntity1ResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1060220654
+// LIFERAY-REST-BUILDER-HASH:2054175493

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity2ResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity2ResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTe
 import com.liferay.portal.tools.rest.builder.test.dto.v1_0.Filter;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.EntityModelResourceTestEntity2Resource;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -41,7 +42,8 @@ import java.util.Map;
 @Generated("")
 @jakarta.ws.rs.Path("/v1.0")
 public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
-	implements EntityModelResourceTestEntity2Resource {
+	implements EntityModelResourceTestEntity2Resource,
+			   VulcanCRUDItemDelegate<EntityModelResourceTestEntity2> {
 
 	/**
 	 * Invoke this method with the command line:
@@ -72,15 +74,19 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public EntityModelResourceTestEntity2
-			getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@jakarta.validation.constraints.NotNull
-				@jakarta.ws.rs.PathParam("entityModelResourceTestEntity2Id")
-				Long entityModelResourceTestEntity2Id)
+	public EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("entityModelResourceTestEntity2Id")
+			Long entityModelResourceTestEntity2Id)
 		throws Exception {
 
 		return new EntityModelResourceTestEntity2();
+	}
+
+	@Override
+	public EntityModelResourceTestEntity2 getItem(Long id) throws Exception {
+		return getEntityModelResourceTestEntity2(id);
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -529,4 +535,4 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
 			BaseEntityModelResourceTestEntity2ResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:507882112
+// LIFERAY-REST-BUILDER-HASH:1401931497

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/entity-model-resource-test-entity1.properties
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/entity-model-resource-test-entity1.properties
@@ -5,7 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTestEntity1
 batch.engine.task.item.delegate=true
-batch.planner.export.enabled=false
+batch.planner.export.enabled=true
 batch.planner.import.enabled=false
 entity.class.name=com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTestEntity1
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Tools.REST.Builder.Test)

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/entity-model-resource-test-entity2.properties
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/entity-model-resource-test-entity2.properties
@@ -3,6 +3,8 @@
 #
 
 api.version=v1.0
+crud.entity.class.name=com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTestEntity2
+crud.item.delegate=true
 entity.class.name=com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTestEntity2
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Tools.REST.Builder.Test)
 osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity1ResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity1ResourceTestCase.java
@@ -249,12 +249,12 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 
 	protected void assertContains(
 		EntityModelResourceTestEntity1 entityModelResourceTestEntity1,
-		List<EntityModelResourceTestEntity1> entityModelResourceTestEntity1s) {
+		List<EntityModelResourceTestEntity1> entityModelResourceTestEntities1) {
 
 		boolean contains = false;
 
 		for (EntityModelResourceTestEntity1 item :
-				entityModelResourceTestEntity1s) {
+				entityModelResourceTestEntities1) {
 
 			if (equals(entityModelResourceTestEntity1, item)) {
 				contains = true;
@@ -264,7 +264,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 		}
 
 		Assert.assertTrue(
-			entityModelResourceTestEntity1s + " does not contain " +
+			entityModelResourceTestEntities1 + " does not contain " +
 				entityModelResourceTestEntity1,
 			contains);
 	}
@@ -290,18 +290,19 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 	}
 
 	protected void assertEquals(
-		List<EntityModelResourceTestEntity1> entityModelResourceTestEntity1s1,
-		List<EntityModelResourceTestEntity1> entityModelResourceTestEntity1s2) {
+		List<EntityModelResourceTestEntity1> entityModelResourceTestEntities11,
+		List<EntityModelResourceTestEntity1>
+			entityModelResourceTestEntities12) {
 
 		Assert.assertEquals(
-			entityModelResourceTestEntity1s1.size(),
-			entityModelResourceTestEntity1s2.size());
+			entityModelResourceTestEntities11.size(),
+			entityModelResourceTestEntities12.size());
 
-		for (int i = 0; i < entityModelResourceTestEntity1s1.size(); i++) {
+		for (int i = 0; i < entityModelResourceTestEntities11.size(); i++) {
 			EntityModelResourceTestEntity1 entityModelResourceTestEntity11 =
-				entityModelResourceTestEntity1s1.get(i);
+				entityModelResourceTestEntities11.get(i);
 			EntityModelResourceTestEntity1 entityModelResourceTestEntity12 =
-				entityModelResourceTestEntity1s2.get(i);
+				entityModelResourceTestEntities12.get(i);
 
 			assertEquals(
 				entityModelResourceTestEntity11,
@@ -310,21 +311,22 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 	}
 
 	protected void assertEqualsIgnoringOrder(
-		List<EntityModelResourceTestEntity1> entityModelResourceTestEntity1s1,
-		List<EntityModelResourceTestEntity1> entityModelResourceTestEntity1s2) {
+		List<EntityModelResourceTestEntity1> entityModelResourceTestEntities11,
+		List<EntityModelResourceTestEntity1>
+			entityModelResourceTestEntities12) {
 
 		Assert.assertEquals(
-			entityModelResourceTestEntity1s1.size(),
-			entityModelResourceTestEntity1s2.size());
+			entityModelResourceTestEntities11.size(),
+			entityModelResourceTestEntities12.size());
 
 		for (EntityModelResourceTestEntity1 entityModelResourceTestEntity11 :
-				entityModelResourceTestEntity1s1) {
+				entityModelResourceTestEntities11) {
 
 			boolean contains = false;
 
 			for (EntityModelResourceTestEntity1
 					entityModelResourceTestEntity12 :
-						entityModelResourceTestEntity1s2) {
+						entityModelResourceTestEntities12) {
 
 				if (equals(
 						entityModelResourceTestEntity11,
@@ -337,7 +339,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 			}
 
 			Assert.assertTrue(
-				entityModelResourceTestEntity1s2 + " does not contain " +
+				entityModelResourceTestEntities12 + " does not contain " +
 					entityModelResourceTestEntity11,
 				contains);
 		}
@@ -383,9 +385,9 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 		boolean valid = false;
 
 		java.util.Collection<EntityModelResourceTestEntity1>
-			entityModelResourceTestEntity1s = page.getItems();
+			entityModelResourceTestEntities1 = page.getItems();
 
-		int size = entityModelResourceTestEntity1s.size();
+		int size = entityModelResourceTestEntities1.size();
 
 		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
 			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
@@ -959,4 +961,4 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 			_entityModelResourceTestEntity1Resource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:103781422
+// LIFERAY-REST-BUILDER-HASH:-1424656881

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -21,6 +22,12 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -34,18 +41,30 @@ import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.EntityModelResourceTestEntity2;
 import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
 import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
 import com.liferay.portal.tools.rest.builder.test.client.resource.v1_0.EntityModelResourceTestEntity2Resource;
 import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.EntityModelResourceTestEntity2SerDes;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import jakarta.annotation.Generated;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 
 import java.lang.reflect.Method;
+
+import java.net.URI;
 
 import java.text.Format;
 
@@ -56,6 +75,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -68,6 +88,9 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
 /**
  * @author Alejandro Tardín
  * @generated
@@ -77,8 +100,10 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -192,15 +217,13 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 	}
 
 	@Test
-	public void testGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2()
-		throws Exception {
-
+	public void testGetEntityModelResourceTestEntity2() throws Exception {
 		EntityModelResourceTestEntity2 postEntityModelResourceTestEntity2 =
-			testGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
+			testGetEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
 
 		EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2 =
 			entityModelResourceTestEntity2Resource.
-				getEntityModelResourceTestEntities2EntityModelResourceTestEntity2(
+				getEntityModelResourceTestEntity2(
 					postEntityModelResourceTestEntity2.getId());
 
 		assertEquals(
@@ -209,8 +232,209 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 		assertValid(getEntityModelResourceTestEntity2);
 	}
 
+	@Test
+	public void testVulcanCRUDItemDelegateGetItem() throws Exception {
+		EntityModelResourceTestEntity2 postEntityModelResourceTestEntity2 =
+			testGetEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
+
+		EntityModelResourceTestEntity2 getEntityModelResourceTestEntity2 =
+			entityModelResourceTestEntity2Resource.
+				getEntityModelResourceTestEntity2(
+					postEntityModelResourceTestEntity2.getId());
+
+		VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+			_vulcanCRUDItemDelegateBuilderRegistry.builder(
+				testCompany,
+				"com.liferay.portal.tools.rest.builder.test.dto.v1_0.EntityModelResourceTestEntity2"
+			).acceptLanguage(
+				new AcceptLanguage() {
+
+					@Override
+					public List<Locale> getLocales() {
+						return Arrays.asList(LocaleUtil.getDefault());
+					}
+
+					@Override
+					public String getPreferredLanguageId() {
+						return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+					}
+
+					@Override
+					public Locale getPreferredLocale() {
+						return LocaleUtil.getDefault();
+					}
+
+				}
+			).groupLocalService(
+				_groupLocalService
+			).httpServletRequest(
+				testVulcanCRUDItemDelegate_getHttpServletRequest()
+			).httpServletResponse(
+				new MockHttpServletResponse()
+			).resourceActionLocalService(
+				_resourceActionLocalService
+			).resourcePermissionLocalService(
+				_resourcePermissionLocalService
+			).roleLocalService(
+				_roleLocalService
+			).scopeChecker(
+				_scopeChecker
+			).uriInfo(
+				testVulcanCRUDItemDelegate_getUriInfo()
+			).user(
+				testVulcanCRUDItemDelegate_getUser()
+			).build();
+
+		Object item = vulcanCRUDItemDelegate.getItem(
+			postEntityModelResourceTestEntity2.getId());
+
+		assertEquals(
+			getEntityModelResourceTestEntity2,
+			EntityModelResourceTestEntity2SerDes.toDTO(item.toString()));
+	}
+
+	protected HttpServletRequest
+		testVulcanCRUDItemDelegate_getHttpServletRequest() {
+
+		return new MockHttpServletRequest() {
+
+			@Override
+			public StringBuffer getRequestURL() {
+				return new StringBuffer(
+					StringBundler.concat(
+						"http://localhost:",
+						String.valueOf(PortalUtil.getPortalServerPort(false)),
+						"/o/v1.0/", RandomTestUtil.randomString(), "/",
+						RandomTestUtil.randomString()));
+			}
+
+		};
+	}
+
+	protected UriInfo testVulcanCRUDItemDelegate_getUriInfo() {
+		String applicationPath = RandomTestUtil.randomString() + "/";
+		String resourcePath = RandomTestUtil.randomString();
+
+		return new UriInfo() {
+
+			@Override
+			public String getPath() {
+				return resourcePath;
+			}
+
+			@Override
+			public String getPath(boolean decode) {
+				return getPath();
+			}
+
+			@Override
+			public List<PathSegment> getPathSegments() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<PathSegment> getPathSegments(boolean decode) {
+				return getPathSegments();
+			}
+
+			@Override
+			public URI getRequestUri() {
+				return URI.create(
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false), "/o/",
+						applicationPath, resourcePath));
+			}
+
+			@Override
+			public UriBuilder getRequestUriBuilder() {
+				return UriBuilder.fromUri(getRequestUri());
+			}
+
+			@Override
+			public URI getAbsolutePath() {
+				return getRequestUri();
+			}
+
+			@Override
+			public UriBuilder getAbsolutePathBuilder() {
+				return getRequestUriBuilder();
+			}
+
+			@Override
+			public URI getBaseUri() {
+				return URI.create(
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false), "/o/",
+						applicationPath));
+			}
+
+			@Override
+			public UriBuilder getBaseUriBuilder() {
+				return UriBuilder.fromUri(getBaseUri());
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getPathParameters() {
+				return new MultivaluedHashMap<>();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getPathParameters(
+				boolean decode) {
+
+				return getPathParameters();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getQueryParameters() {
+				return new MultivaluedHashMap<>();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getQueryParameters(
+				boolean decode) {
+
+				return getQueryParameters();
+			}
+
+			@Override
+			public List<String> getMatchedURIs() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<String> getMatchedURIs(boolean decode) {
+				return getMatchedURIs();
+			}
+
+			@Override
+			public List<Object> getMatchedResources() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public URI resolve(URI requestUri) {
+				return getBaseUri().resolve(requestUri);
+			}
+
+			@Override
+			public URI relativize(URI uri) {
+				return getBaseUri().relativize(uri);
+			}
+
+		};
+	}
+
+	protected com.liferay.portal.kernel.model.User
+		testVulcanCRUDItemDelegate_getUser() {
+
+		return _testCompanyAdminUser;
+	}
+
 	protected EntityModelResourceTestEntity2
-			testGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2_addEntityModelResourceTestEntity2()
+			testGetEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -218,11 +442,11 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2()
+	public void testGraphQLGetEntityModelResourceTestEntity2()
 		throws Exception {
 
 		EntityModelResourceTestEntity2 entityModelResourceTestEntity2 =
-			testGraphQLGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
+			testGraphQLGetEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
 
 		// No namespace
 
@@ -233,7 +457,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
+								"entityModelResourceTestEntity2",
 								new HashMap<String, Object>() {
 									{
 										put(
@@ -244,7 +468,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
-						"Object/entityModelResourceTestEntities2EntityModelResourceTestEntity2"))));
+						"Object/entityModelResourceTestEntity2"))));
 
 		// Using the namespace portalTools_v1_0
 
@@ -257,7 +481,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 							new GraphQLField(
 								"portalTools_v1_0",
 								new GraphQLField(
-									"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
+									"entityModelResourceTestEntity2",
 									new HashMap<String, Object>() {
 										{
 											put(
@@ -268,11 +492,11 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 									},
 									getGraphQLFields()))),
 						"JSONObject/data", "JSONObject/portalTools_v1_0",
-						"Object/entityModelResourceTestEntities2EntityModelResourceTestEntity2"))));
+						"Object/entityModelResourceTestEntity2"))));
 	}
 
 	@Test
-	public void testGraphQLGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2NotFound()
+	public void testGraphQLGetEntityModelResourceTestEntity2NotFound()
 		throws Exception {
 
 		Long irrelevantEntityModelResourceTestEntity2Id =
@@ -285,7 +509,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
+						"entityModelResourceTestEntity2",
 						new HashMap<String, Object>() {
 							{
 								put(
@@ -306,7 +530,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 					new GraphQLField(
 						"portalTools_v1_0",
 						new GraphQLField(
-							"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
+							"entityModelResourceTestEntity2",
 							new HashMap<String, Object>() {
 								{
 									put(
@@ -320,7 +544,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 	}
 
 	protected EntityModelResourceTestEntity2
-			testGraphQLGetEntityModelResourceTestEntities2EntityModelResourceTestEntity2_addEntityModelResourceTestEntity2()
+			testGraphQLGetEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2()
 		throws Exception {
 
 		return testGraphQLEntityModelResourceTestEntity2_addEntityModelResourceTestEntity2();
@@ -336,12 +560,12 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 
 	protected void assertContains(
 		EntityModelResourceTestEntity2 entityModelResourceTestEntity2,
-		List<EntityModelResourceTestEntity2> entityModelResourceTestEntity2s) {
+		List<EntityModelResourceTestEntity2> entityModelResourceTestEntities2) {
 
 		boolean contains = false;
 
 		for (EntityModelResourceTestEntity2 item :
-				entityModelResourceTestEntity2s) {
+				entityModelResourceTestEntities2) {
 
 			if (equals(entityModelResourceTestEntity2, item)) {
 				contains = true;
@@ -351,7 +575,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 		}
 
 		Assert.assertTrue(
-			entityModelResourceTestEntity2s + " does not contain " +
+			entityModelResourceTestEntities2 + " does not contain " +
 				entityModelResourceTestEntity2,
 			contains);
 	}
@@ -377,18 +601,19 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 	}
 
 	protected void assertEquals(
-		List<EntityModelResourceTestEntity2> entityModelResourceTestEntity2s1,
-		List<EntityModelResourceTestEntity2> entityModelResourceTestEntity2s2) {
+		List<EntityModelResourceTestEntity2> entityModelResourceTestEntities21,
+		List<EntityModelResourceTestEntity2>
+			entityModelResourceTestEntities22) {
 
 		Assert.assertEquals(
-			entityModelResourceTestEntity2s1.size(),
-			entityModelResourceTestEntity2s2.size());
+			entityModelResourceTestEntities21.size(),
+			entityModelResourceTestEntities22.size());
 
-		for (int i = 0; i < entityModelResourceTestEntity2s1.size(); i++) {
+		for (int i = 0; i < entityModelResourceTestEntities21.size(); i++) {
 			EntityModelResourceTestEntity2 entityModelResourceTestEntity21 =
-				entityModelResourceTestEntity2s1.get(i);
+				entityModelResourceTestEntities21.get(i);
 			EntityModelResourceTestEntity2 entityModelResourceTestEntity22 =
-				entityModelResourceTestEntity2s2.get(i);
+				entityModelResourceTestEntities22.get(i);
 
 			assertEquals(
 				entityModelResourceTestEntity21,
@@ -397,21 +622,22 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 	}
 
 	protected void assertEqualsIgnoringOrder(
-		List<EntityModelResourceTestEntity2> entityModelResourceTestEntity2s1,
-		List<EntityModelResourceTestEntity2> entityModelResourceTestEntity2s2) {
+		List<EntityModelResourceTestEntity2> entityModelResourceTestEntities21,
+		List<EntityModelResourceTestEntity2>
+			entityModelResourceTestEntities22) {
 
 		Assert.assertEquals(
-			entityModelResourceTestEntity2s1.size(),
-			entityModelResourceTestEntity2s2.size());
+			entityModelResourceTestEntities21.size(),
+			entityModelResourceTestEntities22.size());
 
 		for (EntityModelResourceTestEntity2 entityModelResourceTestEntity21 :
-				entityModelResourceTestEntity2s1) {
+				entityModelResourceTestEntities21) {
 
 			boolean contains = false;
 
 			for (EntityModelResourceTestEntity2
 					entityModelResourceTestEntity22 :
-						entityModelResourceTestEntity2s2) {
+						entityModelResourceTestEntities22) {
 
 				if (equals(
 						entityModelResourceTestEntity21,
@@ -424,7 +650,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 			}
 
 			Assert.assertTrue(
-				entityModelResourceTestEntity2s2 + " does not contain " +
+				entityModelResourceTestEntities22 + " does not contain " +
 					entityModelResourceTestEntity21,
 				contains);
 		}
@@ -470,9 +696,9 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 		boolean valid = false;
 
 		java.util.Collection<EntityModelResourceTestEntity2>
-			entityModelResourceTestEntity2s = page.getItems();
+			entityModelResourceTestEntities2 = page.getItems();
 
-		int size = entityModelResourceTestEntity2s.size();
+		int size = entityModelResourceTestEntities2.size();
 
 		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
 			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
@@ -1045,5 +1271,27 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 		EntityModelResourceTestEntity2Resource
 			_entityModelResourceTestEntity2Resource;
 
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private ScopeChecker _scopeChecker;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@Inject
+	private VulcanCRUDItemDelegateBuilderRegistry
+		_vulcanCRUDItemDelegateBuilderRegistry;
+
 }
-// LIFERAY-REST-BUILDER-HASH:-403321362
+// LIFERAY-REST-BUILDER-HASH:-721920204

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1807,7 +1807,7 @@ public class RESTBuilder {
 
 			String text = CamelCaseUtil.fromCamelCase(selParameterName);
 
-			text = TextFormatter.formatPlural(
+			text = OpenAPIUtil.formatPlural(
 				text.substring(0, text.length() - 3));
 
 			StringBuilder sb = new StringBuilder();
@@ -1967,7 +1967,7 @@ public class RESTBuilder {
 				int z = yamlString.indexOf(':', y);
 
 				if (Objects.equals(propertySchema.getType(), "array")) {
-					String plural = TextFormatter.formatPlural(schemaVarName);
+					String plural = OpenAPIUtil.formatPlural(schemaVarName);
 
 					if (propertyName.endsWith(
 							StringUtil.upperCaseFirstLetter(plural)) &&
@@ -2118,15 +2118,14 @@ public class RESTBuilder {
 		}
 
 		context.put("schemaName", schemaName);
-		context.put("schemaNames", TextFormatter.formatPlural(schemaName));
+		context.put("schemaNames", OpenAPIUtil.formatPlural(schemaName));
 		context.put(
 			"schemaPath", TextFormatter.format(schemaName, TextFormatter.K));
 
 		String schemaVarName = OpenAPIParserUtil.getSchemaVarName(schemaName);
 
 		context.put("schemaVarName", schemaVarName);
-		context.put(
-			"schemaVarNames", TextFormatter.formatPlural(schemaVarName));
+		context.put("schemaVarNames", OpenAPIUtil.formatPlural(schemaVarName));
 
 		context.put("relatedSchemaNames", relatedSchemaNames);
 	}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1808,7 +1808,7 @@ public class RESTBuilder {
 			String text = CamelCaseUtil.fromCamelCase(selParameterName);
 
 			text = OpenAPIUtil.formatPlural(
-				text.substring(0, text.length() - 3));
+				_configYAML, text.substring(0, text.length() - 3));
 
 			StringBuilder sb = new StringBuilder();
 
@@ -1967,7 +1967,8 @@ public class RESTBuilder {
 				int z = yamlString.indexOf(':', y);
 
 				if (Objects.equals(propertySchema.getType(), "array")) {
-					String plural = OpenAPIUtil.formatPlural(schemaVarName);
+					String plural = OpenAPIUtil.formatPlural(
+						_configYAML, schemaVarName);
 
 					if (propertyName.endsWith(
 							StringUtil.upperCaseFirstLetter(plural)) &&
@@ -2118,14 +2119,17 @@ public class RESTBuilder {
 		}
 
 		context.put("schemaName", schemaName);
-		context.put("schemaNames", OpenAPIUtil.formatPlural(schemaName));
+		context.put(
+			"schemaNames", OpenAPIUtil.formatPlural(_configYAML, schemaName));
 		context.put(
 			"schemaPath", TextFormatter.format(schemaName, TextFormatter.K));
 
 		String schemaVarName = OpenAPIParserUtil.getSchemaVarName(schemaName);
 
 		context.put("schemaVarName", schemaVarName);
-		context.put("schemaVarNames", OpenAPIUtil.formatPlural(schemaVarName));
+		context.put(
+			"schemaVarNames",
+			OpenAPIUtil.formatPlural(_configYAML, schemaVarName));
 
 		context.put("relatedSchemaNames", relatedSchemaNames);
 	}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1253,7 +1253,7 @@ public class FreeMarkerTool {
 		String methodName = javaMethodSignature.getMethodName();
 		String parentSchemaName = GetterUtil.getString(
 			javaMethodSignature.getParentSchemaName());
-		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
+		String pluralSchemaName = OpenAPIUtil.formatPlural(schemaName);
 
 		if (!(methodName.equals(
 				StringBundler.concat(
@@ -1381,7 +1381,7 @@ public class FreeMarkerTool {
 		String formattedParameterSchemaName = TextFormatter.format(
 			parameterSchemaName, TextFormatter.K);
 		String formattedSchemaNamePlural = TextFormatter.format(
-			TextFormatter.formatPlural(schemaName), TextFormatter.K);
+			OpenAPIUtil.formatPlural(schemaName), TextFormatter.K);
 		String formattedSchemaNameSingular = TextFormatter.format(
 			schemaName, TextFormatter.K);
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1133,10 +1133,10 @@ public class FreeMarkerTool {
 	}
 
 	public boolean hasReadVulcanBatchImplementation(
-		List<JavaMethodSignature> javaMethodSignatures) {
+		ConfigYAML configYAML, List<JavaMethodSignature> javaMethodSignatures) {
 
 		return ResourceOpenAPIParser.hasReadVulcanBatchImplementation(
-			javaMethodSignatures);
+			configYAML, javaMethodSignatures);
 	}
 
 	public boolean hasRequestBodyMediaType(
@@ -1253,7 +1253,8 @@ public class FreeMarkerTool {
 		String methodName = javaMethodSignature.getMethodName();
 		String parentSchemaName = GetterUtil.getString(
 			javaMethodSignature.getParentSchemaName());
-		String pluralSchemaName = OpenAPIUtil.formatPlural(schemaName);
+		String pluralSchemaName = OpenAPIUtil.formatPlural(
+			configYAML, schemaName);
 
 		if (!(methodName.equals(
 				StringBundler.concat(
@@ -1324,7 +1325,8 @@ public class FreeMarkerTool {
 	}
 
 	public boolean isParameterNameSchemaRelated(
-		String parameterName, String path, String schemaName) {
+		ConfigYAML configYAML, String parameterName, String path,
+		String schemaName) {
 
 		String schemaVarName = TextFormatter.format(
 			schemaName, TextFormatter.I);
@@ -1381,7 +1383,7 @@ public class FreeMarkerTool {
 		String formattedParameterSchemaName = TextFormatter.format(
 			parameterSchemaName, TextFormatter.K);
 		String formattedSchemaNamePlural = TextFormatter.format(
-			OpenAPIUtil.formatPlural(schemaName), TextFormatter.K);
+			OpenAPIUtil.formatPlural(configYAML, schemaName), TextFormatter.K);
 		String formattedSchemaNameSingular = TextFormatter.format(
 			schemaName, TextFormatter.K);
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -454,7 +454,7 @@ public class ResourceOpenAPIParser {
 			if (methodName.equals(
 					StringBundler.concat(
 						"get", parentSchemaName,
-						TextFormatter.formatPlural(schemaName), "Page"))) {
+						OpenAPIUtil.formatPlural(schemaName), "Page"))) {
 
 				return true;
 			}
@@ -553,7 +553,7 @@ public class ResourceOpenAPIParser {
 			methodName.equals(
 				StringBundler.concat(
 					"get", parentSchemaName,
-					TextFormatter.formatPlural(schemaName), "Page"))) {
+					OpenAPIUtil.formatPlural(schemaName), "Page"))) {
 
 			batchOperationType = BatchOperationType.EXPORT;
 		}
@@ -965,7 +965,7 @@ public class ResourceOpenAPIParser {
 					simpleClassName = elementClassName.substring(
 						elementClassName.lastIndexOf(".") + 1);
 
-					parameterName = TextFormatter.formatPlural(
+					parameterName = OpenAPIUtil.formatPlural(
 						TextFormatter.format(simpleClassName, TextFormatter.I));
 				}
 
@@ -1095,7 +1095,7 @@ public class ResourceOpenAPIParser {
 		operationIdSegments.add(OpenAPIParserUtil.getHTTPMethod(operation));
 
 		String[] pathSegments = path.split("/");
-		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
+		String pluralSchemaName = OpenAPIUtil.formatPlural(schemaName);
 
 		for (int i = 0; i < pathSegments.length; i++) {
 			String pathSegment = pathSegments[i];

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -96,7 +96,7 @@ public class ResourceOpenAPIParser {
 
 							List<JavaMethodParameter> javaMethodParameters =
 								_getJavaMethodParameters(
-									javaDataTypeMap, operation,
+									configYAML, javaDataTypeMap, operation,
 									requestBodyMediaTypes);
 
 							JavaMethodSignature javaMethodSignature =
@@ -440,7 +440,7 @@ public class ResourceOpenAPIParser {
 	}
 
 	public static boolean hasReadVulcanBatchImplementation(
-		List<JavaMethodSignature> javaMethodSignatures) {
+		ConfigYAML configYAML, List<JavaMethodSignature> javaMethodSignatures) {
 
 		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
 			String methodName = javaMethodSignature.getMethodName();
@@ -454,7 +454,8 @@ public class ResourceOpenAPIParser {
 			if (methodName.equals(
 					StringBundler.concat(
 						"get", parentSchemaName,
-						OpenAPIUtil.formatPlural(schemaName), "Page"))) {
+						OpenAPIUtil.formatPlural(configYAML, schemaName),
+						"Page"))) {
 
 				return true;
 			}
@@ -553,7 +554,8 @@ public class ResourceOpenAPIParser {
 			methodName.equals(
 				StringBundler.concat(
 					"get", parentSchemaName,
-					OpenAPIUtil.formatPlural(schemaName), "Page"))) {
+					OpenAPIUtil.formatPlural(configYAML, schemaName),
+					"Page"))) {
 
 			batchOperationType = BatchOperationType.EXPORT;
 		}
@@ -840,8 +842,8 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static List<JavaMethodParameter> _getJavaMethodParameters(
-		Map<String, String> javaDataTypeMap, Operation operation,
-		Set<String> requestBodyMediaTypes) {
+		ConfigYAML configYAML, Map<String, String> javaDataTypeMap,
+		Operation operation, Set<String> requestBodyMediaTypes) {
 
 		if ((operation == null) || (operation.getParameters() == null)) {
 			return Collections.emptyList();
@@ -966,6 +968,7 @@ public class ResourceOpenAPIParser {
 						elementClassName.lastIndexOf(".") + 1);
 
 					parameterName = OpenAPIUtil.formatPlural(
+						configYAML,
 						TextFormatter.format(simpleClassName, TextFormatter.I));
 				}
 
@@ -1095,7 +1098,8 @@ public class ResourceOpenAPIParser {
 		operationIdSegments.add(OpenAPIParserUtil.getHTTPMethod(operation));
 
 		String[] pathSegments = path.split("/");
-		String pluralSchemaName = OpenAPIUtil.formatPlural(schemaName);
+		String pluralSchemaName = OpenAPIUtil.formatPlural(
+			configYAML, schemaName);
 
 		for (int i = 0; i < pathSegments.length; i++) {
 			String pathSegment = pathSegments[i];

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.rest.builder.internal.freemarker.util;
 
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,35 +51,12 @@ public class OpenAPIUtil {
 		return "v" + matcher.replaceFirst("");
 	}
 
+	public static String formatPlural(String s) {
+		return _format(s, TextFormatter::formatPlural);
+	}
+
 	public static String formatSingular(ConfigYAML configYAML, String s) {
-		if (s.endsWith("ases")) {
-
-			// bases to base
-
-			s = s.substring(0, s.length() - 1);
-		}
-		else if (s.endsWith("auses")) {
-
-			// clauses to clause
-
-			s = s.substring(0, s.length() - 1);
-		}
-		else if (s.endsWith("ses") || s.endsWith("xes")) {
-			s = s.substring(0, s.length() - 2);
-		}
-		else if (s.endsWith("ies")) {
-			s = s.substring(0, s.length() - 3) + "y";
-		}
-		else if (s.endsWith("s") &&
-				 (!s.endsWith("ss") ||
-				  !ConfigUtil.isVersionCompatible(configYAML, 6)) &&
-				 (!s.endsWith("tus") ||
-				  !ConfigUtil.isVersionCompatible(configYAML, 11))) {
-
-			s = s.substring(0, s.length() - 1);
-		}
-
-		return s;
+		return _format(s, string -> _formatSingular(configYAML, string));
 	}
 
 	public static Map<String, Schema> getAllExternalSchemas(
@@ -345,6 +324,57 @@ public class OpenAPIUtil {
 			allExternalSchemas.putAll(externalSchemaMap);
 			queue.add(externalSchemaMap);
 		}
+	}
+
+	private static String _format(String s, Function<String, String> function) {
+		if (Validator.isNull(s)) {
+			return s;
+		}
+
+		int pos = s.length();
+
+		while ((pos > 0) && Character.isDigit(s.charAt(pos - 1))) {
+			pos--;
+		}
+
+		if (pos == s.length()) {
+			return function.apply(s);
+		}
+
+		String prefix = s.substring(0, pos);
+
+		return function.apply(prefix) + s.substring(pos);
+	}
+
+	private static String _formatSingular(ConfigYAML configYAML, String s) {
+		if (s.endsWith("ases")) {
+
+			// bases to base
+
+			s = s.substring(0, s.length() - 1);
+		}
+		else if (s.endsWith("auses")) {
+
+			// clauses to clause
+
+			s = s.substring(0, s.length() - 1);
+		}
+		else if (s.endsWith("ses") || s.endsWith("xes")) {
+			s = s.substring(0, s.length() - 2);
+		}
+		else if (s.endsWith("ies")) {
+			s = s.substring(0, s.length() - 3) + "y";
+		}
+		else if (s.endsWith("s") &&
+				 (!s.endsWith("ss") ||
+				  !ConfigUtil.isVersionCompatible(configYAML, 6)) &&
+				 (!s.endsWith("tus") ||
+				  !ConfigUtil.isVersionCompatible(configYAML, 11))) {
+
+			s = s.substring(0, s.length() - 1);
+		}
+
+		return s;
 	}
 
 	private static boolean _isAnyAllOfSchemasMissing(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -367,6 +367,13 @@ public class OpenAPIUtil {
 
 			s = s.substring(0, s.length() - 1);
 		}
+		else if (s.endsWith("ouses") &&
+				 ConfigUtil.isVersionCompatible(configYAML, 16)) {
+
+			// warehouses to warehouse
+
+			s = s.substring(0, s.length() - 1);
+		}
 		else if (s.endsWith("ses") || s.endsWith("xes")) {
 			s = s.substring(0, s.length() - 2);
 		}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -51,11 +51,19 @@ public class OpenAPIUtil {
 		return "v" + matcher.replaceFirst("");
 	}
 
-	public static String formatPlural(String s) {
+	public static String formatPlural(ConfigYAML configYAML, String s) {
+		if (!ConfigUtil.isVersionCompatible(configYAML, 16)) {
+			return TextFormatter.formatPlural(s);
+		}
+
 		return _format(s, TextFormatter::formatPlural);
 	}
 
 	public static String formatSingular(ConfigYAML configYAML, String s) {
+		if (!ConfigUtil.isVersionCompatible(configYAML, 16)) {
+			return _formatSingular(configYAML, s);
+		}
+
 		return _format(s, string -> _formatSingular(configYAML, string));
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -1179,7 +1179,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 		@Override
 		public Page<${javaDataType}> read(com.liferay.portal.kernel.search.filter.Filter filter, Pagination pagination, com.liferay.portal.kernel.search.Sort[] sorts, Map<String, Serializable> parameters, String search) throws Exception {
-			<#if freeMarkerTool.hasReadVulcanBatchImplementation(javaMethodSignatures)>
+			<#if freeMarkerTool.hasReadVulcanBatchImplementation(configYAML, javaMethodSignatures)>
 				<#assign parentParameterNames = [] />
 
 				<#list getParentBatchJavaMethodSignatures as getParentBatchJavaMethodSignature>
@@ -2049,7 +2049,7 @@ public abstract class Base${schemaName}ResourceImpl
 	<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 		<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 			${schemaVarName}
-		<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && properties?keys?seq_contains("externalReferenceCode") && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+		<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && properties?keys?seq_contains("externalReferenceCode") && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 			${schemaVarName}.getExternalReferenceCode()
 		<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody")>
 			(MultipartBody)null

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -572,9 +572,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 					Page<Permission> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-							<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+							<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 								post${schemaName}.getExternalReferenceCode()
-							<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+							<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 								post${schemaName}.${getIdMethodName}()
 							<#elseif stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryExternalReferenceCode")>
 								testDepotEntryGroup.getExternalReferenceCode()
@@ -745,9 +745,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 						<#if hasExternalReferenceCodeProperty || hasIdProperty>
 							${schemaVarName}Resource.delete${schemaName}(
 								<#list deleteJavaMethodSignature.javaMethodParameters as javaMethodParameter>
-									<#if freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
+									<#if freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
 										${schemaVarName}1.getExternalReferenceCode()
-									<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
+									<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
 										${schemaVarName}1.${getIdMethodName}()
 									<#else>
 										null
@@ -759,9 +759,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 							${schemaVarName}Resource.delete${schemaName}(
 								<#list deleteJavaMethodSignature.javaMethodParameters as javaMethodParameter>
-									<#if freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
+									<#if freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
 										${schemaVarName}2.getExternalReferenceCode()
-									<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
+									<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, deleteJavaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, deleteJavaMethodSignature.path, schemaName)>
 										${schemaVarName}2.${getIdMethodName}()
 									<#else>
 										null
@@ -1320,7 +1320,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 					${schemaName} get${schemaName} = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-							<#if freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+							<#if freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 								post${schemaName}.${getIdMethodName}()
 							<#else>
 								null
@@ -1526,9 +1526,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
 								<#if freeMarkerTool.isIdParameterName(javaMethodParameter.parameterName, "AssetLibrary") && generateDepotEntry && !stringUtil.equals(schemaName, "AssetLibrary")>
 									<#assign parameterNames = parameterNames + ["testDepotEntry.getDepotEntryId()"] />
-								<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									<#assign parameterNames = parameterNames + ["post${schemaName}.getExternalReferenceCode()"] />
-								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									<#assign parameterNames = parameterNames + ["post${schemaName}.${getIdMethodName}()"] />
 								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 									<#assign parameterNames = parameterNames + ["post${schemaName}.get${javaMethodParameter.parameterName?cap_first}()"] />
@@ -1558,9 +1558,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
 								<#if freeMarkerTool.isIdParameterName(javaMethodParameter.parameterName, "AssetLibrary") && generateDepotEntry>
 									<#assign parameterNames = parameterNames + ["testDepotEntry.getDepotEntryId()"] />
-								<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#elseif freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									<#assign parameterNames = parameterNames + ["patch${schemaName}.getExternalReferenceCode()"] />
-								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									<#assign parameterNames = parameterNames + ["patch${schemaName}.${getIdMethodName}()"] />
 								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 									<#assign parameterNames = parameterNames + ["patch${schemaName}.get${javaMethodParameter.parameterName?cap_first}()"] />
@@ -1969,11 +1969,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-								<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									${schemaVarName}.getExternalReferenceCode()
-								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									${schemaVarName}.${getIdMethodName}()
-								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 								<#else>
 									<#assign getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
@@ -1999,9 +1999,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 							<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-								<#if (freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) || freeMarkerTool.isIdParameter(javaMethodParameter, schemaName)) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+								<#if (freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) || freeMarkerTool.isIdParameter(javaMethodParameter, schemaName)) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 									<@getDefaultParameter javaMethodParameter = javaMethodParameter />
-								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 									${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 								<#else>
 									<#assign getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
@@ -2662,7 +2662,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 									testGroup.getExternalReferenceCode(),
 								<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
 									testGroup.getGroupId(),
-								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+								<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 									random${schemaName}.get${javaMethodParameter.parameterName?cap_first}(),
 								<#else>
 									<#assign getterJavaMethodParametersMap = getterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
@@ -4377,7 +4377,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 			put("page", 1);
 			put("pageSize", 10);
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
+			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
 				put("${javaMethodParameter.parameterName}",
 					<#if stringUtil.equals(properties["externalReferenceCode"], "String")>
 						<@getQuotedString unquotedString = "${varName}.getExternalReferenceCode()" />
@@ -4385,7 +4385,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 						${varName}.getExternalReferenceCode()
 					</#if>
 				);
-			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
+			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
 				put("${javaMethodParameter.parameterName}",
 					<#if stringUtil.equals(properties[idParameterName], "String")>
 						<@getQuotedString unquotedString = "${varName}.${getIdMethodName}()" />
@@ -4393,7 +4393,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 						${varName}.${getIdMethodName}()
 					</#if>
 				);
-			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 				<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
 					put("siteKey", <@getQuotedString unquotedString="${varName}.get${javaMethodParameter.parameterName?cap_first}()" />);
 				<#else>
@@ -4442,7 +4442,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#assign parameterNames = parameterNames + ["null"] />
 			</#if>
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) || freeMarkerTool.isQueryParameter(javaMethodParameter, javaMethodSignature.operation)>
-			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
+			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
 				<#if defaultParameter>
 					<#assign parameterName>
 						<@getDefaultParameter javaMethodParameter = javaMethodParameter />
@@ -4451,7 +4451,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#else>
 					<#assign parameterNames = parameterNames + ["${varName}.getExternalReferenceCode()"] />
 				</#if>
-			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
+			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
 				<#if defaultParameter>
 					<#assign parameterName>
 						<@getDefaultParameter javaMethodParameter = javaMethodParameter />
@@ -4460,7 +4460,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#else>
 					<#assign parameterNames = parameterNames + ["${varName}.${getIdMethodName}()"] />
 				</#if>
-			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 				<#assign parameterNames = parameterNames + ["${varName}.get${javaMethodParameter.parameterName?cap_first}()"] />
 			<#else>
 				<#assign
@@ -4482,7 +4482,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	roleName
 	schemaVarNameId
 >
-	<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+	<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 		${schemaVarName}.getExternalReferenceCode()
 	<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName) && !freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName)>
 		${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
@@ -4521,11 +4521,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 	varName
 >
 	<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-		<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+		<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 			${varName}.${getIdMethodName}()
-		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
+		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName)>
 			${varName}.getExternalReferenceCode()
-		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 			${varName}.get${javaMethodParameter.parameterName?cap_first}()
 		<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody") || stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 			${newVarName}
@@ -4574,7 +4574,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#assign parameterNames = parameterNames + ["null"] />
 			</#if>
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) || freeMarkerTool.isQueryParameter(javaMethodParameter, javaMethodSignature.operation)>
-			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
+			<#if freeMarkerTool.isExternalReferenceCodeParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasExternalReferenceCodeProperty>
 				<#if defaultParameter>
 					<#assign parameterName>
 						<@getDefaultParameter javaMethodParameter = javaMethodParameter />
@@ -4583,7 +4583,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#else>
 					<#assign parameterNames = parameterNames + ["${varName}.getExternalReferenceCode()"] />
 				</#if>
-			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
+			<#elseif freeMarkerTool.isIdParameter(javaMethodParameter, schemaName) && freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) && hasIdProperty>
 				<#if defaultParameter>
 					<#assign parameterName>
 						<@getDefaultParameter javaMethodParameter = javaMethodParameter />
@@ -4592,7 +4592,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#else>
 					<#assign parameterNames = parameterNames + ["${varName}.${getIdMethodName}()"] />
 				</#if>
-			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
+			<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName) && (freeMarkerTool.isParameterNameSchemaRelated(configYAML, javaMethodParameter.parameterName, javaMethodSignature.path, schemaName) || freeMarkerTool.isParameterNameScopeRelated(javaMethodParameter.parameterName))>
 				<#assign parameterNames = parameterNames + ["${varName}.get${javaMethodParameter.parameterName?cap_first}()"] />
 			<#else>
 				<#assign

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
@@ -17,7 +17,7 @@ openapi.resource.path=${configYAML.application.baseURI}
 <#elseif generateBatch>
 batch.engine.entity.class.name=${javaDataType}
 batch.engine.task.item.delegate=true
-batch.planner.export.enabled=${freeMarkerTool.hasReadVulcanBatchImplementation(javaMethodSignatures)?c}
+batch.planner.export.enabled=${freeMarkerTool.hasReadVulcanBatchImplementation(configYAML, javaMethodSignatures)?c}
 batch.planner.import.enabled=${freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas))?has_content?c}
 </#if>
 <#if generateCRUD>

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtilTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtilTest.java
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.freemarker.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class OpenAPIUtilTest {
+
+	@Test
+	public void testFormatPlural() {
+		_testFormatPlural(15, "car10s", "car10");
+		_testFormatPlural(15, "category1s", "category1");
+		_testFormatPlural(16, StringPool.BLANK, StringPool.BLANK);
+		_testFormatPlural(16, "123", "123");
+		_testFormatPlural(16, "batches", "batch");
+		_testFormatPlural(16, "boxes", "box");
+		_testFormatPlural(16, "boys", "boy");
+		_testFormatPlural(16, "buses", "bus");
+		_testFormatPlural(16, "cars", "car");
+		_testFormatPlural(16, "cars10", "car10");
+		_testFormatPlural(16, "categories", "category");
+		_testFormatPlural(16, "categories1", "category1");
+		_testFormatPlural(16, "days", "day");
+		_testFormatPlural(16, "dishes", "dish");
+		_testFormatPlural(16, "guys", "guy");
+		_testFormatPlural(16, "keys", "key");
+		_testFormatPlural(16, "quizes", "quiz");
+		_testFormatPlural(16, null, null);
+	}
+
+	@Test
+	public void testFormatSingular() {
+		_testFormatSingular(1, "clas", "class");
+		_testFormatSingular(1, "status1", "status1");
+		_testFormatSingular(6, "class", "class");
+		_testFormatSingular(6, "statu", "status");
+		_testFormatSingular(15, "cars10", "cars10");
+		_testFormatSingular(15, "categories1", "categories1");
+		_testFormatSingular(16, StringPool.BLANK, StringPool.BLANK);
+		_testFormatSingular(16, "123", "123");
+		_testFormatSingular(16, "base", "bases");
+		_testFormatSingular(16, "box", "boxes");
+		_testFormatSingular(16, "bus", "buses");
+		_testFormatSingular(16, "car", "car");
+		_testFormatSingular(16, "car", "cars");
+		_testFormatSingular(16, "car10", "cars10");
+		_testFormatSingular(16, "category", "categories");
+		_testFormatSingular(16, "category1", "categories1");
+		_testFormatSingular(16, "clause", "clauses");
+		_testFormatSingular(16, "key", "keys");
+		_testFormatSingular(16, "status", "status");
+		_testFormatSingular(16, "status1", "status1");
+		_testFormatSingular(16, null, null);
+	}
+
+	private void _testFormatPlural(
+		int compatibilityVersion, String expected, String s) {
+
+		ConfigYAML configYAML = new ConfigYAML();
+
+		configYAML.setCompatibilityVersion(compatibilityVersion);
+
+		Assert.assertEquals(expected, OpenAPIUtil.formatPlural(configYAML, s));
+	}
+
+	private void _testFormatSingular(
+		int compatibilityVersion, String expected, String s) {
+
+		ConfigYAML configYAML = new ConfigYAML();
+
+		configYAML.setCompatibilityVersion(compatibilityVersion);
+
+		Assert.assertEquals(
+			expected, OpenAPIUtil.formatSingular(configYAML, s));
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtilTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtilTest.java
@@ -46,6 +46,8 @@ public class OpenAPIUtilTest {
 		_testFormatSingular(6, "statu", "status");
 		_testFormatSingular(15, "cars10", "cars10");
 		_testFormatSingular(15, "categories1", "categories1");
+		_testFormatSingular(15, "warehous", "warehouses");
+		_testFormatSingular(15, "warehouses1", "warehouses1");
 		_testFormatSingular(16, StringPool.BLANK, StringPool.BLANK);
 		_testFormatSingular(16, "123", "123");
 		_testFormatSingular(16, "base", "bases");
@@ -60,6 +62,8 @@ public class OpenAPIUtilTest {
 		_testFormatSingular(16, "key", "keys");
 		_testFormatSingular(16, "status", "status");
 		_testFormatSingular(16, "status1", "status1");
+		_testFormatSingular(16, "warehouse", "warehouses");
+		_testFormatSingular(16, "warehouse1", "warehouses1");
 		_testFormatSingular(16, null, null);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-68399

Supersedes https://github.com/liferay-headless/liferay-portal/pull/4047 (continued while @adolfopa is on PTO).

**What is being fixed:** REST Builder mishandles schema names ending in digits. The pluralization helpers treated a trailing digit as part of the word ending, so a schema such as `Entity1` pluralized to `Entity1s` while the collection method name derived from the resource path used `Entities1`. Because the recomputed name never matched, such schemas got no batch endpoints (`export-batch` was never generated and the batch `read` delegate threw `UnsupportedOperationException`) and item operations received doubled operation ids like `getEntities2Entity2`. Additionally, the generic `ses` singularization rule misspells nouns whose singular ends in `se` (`warehouses` became `warehous`).

**How it is being fixed:** The `formatPlural` and `formatSingular` helpers now peel the trailing digit run, transform the alphabetic stem, and reattach the digits, and nouns ending in `ouses` singularize by dropping only the trailing `s`. Because these rules change names that existing modules already generate and publish (computed operation ids, GraphQL fields, and predictable schema property names), the new behavior is gated behind a new compatibility version 16, following the same precedent as the earlier `ss` and `tus` gates: modules at version 15 or lower regenerate byte-identically. Every `rest-config.yaml` in the repository is bumped to 16 so internal APIs always generate with the latest naming rules; the only resulting output change is the oauth-client module picking up the version 15 export behavior it had missed while pinned at 14. A full `ant build-rests` sweep regenerates with no other diffs, and the unit tests pin both the new naming and the frozen behavior of every older compatibility level.
