### PR TITLE
LPD-90963 Fix malformed Blob assertion in testCreateDraft template

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryOrganizationRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryOrganizationRelPersistenceTest.java
@@ -555,4 +555,4 @@ public class AccountEntryOrganizationRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1281538462
+// LIFERAY-SERVICE-BUILDER-HASH:-368067776

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
@@ -689,4 +689,4 @@ public class AccountEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-483620059
+// LIFERAY-SERVICE-BUILDER-HASH:-2069400825

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryUserRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryUserRelPersistenceTest.java
@@ -513,4 +513,4 @@ public class AccountEntryUserRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1944329820
+// LIFERAY-SERVICE-BUILDER-HASH:1089929046

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
@@ -623,4 +623,4 @@ public class AccountGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1722076007
+// LIFERAY-SERVICE-BUILDER-HASH:1463035009

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupRelPersistenceTest.java
@@ -547,4 +547,4 @@ public class AccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1804310193
+// LIFERAY-SERVICE-BUILDER-HASH:716366221

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
@@ -548,4 +548,4 @@ public class AccountRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1383680644
+// LIFERAY-SERVICE-BUILDER-HASH:351597970

--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/persistence/test/AMImageEntryPersistenceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/persistence/test/AMImageEntryPersistenceTest.java
@@ -609,4 +609,4 @@ public class AMImageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1920985673
+// LIFERAY-SERVICE-BUILDER-HASH:-523387051

--- a/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/persistence/test/AssetAutoTaggerEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/persistence/test/AssetAutoTaggerEntryPersistenceTest.java
@@ -561,4 +561,4 @@ public class AssetAutoTaggerEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:754453545
+// LIFERAY-SERVICE-BUILDER-HASH:-1036378817

--- a/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
+++ b/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
@@ -645,4 +645,4 @@ public class AssetCategoryPropertyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-900197240
+// LIFERAY-SERVICE-BUILDER-HASH:23396136

--- a/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
@@ -665,4 +665,4 @@ public class AssetDisplayPageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1934513584
+// LIFERAY-SERVICE-BUILDER-HASH:553453720

--- a/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/service/persistence/test/AssetEntryAssetCategoryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/service/persistence/test/AssetEntryAssetCategoryRelPersistenceTest.java
@@ -566,4 +566,4 @@ public class AssetEntryAssetCategoryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1809647120
+// LIFERAY-SERVICE-BUILDER-HASH:330047380

--- a/modules/apps/asset/asset-link-test/src/testIntegration/java/com/liferay/asset/link/service/persistence/test/AssetLinkPersistenceTest.java
+++ b/modules/apps/asset/asset-link-test/src/testIntegration/java/com/liferay/asset/link/service/persistence/test/AssetLinkPersistenceTest.java
@@ -546,4 +546,4 @@ public class AssetLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2107619579
+// LIFERAY-SERVICE-BUILDER-HASH:1994978465

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryAssetEntryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryAssetEntryRelPersistenceTest.java
@@ -711,4 +711,4 @@ public class AssetListEntryAssetEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2078348456
+// LIFERAY-SERVICE-BUILDER-HASH:-1500205872

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
@@ -803,4 +803,4 @@ public class AssetListEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2023074775
+// LIFERAY-SERVICE-BUILDER-HASH:1340684435

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntrySegmentsEntryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntrySegmentsEntryRelPersistenceTest.java
@@ -705,4 +705,4 @@ public class AssetListEntrySegmentsEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1292147763
+// LIFERAY-SERVICE-BUILDER-HASH:-1781072257

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
@@ -708,4 +708,4 @@ public class AssetListEntryUsagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:987564824
+// LIFERAY-SERVICE-BUILDER-HASH:-1326769940

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
@@ -554,4 +554,4 @@ public class AudiencesEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1067092027
+// LIFERAY-SERVICE-BUILDER-HASH:1727085347

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerMappingPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerMappingPersistenceTest.java
@@ -576,4 +576,4 @@ public class BatchPlannerMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1919057240
+// LIFERAY-SERVICE-BUILDER-HASH:325312110

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
@@ -553,4 +553,4 @@ public class BatchPlannerPlanPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2091624505
+// LIFERAY-SERVICE-BUILDER-HASH:-2104934227

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPolicyPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPolicyPersistenceTest.java
@@ -540,4 +540,4 @@ public class BatchPlannerPolicyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-712855344
+// LIFERAY-SERVICE-BUILDER-HASH:-769664114

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -962,4 +962,4 @@ public class BlogsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-663227059
+// LIFERAY-SERVICE-BUILDER-HASH:1100644895

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
@@ -721,4 +721,4 @@ public class BookmarksEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2039379468
+// LIFERAY-SERVICE-BUILDER-HASH:-232466774

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
@@ -681,4 +681,4 @@ public class BookmarksFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:43402575
+// LIFERAY-SERVICE-BUILDER-HASH:589968457

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
@@ -834,4 +834,4 @@ public class CalendarBookingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1533980789
+// LIFERAY-SERVICE-BUILDER-HASH:380495095

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
@@ -699,4 +699,4 @@ public class CalendarNotificationTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-10957153
+// LIFERAY-SERVICE-BUILDER-HASH:29972543

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
@@ -595,4 +595,4 @@ public class CalendarPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-545665790
+// LIFERAY-SERVICE-BUILDER-HASH:1574910012

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
@@ -692,4 +692,4 @@ public class CalendarResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1631722103
+// LIFERAY-SERVICE-BUILDER-HASH:-1079338551

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSChildPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSChildPersistenceTest.java
@@ -438,4 +438,4 @@ public class CTSChildPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:306775951
+// LIFERAY-SERVICE-BUILDER-HASH:-166233217

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSGrandParentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSGrandParentPersistenceTest.java
@@ -412,4 +412,4 @@ public class CTSGrandParentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:7946473
+// LIFERAY-SERVICE-BUILDER-HASH:499573445

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSParentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSParentPersistenceTest.java
@@ -419,4 +419,4 @@ public class CTSParentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-750146600
+// LIFERAY-SERVICE-BUILDER-HASH:1676312628

--- a/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -167,10 +166,8 @@ public class CTSContentPersistenceTest {
 			existingCTSContent.getVersion(), newCTSContent.getVersion());
 		Blob existingData = existingCTSContent.getData();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingData.getBytes(1, (int)existingData.length()),
-				newDataBytes));
+		Assert.assertArrayEquals(
+			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
 		Assert.assertEquals(
 			existingCTSContent.getSize(), newCTSContent.getSize());
 		Assert.assertEquals(
@@ -581,4 +578,4 @@ public class CTSContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-597241943
+// LIFERAY-SERVICE-BUILDER-HASH:-1473486047

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTAutoResolutionInfoPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTAutoResolutionInfoPersistenceTest.java
@@ -463,4 +463,4 @@ public class CTAutoResolutionInfoPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-904647825
+// LIFERAY-SERVICE-BUILDER-HASH:1118706015

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
@@ -637,4 +637,4 @@ public class CTCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-76312410
+// LIFERAY-SERVICE-BUILDER-HASH:-359539616

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionTemplatePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionTemplatePersistenceTest.java
@@ -466,4 +466,4 @@ public class CTCollectionTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1292633120
+// LIFERAY-SERVICE-BUILDER-HASH:1195204366

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCommentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCommentPersistenceTest.java
@@ -437,4 +437,4 @@ public class CTCommentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1422675606
+// LIFERAY-SERVICE-BUILDER-HASH:1930930318

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
@@ -618,4 +618,4 @@ public class CTEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1221765012
+// LIFERAY-SERVICE-BUILDER-HASH:-133881066

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTMessagePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTMessagePersistenceTest.java
@@ -403,4 +403,4 @@ public class CTMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1850277895
+// LIFERAY-SERVICE-BUILDER-HASH:-220509947

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTPreferencesPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTPreferencesPersistenceTest.java
@@ -505,4 +505,4 @@ public class CTPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-852589490
+// LIFERAY-SERVICE-BUILDER-HASH:2036796056

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTProcessPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTProcessPersistenceTest.java
@@ -439,4 +439,4 @@ public class CTProcessPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1749344047
+// LIFERAY-SERVICE-BUILDER-HASH:1525151765

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTRemotePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTRemotePersistenceTest.java
@@ -438,4 +438,4 @@ public class CTRemotePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:368071653
+// LIFERAY-SERVICE-BUILDER-HASH:617776283

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTSchemaVersionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTSchemaVersionPersistenceTest.java
@@ -407,4 +407,4 @@ public class CTSchemaVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1793370604
+// LIFERAY-SERVICE-BUILDER-HASH:2139588968

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTScorePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTScorePersistenceTest.java
@@ -453,4 +453,4 @@ public class CTScorePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2013155455
+// LIFERAY-SERVICE-BUILDER-HASH:-763148773

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetCollectionPersistenceTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetCollectionPersistenceTest.java
@@ -566,4 +566,4 @@ public class ChangesetCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:266850374
+// LIFERAY-SERVICE-BUILDER-HASH:-142397092

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetEntryPersistenceTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetEntryPersistenceTest.java
@@ -598,4 +598,4 @@ public class ChangesetEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-155169094
+// LIFERAY-SERVICE-BUILDER-HASH:2082134764

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
@@ -691,4 +691,4 @@ public class ClientExtensionEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:851870453
+// LIFERAY-SERVICE-BUILDER-HASH:-1423701461

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
@@ -725,4 +725,4 @@ public class ClientExtensionEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1657813550
+// LIFERAY-SERVICE-BUILDER-HASH:399679866

--- a/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
+++ b/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
@@ -706,4 +706,4 @@ public class CommerceCurrencyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1101771107
+// LIFERAY-SERVICE-BUILDER-HASH:1525736261

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountAccountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountAccountRelPersistenceTest.java
@@ -632,4 +632,4 @@ public class CommerceDiscountAccountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1666630778
+// LIFERAY-SERVICE-BUILDER-HASH:-2098303322

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountCommerceAccountGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountCommerceAccountGroupRelPersistenceTest.java
@@ -651,4 +651,4 @@ public class CommerceDiscountCommerceAccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-304284353
+// LIFERAY-SERVICE-BUILDER-HASH:168193007

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountOrderTypeRelPersistenceTest.java
@@ -637,4 +637,4 @@ public class CommerceDiscountOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2082815603
+// LIFERAY-SERVICE-BUILDER-HASH:370923543

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
@@ -815,4 +815,4 @@ public class CommerceDiscountPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:276959809
+// LIFERAY-SERVICE-BUILDER-HASH:-539636407

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRelPersistenceTest.java
@@ -499,4 +499,4 @@ public class CommerceDiscountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:867726896
+// LIFERAY-SERVICE-BUILDER-HASH:1535117242

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRulePersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRulePersistenceTest.java
@@ -488,4 +488,4 @@ public class CommerceDiscountRulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:927228666
+// LIFERAY-SERVICE-BUILDER-HASH:174313914

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountUsageEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountUsageEntryPersistenceTest.java
@@ -536,4 +536,4 @@ public class CommerceDiscountUsageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2110951881
+// LIFERAY-SERVICE-BUILDER-HASH:-60480319

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryAuditPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryAuditPersistenceTest.java
@@ -519,4 +519,4 @@ public class CommerceInventoryAuditPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1190988874
+// LIFERAY-SERVICE-BUILDER-HASH:-390962234

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryBookedQuantityPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryBookedQuantityPersistenceTest.java
@@ -573,4 +573,4 @@ public class CommerceInventoryBookedQuantityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:389412273
+// LIFERAY-SERVICE-BUILDER-HASH:1737379793

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
@@ -758,4 +758,4 @@ public class CommerceInventoryReplenishmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:161930988
+// LIFERAY-SERVICE-BUILDER-HASH:1964170772

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
@@ -731,4 +731,4 @@ public class CommerceInventoryWarehouseItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:73408003
+// LIFERAY-SERVICE-BUILDER-HASH:316791305

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
@@ -756,4 +756,4 @@ public class CommerceInventoryWarehousePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2078569553
+// LIFERAY-SERVICE-BUILDER-HASH:-1636296815

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseRelPersistenceTest.java
@@ -618,4 +618,4 @@ public class CommerceInventoryWarehouseRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-383269592
+// LIFERAY-SERVICE-BUILDER-HASH:310376942

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
@@ -665,4 +665,4 @@ public class COREntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1069158919
+// LIFERAY-SERVICE-BUILDER-HASH:-796077067

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryRelPersistenceTest.java
@@ -528,4 +528,4 @@ public class COREntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:221157037
+// LIFERAY-SERVICE-BUILDER-HASH:1802783169

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryAuditPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryAuditPersistenceTest.java
@@ -525,4 +525,4 @@ public class CommercePaymentEntryAuditPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1892280911
+// LIFERAY-SERVICE-BUILDER-HASH:-76784185

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
@@ -749,4 +749,4 @@ public class CommercePaymentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1291654818
+// LIFERAY-SERVICE-BUILDER-HASH:-1442691452

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelPersistenceTest.java
@@ -678,4 +678,4 @@ public class CommercePaymentMethodGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1884356129
+// LIFERAY-SERVICE-BUILDER-HASH:210158533

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelQualifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelQualifierPersistenceTest.java
@@ -665,4 +665,4 @@ public class CommercePaymentMethodGroupRelQualifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1927560020
+// LIFERAY-SERVICE-BUILDER-HASH:-1903009504

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
@@ -838,4 +838,4 @@ public class CommercePriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1644816883
+// LIFERAY-SERVICE-BUILDER-HASH:-818217499

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListAccountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListAccountRelPersistenceTest.java
@@ -639,4 +639,4 @@ public class CommercePriceListAccountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1996880232
+// LIFERAY-SERVICE-BUILDER-HASH:504997888

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListChannelRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListChannelRelPersistenceTest.java
@@ -639,4 +639,4 @@ public class CommercePriceListChannelRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:894732922
+// LIFERAY-SERVICE-BUILDER-HASH:-2087819650

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListCommerceAccountGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListCommerceAccountGroupRelPersistenceTest.java
@@ -713,4 +713,4 @@ public class CommercePriceListCommerceAccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1275792663
+// LIFERAY-SERVICE-BUILDER-HASH:-1746219097

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListDiscountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListDiscountRelPersistenceTest.java
@@ -641,4 +641,4 @@ public class CommercePriceListDiscountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1626406933
+// LIFERAY-SERVICE-BUILDER-HASH:-58064701

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListOrderTypeRelPersistenceTest.java
@@ -650,4 +650,4 @@ public class CommercePriceListOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:958336300
+// LIFERAY-SERVICE-BUILDER-HASH:1225927962

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
@@ -846,4 +846,4 @@ public class CommercePriceListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:826078797
+// LIFERAY-SERVICE-BUILDER-HASH:-1902118147

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
@@ -826,4 +826,4 @@ public class CommerceTierPriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1430891760
+// LIFERAY-SERVICE-BUILDER-HASH:-606172556

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
@@ -821,4 +821,4 @@ public class CommercePriceModifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1341899791
+// LIFERAY-SERVICE-BUILDER-HASH:-597161225

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierRelPersistenceTest.java
@@ -606,4 +606,4 @@ public class CommercePriceModifierRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1420995713
+// LIFERAY-SERVICE-BUILDER-HASH:-1944374381

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassCPDefinitionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassCPDefinitionRelPersistenceTest.java
@@ -648,4 +648,4 @@ public class CommercePricingClassCPDefinitionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1098504803
+// LIFERAY-SERVICE-BUILDER-HASH:1356820981

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
@@ -638,4 +638,4 @@ public class CommercePricingClassPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1639902939
+// LIFERAY-SERVICE-BUILDER-HASH:2107409333

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
@@ -868,4 +868,4 @@ public class CPAttachmentFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:34817944
+// LIFERAY-SERVICE-BUILDER-HASH:-275561754

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
@@ -887,4 +887,4 @@ public class CPConfigurationEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2146566841
+// LIFERAY-SERVICE-BUILDER-HASH:-63419317

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntrySettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntrySettingPersistenceTest.java
@@ -652,4 +652,4 @@ public class CPConfigurationEntrySettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1152965699
+// LIFERAY-SERVICE-BUILDER-HASH:1891300175

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
@@ -776,4 +776,4 @@ public class CPConfigurationListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1290832319
+// LIFERAY-SERVICE-BUILDER-HASH:-804965261

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListRelPersistenceTest.java
@@ -590,4 +590,4 @@ public class CPConfigurationListRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-120472000
+// LIFERAY-SERVICE-BUILDER-HASH:80569526

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLinkPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLinkPersistenceTest.java
@@ -731,4 +731,4 @@ public class CPDefinitionLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1352959647
+// LIFERAY-SERVICE-BUILDER-HASH:910619107

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLocalizationPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLocalizationPersistenceTest.java
@@ -570,4 +570,4 @@ public class CPDefinitionLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:111763230
+// LIFERAY-SERVICE-BUILDER-HASH:480022718

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionRelPersistenceTest.java
@@ -770,4 +770,4 @@ public class CPDefinitionOptionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1428323899
+// LIFERAY-SERVICE-BUILDER-HASH:93978683

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionValueRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionValueRelPersistenceTest.java
@@ -753,4 +753,4 @@ public class CPDefinitionOptionValueRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:960810872
+// LIFERAY-SERVICE-BUILDER-HASH:87310304

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionPersistenceTest.java
@@ -922,4 +922,4 @@ public class CPDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1555603426
+// LIFERAY-SERVICE-BUILDER-HASH:2118161648

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
@@ -881,4 +881,4 @@ public class CPDefinitionSpecificationOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:640902703
+// LIFERAY-SERVICE-BUILDER-HASH:-1544734001

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDisplayLayoutPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDisplayLayoutPersistenceTest.java
@@ -649,4 +649,4 @@ public class CPDisplayLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1537012600
+// LIFERAY-SERVICE-BUILDER-HASH:-1422356328

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceOptionValueRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceOptionValueRelPersistenceTest.java
@@ -680,4 +680,4 @@ public class CPInstanceOptionValueRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1060382629
+// LIFERAY-SERVICE-BUILDER-HASH:998537721

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
@@ -996,4 +996,4 @@ public class CPInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1160124224
+// LIFERAY-SERVICE-BUILDER-HASH:487147822

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceUnitOfMeasurePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceUnitOfMeasurePersistenceTest.java
@@ -705,4 +705,4 @@ public class CPInstanceUnitOfMeasurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1547151755
+// LIFERAY-SERVICE-BUILDER-HASH:1957473553

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
@@ -699,4 +699,4 @@ public class CPMeasurementUnitPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:881297784
+// LIFERAY-SERVICE-BUILDER-HASH:1072606144

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
@@ -635,4 +635,4 @@ public class CPOptionCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:55873155
+// LIFERAY-SERVICE-BUILDER-HASH:1837429045

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
@@ -625,4 +625,4 @@ public class CPOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:469016723
+// LIFERAY-SERVICE-BUILDER-HASH:901031617

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
@@ -630,4 +630,4 @@ public class CPOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1505851748
+// LIFERAY-SERVICE-BUILDER-HASH:-1893416348

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionListTypeDefinitionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionListTypeDefinitionRelPersistenceTest.java
@@ -635,4 +635,4 @@ public class CPSpecificationOptionListTypeDefinitionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:55205659
+// LIFERAY-SERVICE-BUILDER-HASH:776712083

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
@@ -709,4 +709,4 @@ public class CPSpecificationOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:741350539
+// LIFERAY-SERVICE-BUILDER-HASH:1204727235

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
@@ -581,4 +581,4 @@ public class CPTaxCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-861751517
+// LIFERAY-SERVICE-BUILDER-HASH:1609437737

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
@@ -588,4 +588,4 @@ public class CProductPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1936652787
+// LIFERAY-SERVICE-BUILDER-HASH:1586055079

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
@@ -627,4 +627,4 @@ public class CommerceCatalogPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1336146064
+// LIFERAY-SERVICE-BUILDER-HASH:-565766648

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelAccountEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelAccountEntryRelPersistenceTest.java
@@ -710,4 +710,4 @@ public class CommerceChannelAccountEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-541740856
+// LIFERAY-SERVICE-BUILDER-HASH:-573370556

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
@@ -648,4 +648,4 @@ public class CommerceChannelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1802377063
+// LIFERAY-SERVICE-BUILDER-HASH:1930838379

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelRelPersistenceTest.java
@@ -559,4 +559,4 @@ public class CommerceChannelRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:733668831
+// LIFERAY-SERVICE-BUILDER-HASH:1507576581

--- a/modules/apps/commerce/commerce-product-type-grouped-test/src/testIntegration/java/com/liferay/commerce/product/type/grouped/service/persistence/test/CPDefinitionGroupedEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-grouped-test/src/testIntegration/java/com/liferay/commerce/product/type/grouped/service/persistence/test/CPDefinitionGroupedEntryPersistenceTest.java
@@ -644,4 +644,4 @@ public class CPDefinitionGroupedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2002894502
+// LIFERAY-SERVICE-BUILDER-HASH:-490600772

--- a/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemFileEntryPersistenceTest.java
@@ -682,4 +682,4 @@ public class CommerceVirtualOrderItemFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2117508729
+// LIFERAY-SERVICE-BUILDER-HASH:-1251184877

--- a/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemPersistenceTest.java
@@ -648,4 +648,4 @@ public class CommerceVirtualOrderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-988058295
+// LIFERAY-SERVICE-BUILDER-HASH:803512411

--- a/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDVirtualSettingFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDVirtualSettingFileEntryPersistenceTest.java
@@ -642,4 +642,4 @@ public class CPDVirtualSettingFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1084227417
+// LIFERAY-SERVICE-BUILDER-HASH:1579594715

--- a/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDefinitionVirtualSettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDefinitionVirtualSettingPersistenceTest.java
@@ -725,4 +725,4 @@ public class CPDefinitionVirtualSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1037519849
+// LIFERAY-SERVICE-BUILDER-HASH:-1393964915

--- a/modules/apps/commerce/commerce-qualifier-test/src/testIntegration/java/com/liferay/commerce/qualifier/service/persistence/test/CommerceQualifierEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-qualifier-test/src/testIntegration/java/com/liferay/commerce/qualifier/service/persistence/test/CommerceQualifierEntryPersistenceTest.java
@@ -637,4 +637,4 @@ public class CommerceQualifierEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1025084400
+// LIFERAY-SERVICE-BUILDER-HASH:-676577356

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionPersistenceTest.java
@@ -628,4 +628,4 @@ public class CommerceShippingFixedOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1942775341
+// LIFERAY-SERVICE-BUILDER-HASH:1068597029

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionQualifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionQualifierPersistenceTest.java
@@ -661,4 +661,4 @@ public class CommerceShippingFixedOptionQualifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1598144071
+// LIFERAY-SERVICE-BUILDER-HASH:-1242503575

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionRelPersistenceTest.java
@@ -624,4 +624,4 @@ public class CommerceShippingFixedOptionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-235724732
+// LIFERAY-SERVICE-BUILDER-HASH:-965255886

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
@@ -624,4 +624,4 @@ public class CSDiagramEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-327564316
+// LIFERAY-SERVICE-BUILDER-HASH:208864640

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramPinPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramPinPersistenceTest.java
@@ -462,4 +462,4 @@ public class CSDiagramPinPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1983853136
+// LIFERAY-SERVICE-BUILDER-HASH:-145339814

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramSettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramSettingPersistenceTest.java
@@ -563,4 +563,4 @@ public class CSDiagramSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1532356934
+// LIFERAY-SERVICE-BUILDER-HASH:-834061210

--- a/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRateAddressRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRateAddressRelPersistenceTest.java
@@ -567,4 +567,4 @@ public class CommerceTaxFixedRateAddressRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:596740637
+// LIFERAY-SERVICE-BUILDER-HASH:776347611

--- a/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRatePersistenceTest.java
@@ -577,4 +577,4 @@ public class CommerceTaxFixedRatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1005123486
+// LIFERAY-SERVICE-BUILDER-HASH:-2029196282

--- a/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
@@ -690,4 +690,4 @@ public class CommerceTaxCategoryMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1543232884
+// LIFERAY-SERVICE-BUILDER-HASH:-1155136862

--- a/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxMethodPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxMethodPersistenceTest.java
@@ -570,4 +570,4 @@ public class CommerceTaxMethodPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:240740727
+// LIFERAY-SERVICE-BUILDER-HASH:-4016139

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CTermEntryLocalizationPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CTermEntryLocalizationPersistenceTest.java
@@ -514,4 +514,4 @@ public class CTermEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:218239652
+// LIFERAY-SERVICE-BUILDER-HASH:821465778

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
@@ -752,4 +752,4 @@ public class CommerceTermEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1180750757
+// LIFERAY-SERVICE-BUILDER-HASH:-1661615149

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryRelPersistenceTest.java
@@ -574,4 +574,4 @@ public class CommerceTermEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-284860596
+// LIFERAY-SERVICE-BUILDER-HASH:2036157880

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDAvailabilityEstimatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDAvailabilityEstimatePersistenceTest.java
@@ -596,4 +596,4 @@ public class CPDAvailabilityEstimatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-484152596
+// LIFERAY-SERVICE-BUILDER-HASH:-544457614

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDefinitionInventoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDefinitionInventoryPersistenceTest.java
@@ -692,4 +692,4 @@ public class CPDefinitionInventoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1539306494
+// LIFERAY-SERVICE-BUILDER-HASH:-111747836

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAddressRestrictionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAddressRestrictionPersistenceTest.java
@@ -606,4 +606,4 @@ public class CommerceAddressRestrictionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1320145230
+// LIFERAY-SERVICE-BUILDER-HASH:2146285276

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
@@ -665,4 +665,4 @@ public class CommerceAvailabilityEstimatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1263925719
+// LIFERAY-SERVICE-BUILDER-HASH:-1706558911

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
@@ -693,4 +693,4 @@ public class CommerceOrderAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1416523454
+// LIFERAY-SERVICE-BUILDER-HASH:-1137200550

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
@@ -1167,4 +1167,4 @@ public class CommerceOrderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1821911223
+// LIFERAY-SERVICE-BUILDER-HASH:1666211597

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
@@ -626,4 +626,4 @@ public class CommerceOrderNotePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-59050498
+// LIFERAY-SERVICE-BUILDER-HASH:2027228004

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPaymentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPaymentPersistenceTest.java
@@ -497,4 +497,4 @@ public class CommerceOrderPaymentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-145142081
+// LIFERAY-SERVICE-BUILDER-HASH:-1826010483

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
@@ -1311,4 +1311,4 @@ public class CommerceOrderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2114684150
+// LIFERAY-SERVICE-BUILDER-HASH:1645718528

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
@@ -676,4 +676,4 @@ public class CommerceOrderTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2025453697
+// LIFERAY-SERVICE-BUILDER-HASH:1572989271

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
@@ -654,4 +654,4 @@ public class CommerceOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:979222311
+// LIFERAY-SERVICE-BUILDER-HASH:750345891

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
@@ -729,4 +729,4 @@ public class CommerceShipmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1404079223
+// LIFERAY-SERVICE-BUILDER-HASH:1546777861

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
@@ -728,4 +728,4 @@ public class CommerceShipmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1258339584
+// LIFERAY-SERVICE-BUILDER-HASH:1085593738

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingMethodPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingMethodPersistenceTest.java
@@ -621,4 +621,4 @@ public class CommerceShippingMethodPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1806077212
+// LIFERAY-SERVICE-BUILDER-HASH:-311589532

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingOptionAccountEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingOptionAccountEntryRelPersistenceTest.java
@@ -674,4 +674,4 @@ public class CommerceShippingOptionAccountEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-732014959
+// LIFERAY-SERVICE-BUILDER-HASH:-495047755

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceSubscriptionEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceSubscriptionEntryPersistenceTest.java
@@ -870,4 +870,4 @@ public class CommerceSubscriptionEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1220152617
+// LIFERAY-SERVICE-BUILDER-HASH:-227292997

--- a/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListItemPersistenceTest.java
@@ -617,4 +617,4 @@ public class CommerceWishListItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1661026957
+// LIFERAY-SERVICE-BUILDER-HASH:-51701049

--- a/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListPersistenceTest.java
@@ -584,4 +584,4 @@ public class CommerceWishListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1723242011
+// LIFERAY-SERVICE-BUILDER-HASH:-1270860889

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
@@ -559,4 +559,4 @@ public class DepotAppCustomizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2058003484
+// LIFERAY-SERVICE-BUILDER-HASH:1284350686

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
@@ -654,4 +654,4 @@ public class DepotEntryGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-248444641
+// LIFERAY-SERVICE-BUILDER-HASH:658586225

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
@@ -551,4 +551,4 @@ public class DepotEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2121966625
+// LIFERAY-SERVICE-BUILDER-HASH:-2131875545

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPinPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPinPersistenceTest.java
@@ -548,4 +548,4 @@ public class DepotEntryPinPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1760724621
+// LIFERAY-SERVICE-BUILDER-HASH:1583096901

--- a/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/service/persistence/test/DLOpenerFileEntryReferencePersistenceTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/service/persistence/test/DLOpenerFileEntryReferencePersistenceTest.java
@@ -607,4 +607,4 @@ public class DLOpenerFileEntryReferencePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:833611621
+// LIFERAY-SERVICE-BUILDER-HASH:-1265236571

--- a/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
+++ b/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -167,10 +166,8 @@ public class DLContentPersistenceTest {
 			existingDLContent.getVersion(), newDLContent.getVersion());
 		Blob existingData = existingDLContent.getData();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingData.getBytes(1, (int)existingData.length()),
-				newDataBytes));
+		Assert.assertArrayEquals(
+			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
 		Assert.assertEquals(
 			existingDLContent.getSize(), newDLContent.getSize());
 	}
@@ -559,4 +556,4 @@ public class DLContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:201945963
+// LIFERAY-SERVICE-BUILDER-HASH:-1728301549

--- a/modules/apps/document-library/document-library-sync-test/src/testIntegration/java/com/liferay/document/library/sync/service/persistence/test/DLSyncEventPersistenceTest.java
+++ b/modules/apps/document-library/document-library-sync-test/src/testIntegration/java/com/liferay/document/library/sync/service/persistence/test/DLSyncEventPersistenceTest.java
@@ -481,4 +481,4 @@ public class DLSyncEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1277682018
+// LIFERAY-SERVICE-BUILDER-HASH:-1408738176

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
@@ -626,4 +626,4 @@ public class DDLRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-941593998
+// LIFERAY-SERVICE-BUILDER-HASH:1817912770

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
@@ -679,4 +679,4 @@ public class DDLRecordSetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:433063173
+// LIFERAY-SERVICE-BUILDER-HASH:-829314943

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetVersionPersistenceTest.java
@@ -611,4 +611,4 @@ public class DDLRecordSetVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1758213242
+// LIFERAY-SERVICE-BUILDER-HASH:-2094520574

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
@@ -612,4 +612,4 @@ public class DDLRecordVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:674546231
+// LIFERAY-SERVICE-BUILDER-HASH:1503089583

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
@@ -554,4 +554,4 @@ public class DDMContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-828389301
+// LIFERAY-SERVICE-BUILDER-HASH:-1222020281

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstanceLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstanceLinkPersistenceTest.java
@@ -564,4 +564,4 @@ public class DDMDataProviderInstanceLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1641794036
+// LIFERAY-SERVICE-BUILDER-HASH:-336966554

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstancePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstancePersistenceTest.java
@@ -670,4 +670,4 @@ public class DDMDataProviderInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-39555662
+// LIFERAY-SERVICE-BUILDER-HASH:-672955112

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldAttributePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldAttributePersistenceTest.java
@@ -545,4 +545,4 @@ public class DDMFieldAttributePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1375402831
+// LIFERAY-SERVICE-BUILDER-HASH:-7519291

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
@@ -539,4 +539,4 @@ public class DDMFieldPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:657708727
+// LIFERAY-SERVICE-BUILDER-HASH:-1591994999

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstancePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstancePersistenceTest.java
@@ -646,4 +646,4 @@ public class DDMFormInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-880998471
+// LIFERAY-SERVICE-BUILDER-HASH:534701473

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
@@ -681,4 +681,4 @@ public class DDMFormInstanceRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-285956691
+// LIFERAY-SERVICE-BUILDER-HASH:-516505005

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordVersionPersistenceTest.java
@@ -693,4 +693,4 @@ public class DDMFormInstanceRecordVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1839766323
+// LIFERAY-SERVICE-BUILDER-HASH:338287885

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceReportPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceReportPersistenceTest.java
@@ -545,4 +545,4 @@ public class DDMFormInstanceReportPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-732549838
+// LIFERAY-SERVICE-BUILDER-HASH:2081587826

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceVersionPersistenceTest.java
@@ -636,4 +636,4 @@ public class DDMFormInstanceVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1768065703
+// LIFERAY-SERVICE-BUILDER-HASH:1447464685

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
@@ -540,4 +540,4 @@ public class DDMStorageLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1986717300
+// LIFERAY-SERVICE-BUILDER-HASH:1602423268

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
@@ -664,4 +664,4 @@ public class DDMStructureLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-231210191
+// LIFERAY-SERVICE-BUILDER-HASH:-2113502191

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
@@ -515,4 +515,4 @@ public class DDMStructureLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1885532546
+// LIFERAY-SERVICE-BUILDER-HASH:311259458

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
@@ -787,4 +787,4 @@ public class DDMStructurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1746414699
+// LIFERAY-SERVICE-BUILDER-HASH:-1477941809

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
@@ -624,4 +624,4 @@ public class DDMStructureVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-207695979
+// LIFERAY-SERVICE-BUILDER-HASH:2062373413

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
@@ -501,4 +501,4 @@ public class DDMTemplateLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-483966005
+// LIFERAY-SERVICE-BUILDER-HASH:-1456036899

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
@@ -874,4 +874,4 @@ public class DDMTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1304476432
+// LIFERAY-SERVICE-BUILDER-HASH:-1465699254

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
@@ -617,4 +617,4 @@ public class DDMTemplateVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:515471795
+// LIFERAY-SERVICE-BUILDER-HASH:1740187757

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/persistence/test/ExportImportReportEntryPersistenceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/persistence/test/ExportImportReportEntryPersistenceTest.java
@@ -650,4 +650,4 @@ public class ExportImportReportEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1768262800
+// LIFERAY-SERVICE-BUILDER-HASH:-458496306

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
@@ -724,4 +724,4 @@ public class FragmentCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1344627558
+// LIFERAY-SERVICE-BUILDER-HASH:-1837523644

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
@@ -775,4 +775,4 @@ public class FragmentCompositionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1389237505
+// LIFERAY-SERVICE-BUILDER-HASH:1396529147

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
@@ -946,4 +946,4 @@ public class FragmentEntryLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:111929934
+// LIFERAY-SERVICE-BUILDER-HASH:-1539095228

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
@@ -1170,4 +1170,4 @@ public class FragmentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-701265265
+// LIFERAY-SERVICE-BUILDER-HASH:790758245

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryVersionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryVersionPersistenceTest.java
@@ -966,4 +966,4 @@ public class FragmentEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1989936988
+// LIFERAY-SERVICE-BUILDER-HASH:-2101270754

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
@@ -662,4 +662,4 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1448802319
+// LIFERAY-SERVICE-BUILDER-HASH:-582172179

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryMappingPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryMappingPersistenceTest.java
@@ -509,4 +509,4 @@ public class FriendlyURLEntryMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-725149441
+// LIFERAY-SERVICE-BUILDER-HASH:443163457

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryPersistenceTest.java
@@ -578,4 +578,4 @@ public class FriendlyURLEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1611995680
+// LIFERAY-SERVICE-BUILDER-HASH:-280931402

--- a/modules/apps/invitation/invitation-invite-members-test/src/testIntegration/java/com/liferay/invitation/invite/members/service/persistence/test/MemberRequestPersistenceTest.java
+++ b/modules/apps/invitation/invitation-invite-members-test/src/testIntegration/java/com/liferay/invitation/invite/members/service/persistence/test/MemberRequestPersistenceTest.java
@@ -566,4 +566,4 @@ public class MemberRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-380862921
+// LIFERAY-SERVICE-BUILDER-HASH:2017623315

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleLocalizationPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleLocalizationPersistenceTest.java
@@ -539,4 +539,4 @@ public class JournalArticleLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1041766921
+// LIFERAY-SERVICE-BUILDER-HASH:923538711

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
@@ -1174,4 +1174,4 @@ public class JournalArticlePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1881453920
+// LIFERAY-SERVICE-BUILDER-HASH:-398671790

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
@@ -576,4 +576,4 @@ public class JournalArticleResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-16012004
+// LIFERAY-SERVICE-BUILDER-HASH:170528562

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
@@ -635,4 +635,4 @@ public class JournalContentSearchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-911491163
+// LIFERAY-SERVICE-BUILDER-HASH:-6902615

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
@@ -681,4 +681,4 @@ public class JournalFeedPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-189051229
+// LIFERAY-SERVICE-BUILDER-HASH:-1717880535

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
@@ -779,4 +779,4 @@ public class JournalFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1513745375
+// LIFERAY-SERVICE-BUILDER-HASH:63747973

--- a/modules/apps/json-storage/json-storage-test/src/testIntegration/java/com/liferay/json/storage/service/persistence/test/JSONStorageEntryPersistenceTest.java
+++ b/modules/apps/json-storage/json-storage-test/src/testIntegration/java/com/liferay/json/storage/service/persistence/test/JSONStorageEntryPersistenceTest.java
@@ -579,4 +579,4 @@ public class JSONStorageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:364213623
+// LIFERAY-SERVICE-BUILDER-HASH:2105899283

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -1427,4 +1427,4 @@ public class KBArticlePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1874403056
+// LIFERAY-SERVICE-BUILDER-HASH:275016910

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBCommentPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBCommentPersistenceTest.java
@@ -617,4 +617,4 @@ public class KBCommentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:109227869
+// LIFERAY-SERVICE-BUILDER-HASH:440275597

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
@@ -703,4 +703,4 @@ public class KBFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-999790360
+// LIFERAY-SERVICE-BUILDER-HASH:2026540294

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBTemplatePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBTemplatePersistenceTest.java
@@ -578,4 +578,4 @@ public class KBTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1091453738
+// LIFERAY-SERVICE-BUILDER-HASH:1834932960

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
@@ -859,4 +859,4 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1220507243
+// LIFERAY-SERVICE-BUILDER-HASH:-851004623

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
@@ -1112,4 +1112,4 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:162554197
+// LIFERAY-SERVICE-BUILDER-HASH:1880568637

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructurePersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructurePersistenceTest.java
@@ -636,4 +636,4 @@ public class LayoutPageTemplateStructurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1240419073
+// LIFERAY-SERVICE-BUILDER-HASH:693207817

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
@@ -865,4 +865,4 @@ public class
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1928368371
+// LIFERAY-SERVICE-BUILDER-HASH:844105925

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
@@ -873,4 +873,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:569507337
+// LIFERAY-SERVICE-BUILDER-HASH:-1262746037

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelPersistenceTest.java
@@ -727,4 +727,4 @@ public class LayoutPageTemplateStructureRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1489402410
+// LIFERAY-SERVICE-BUILDER-HASH:1463971842

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryCustomMetaTagPersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryCustomMetaTagPersistenceTest.java
@@ -462,4 +462,4 @@ public class LayoutSEOEntryCustomMetaTagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:970137636
+// LIFERAY-SERVICE-BUILDER-HASH:-1545671532

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryPersistenceTest.java
@@ -656,4 +656,4 @@ public class LayoutSEOEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-390273782
+// LIFERAY-SERVICE-BUILDER-HASH:-1573322436

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOSitePersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOSitePersistenceTest.java
@@ -567,4 +567,4 @@ public class LayoutSEOSitePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1294938591
+// LIFERAY-SERVICE-BUILDER-HASH:-120256083

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
@@ -754,4 +754,4 @@ public class LayoutClassedModelUsagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-640082554
+// LIFERAY-SERVICE-BUILDER-HASH:-653924718

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutLocalizationPersistenceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutLocalizationPersistenceTest.java
@@ -618,4 +618,4 @@ public class LayoutLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-771706937
+// LIFERAY-SERVICE-BUILDER-HASH:-1233343093

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
@@ -805,4 +805,4 @@ public class LayoutUtilityPageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:607144157
+// LIFERAY-SERVICE-BUILDER-HASH:156035521

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
@@ -598,4 +598,4 @@ public class ListTypeDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1129550753
+// LIFERAY-SERVICE-BUILDER-HASH:679683249

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeEntryPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeEntryPersistenceTest.java
@@ -624,4 +624,4 @@ public class ListTypeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:764330581
+// LIFERAY-SERVICE-BUILDER-HASH:-1261078717

--- a/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
@@ -534,4 +534,4 @@ public class AppPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:325545887
+// LIFERAY-SERVICE-BUILDER-HASH:1405973987

--- a/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
@@ -530,4 +530,4 @@ public class ModulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1901173778
+// LIFERAY-SERVICE-BUILDER-HASH:740498716

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBBanPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBBanPersistenceTest.java
@@ -557,4 +557,4 @@ public class MBBanPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:460789613
+// LIFERAY-SERVICE-BUILDER-HASH:1815716769

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
@@ -805,4 +805,4 @@ public class MBCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:902096164
+// LIFERAY-SERVICE-BUILDER-HASH:1244912962

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBDiscussionPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBDiscussionPersistenceTest.java
@@ -588,4 +588,4 @@ public class MBDiscussionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:447314127
+// LIFERAY-SERVICE-BUILDER-HASH:-657024639

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMailingListPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMailingListPersistenceTest.java
@@ -687,4 +687,4 @@ public class MBMailingListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1808532294
+// LIFERAY-SERVICE-BUILDER-HASH:-93569594

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
@@ -983,4 +983,4 @@ public class MBMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1489612658
+// LIFERAY-SERVICE-BUILDER-HASH:2049504174

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBSuspiciousActivityPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBSuspiciousActivityPersistenceTest.java
@@ -654,4 +654,4 @@ public class MBSuspiciousActivityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1038066977
+// LIFERAY-SERVICE-BUILDER-HASH:1465313819

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadFlagPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadFlagPersistenceTest.java
@@ -575,4 +575,4 @@ public class MBThreadFlagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1427288890
+// LIFERAY-SERVICE-BUILDER-HASH:-962790892

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadPersistenceTest.java
@@ -759,4 +759,4 @@ public class MBThreadPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:266197960
+// LIFERAY-SERVICE-BUILDER-HASH:2121578578

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryAttachmentPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryAttachmentPersistenceTest.java
@@ -486,4 +486,4 @@ public class NotificationQueueEntryAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:229843851
+// LIFERAY-SERVICE-BUILDER-HASH:-718625953

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryPersistenceTest.java
@@ -558,4 +558,4 @@ public class NotificationQueueEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2060431417
+// LIFERAY-SERVICE-BUILDER-HASH:1075912757

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientPersistenceTest.java
@@ -569,4 +569,4 @@ public class NotificationRecipientPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-544389168
+// LIFERAY-SERVICE-BUILDER-HASH:-962469518

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientSettingPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientSettingPersistenceTest.java
@@ -618,4 +618,4 @@ public class NotificationRecipientSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1765690740
+// LIFERAY-SERVICE-BUILDER-HASH:886039922

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplateAttachmentPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplateAttachmentPersistenceTest.java
@@ -554,4 +554,4 @@ public class NotificationTemplateAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1586337421
+// LIFERAY-SERVICE-BUILDER-HASH:1706808729

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
@@ -665,4 +665,4 @@ public class NotificationTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1298978744
+// LIFERAY-SERVICE-BUILDER-HASH:-1686283784

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
@@ -754,4 +754,4 @@ public class OAuthClientASLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-187987132
+// LIFERAY-SERVICE-BUILDER-HASH:250224358

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
@@ -686,4 +686,4 @@ public class OAuthClientEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-336421618
+// LIFERAY-SERVICE-BUILDER-HASH:251064728

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
@@ -718,4 +718,4 @@ public class OAuthClientPRLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1497845597
+// LIFERAY-SERVICE-BUILDER-HASH:1397138195

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectActionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectActionPersistenceTest.java
@@ -707,4 +707,4 @@ public class ObjectActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-132397846
+// LIFERAY-SERVICE-BUILDER-HASH:-513795542

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
@@ -988,4 +988,4 @@ public class ObjectDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1833221191
+// LIFERAY-SERVICE-BUILDER-HASH:1990168429

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionSettingPersistenceTest.java
@@ -616,4 +616,4 @@ public class ObjectDefinitionSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1989435165
+// LIFERAY-SERVICE-BUILDER-HASH:-1834894261

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryFolderPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryFolderPersistenceTest.java
@@ -648,4 +648,4 @@ public class ObjectEntryFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:523643676
+// LIFERAY-SERVICE-BUILDER-HASH:-1884703138

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
@@ -753,4 +753,4 @@ public class ObjectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1461355312
+// LIFERAY-SERVICE-BUILDER-HASH:-1440861900

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
@@ -647,4 +647,4 @@ public class ObjectEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-638064700
+// LIFERAY-SERVICE-BUILDER-HASH:-1703716790

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
@@ -779,4 +779,4 @@ public class ObjectFieldPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1968025669
+// LIFERAY-SERVICE-BUILDER-HASH:235938735

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldSettingPersistenceTest.java
@@ -564,4 +564,4 @@ public class ObjectFieldSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:543232313
+// LIFERAY-SERVICE-BUILDER-HASH:-1498063239

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFilterPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFilterPersistenceTest.java
@@ -475,4 +475,4 @@ public class ObjectFilterPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-86182832
+// LIFERAY-SERVICE-BUILDER-HASH:867640268

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderItemPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderItemPersistenceTest.java
@@ -566,4 +566,4 @@ public class ObjectFolderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-510281197
+// LIFERAY-SERVICE-BUILDER-HASH:1174142059

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
@@ -589,4 +589,4 @@ public class ObjectFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-933257862
+// LIFERAY-SERVICE-BUILDER-HASH:1047035788

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutBoxPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutBoxPersistenceTest.java
@@ -461,4 +461,4 @@ public class ObjectLayoutBoxPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1746601135
+// LIFERAY-SERVICE-BUILDER-HASH:-837797387

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutColumnPersistenceTest.java
@@ -473,4 +473,4 @@ public class ObjectLayoutColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1727625470
+// LIFERAY-SERVICE-BUILDER-HASH:1263574190

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutPersistenceTest.java
@@ -485,4 +485,4 @@ public class ObjectLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1809303522
+// LIFERAY-SERVICE-BUILDER-HASH:1340447686

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutRowPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutRowPersistenceTest.java
@@ -441,4 +441,4 @@ public class ObjectLayoutRowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:322944545
+// LIFERAY-SERVICE-BUILDER-HASH:-1644178151

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutTabPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutTabPersistenceTest.java
@@ -489,4 +489,4 @@ public class ObjectLayoutTabPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1390226969
+// LIFERAY-SERVICE-BUILDER-HASH:491821579

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectRelationshipPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectRelationshipPersistenceTest.java
@@ -845,4 +845,4 @@ public class ObjectRelationshipPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:854761371
+// LIFERAY-SERVICE-BUILDER-HASH:1030218519

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateFlowPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateFlowPersistenceTest.java
@@ -522,4 +522,4 @@ public class ObjectStateFlowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1080156531
+// LIFERAY-SERVICE-BUILDER-HASH:223183293

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStatePersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStatePersistenceTest.java
@@ -538,4 +538,4 @@ public class ObjectStatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1769463306
+// LIFERAY-SERVICE-BUILDER-HASH:-91170256

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateTransitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateTransitionPersistenceTest.java
@@ -528,4 +528,4 @@ public class ObjectStateTransitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-989519734
+// LIFERAY-SERVICE-BUILDER-HASH:962860206

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRulePersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRulePersistenceTest.java
@@ -673,4 +673,4 @@ public class ObjectValidationRulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1853167914
+// LIFERAY-SERVICE-BUILDER-HASH:-433169224

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRuleSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRuleSettingPersistenceTest.java
@@ -650,4 +650,4 @@ public class ObjectValidationRuleSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:35829529
+// LIFERAY-SERVICE-BUILDER-HASH:1704230727

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewColumnPersistenceTest.java
@@ -467,4 +467,4 @@ public class ObjectViewColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1578875894
+// LIFERAY-SERVICE-BUILDER-HASH:367822004

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewFilterColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewFilterColumnPersistenceTest.java
@@ -530,4 +530,4 @@ public class ObjectViewFilterColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1854775932
+// LIFERAY-SERVICE-BUILDER-HASH:-1496982826

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewPersistenceTest.java
@@ -472,4 +472,4 @@ public class ObjectViewPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1880262709
+// LIFERAY-SERVICE-BUILDER-HASH:119573705

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewSortColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewSortColumnPersistenceTest.java
@@ -493,4 +493,4 @@ public class ObjectViewSortColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-961752338
+// LIFERAY-SERVICE-BUILDER-HASH:28482004

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
@@ -639,4 +639,4 @@ public class BackgroundTaskPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-510098229
+// LIFERAY-SERVICE-BUILDER-HASH:-345996177

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
@@ -523,4 +523,4 @@ public class PLOEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1502411394
+// LIFERAY-SERVICE-BUILDER-HASH:-847040590

--- a/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
+++ b/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
@@ -549,4 +549,4 @@ public class LockPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:910464179
+// LIFERAY-SERVICE-BUILDER-HASH:410881603

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
@@ -494,4 +494,4 @@ public class AuditEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1124926776
+// LIFERAY-SERVICE-BUILDER-HASH:938574770

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectSessionPersistenceTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectSessionPersistenceTest.java
@@ -651,4 +651,4 @@ public class OpenIdConnectSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:207899442
+// LIFERAY-SERVICE-BUILDER-HASH:-1665544494

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectUserPersistenceTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectUserPersistenceTest.java
@@ -518,4 +518,4 @@ public class OpenIdConnectUserPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-221259537
+// LIFERAY-SERVICE-BUILDER-HASH:-1455427471

--- a/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
@@ -551,4 +551,4 @@ public class SAPEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-806284371
+// LIFERAY-SERVICE-BUILDER-HASH:-979646221

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
@@ -566,4 +566,4 @@ public class KaleoActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:628697203
+// LIFERAY-SERVICE-BUILDER-HASH:1889296933

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
@@ -562,4 +562,4 @@ public class KaleoConditionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-865471702
+// LIFERAY-SERVICE-BUILDER-HASH:-842860846

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
@@ -760,4 +760,4 @@ public class KaleoDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1056764011
+// LIFERAY-SERVICE-BUILDER-HASH:1727286379

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
@@ -660,4 +660,4 @@ public class KaleoDefinitionVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:670101364
+// LIFERAY-SERVICE-BUILDER-HASH:-451396560

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
@@ -652,4 +652,4 @@ public class KaleoInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:218049073
+// LIFERAY-SERVICE-BUILDER-HASH:-1096779523

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
@@ -569,4 +569,4 @@ public class KaleoInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:544838431
+// LIFERAY-SERVICE-BUILDER-HASH:122205957

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
@@ -641,4 +641,4 @@ public class KaleoLogPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:760193821
+// LIFERAY-SERVICE-BUILDER-HASH:-200066889

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
@@ -505,4 +505,4 @@ public class KaleoNodePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:195095991
+// LIFERAY-SERVICE-BUILDER-HASH:-1206390531

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodeSettingPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodeSettingPersistenceTest.java
@@ -535,4 +535,4 @@ public class KaleoNodeSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:880342261
+// LIFERAY-SERVICE-BUILDER-HASH:1688448557

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
@@ -560,4 +560,4 @@ public class KaleoNotificationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1274619000
+// LIFERAY-SERVICE-BUILDER-HASH:-1239777768

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
@@ -615,4 +615,4 @@ public class KaleoNotificationRecipientPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:248852810
+// LIFERAY-SERVICE-BUILDER-HASH:239953528

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
@@ -664,4 +664,4 @@ public class KaleoTaskAssignmentInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1096969283
+// LIFERAY-SERVICE-BUILDER-HASH:1600257595

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
@@ -575,4 +575,4 @@ public class KaleoTaskAssignmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1132352105
+// LIFERAY-SERVICE-BUILDER-HASH:-1600151037

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormInstancePersistenceTest.java
@@ -671,4 +671,4 @@ public class KaleoTaskFormInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:549252802
+// LIFERAY-SERVICE-BUILDER-HASH:1462258404

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormPersistenceTest.java
@@ -637,4 +637,4 @@ public class KaleoTaskFormPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-119176848
+// LIFERAY-SERVICE-BUILDER-HASH:-1355468884

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
@@ -706,4 +706,4 @@ public class KaleoTaskInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1204026389
+// LIFERAY-SERVICE-BUILDER-HASH:2079438395

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
@@ -539,4 +539,4 @@ public class KaleoTaskPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1589705424
+// LIFERAY-SERVICE-BUILDER-HASH:312969956

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
@@ -702,4 +702,4 @@ public class KaleoTimerInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2017891503
+// LIFERAY-SERVICE-BUILDER-HASH:-2024909927

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
@@ -534,4 +534,4 @@ public class KaleoTimerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1250126303
+// LIFERAY-SERVICE-BUILDER-HASH:-465052835

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
@@ -635,4 +635,4 @@ public class KaleoTransitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2102990744
+// LIFERAY-SERVICE-BUILDER-HASH:-1523539556

--- a/modules/apps/push-notifications/push-notifications-test/src/testIntegration/java/com/liferay/push/notifications/service/persistence/test/PushNotificationsDevicePersistenceTest.java
+++ b/modules/apps/push-notifications/push-notifications-test/src/testIntegration/java/com/liferay/push/notifications/service/persistence/test/PushNotificationsDevicePersistenceTest.java
@@ -549,4 +549,4 @@ public class PushNotificationsDevicePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1262352453
+// LIFERAY-SERVICE-BUILDER-HASH:-789450475

--- a/modules/apps/reading-time/reading-time-test/src/testIntegration/java/com/liferay/reading/time/service/persistence/test/ReadingTimeEntryPersistenceTest.java
+++ b/modules/apps/reading-time/reading-time-test/src/testIntegration/java/com/liferay/reading/time/service/persistence/test/ReadingTimeEntryPersistenceTest.java
@@ -570,4 +570,4 @@ public class ReadingTimeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:736700506
+// LIFERAY-SERVICE-BUILDER-HASH:-1023054752

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectEntryPersistenceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectEntryPersistenceTest.java
@@ -626,4 +626,4 @@ public class RedirectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1939766401
+// LIFERAY-SERVICE-BUILDER-HASH:1753418487

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectNotFoundEntryPersistenceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectNotFoundEntryPersistenceTest.java
@@ -566,4 +566,4 @@ public class RedirectNotFoundEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:888531954
+// LIFERAY-SERVICE-BUILDER-HASH:-1909905366

--- a/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
+++ b/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
@@ -710,4 +710,4 @@ public class SavedContentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:474436523
+// LIFERAY-SERVICE-BUILDER-HASH:700017423

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
@@ -789,4 +789,4 @@ public class SegmentsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:934953616
+// LIFERAY-SERVICE-BUILDER-HASH:695376250

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRelPersistenceTest.java
@@ -565,4 +565,4 @@ public class SegmentsEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1491048524
+// LIFERAY-SERVICE-BUILDER-HASH:1285087144

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRolePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRolePersistenceTest.java
@@ -539,4 +539,4 @@ public class SegmentsEntryRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2089390819
+// LIFERAY-SERVICE-BUILDER-HASH:1993450335

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperienceAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperienceAudienceEntryRelPersistenceTest.java
@@ -712,4 +712,4 @@ public class SegmentsExperienceAudienceEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1105885472
+// LIFERAY-SERVICE-BUILDER-HASH:-1116485920

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
@@ -864,4 +864,4 @@ public class SegmentsExperiencePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:543106300
+// LIFERAY-SERVICE-BUILDER-HASH:1613056766

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentPersistenceTest.java
@@ -700,4 +700,4 @@ public class SegmentsExperimentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-196525270
+// LIFERAY-SERVICE-BUILDER-HASH:-71057614

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentRelPersistenceTest.java
@@ -591,4 +591,4 @@ public class SegmentsExperimentRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-335183991
+// LIFERAY-SERVICE-BUILDER-HASH:1651907551

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -732,4 +732,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:482754459
+// LIFERAY-SERVICE-BUILDER-HASH:-201598475

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
@@ -741,4 +741,4 @@ public class SiteNavigationMenuItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1881215620
+// LIFERAY-SERVICE-BUILDER-HASH:-1740702342

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
@@ -731,4 +731,4 @@ public class SiteNavigationMenuPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1805045977
+// LIFERAY-SERVICE-BUILDER-HASH:-1374653525

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/SiteFriendlyURLPersistenceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/SiteFriendlyURLPersistenceTest.java
@@ -631,4 +631,4 @@ public class SiteFriendlyURLPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1181561529
+// LIFERAY-SERVICE-BUILDER-HASH:-1020847607

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -1040,4 +1040,4 @@ public class StyleBookEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1600151223
+// LIFERAY-SERVICE-BUILDER-HASH:-1718179673

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
@@ -851,4 +851,4 @@ public class StyleBookEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:467862989
+// LIFERAY-SERVICE-BUILDER-HASH:-712525469

--- a/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
+++ b/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
@@ -591,4 +591,4 @@ public class SubscriptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1914057814
+// LIFERAY-SERVICE-BUILDER-HASH:-1006227702

--- a/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
+++ b/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
@@ -662,4 +662,4 @@ public class TemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1365928798
+// LIFERAY-SERVICE-BUILDER-HASH:606805336

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/service/persistence/test/TranslationEntryPersistenceTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/service/persistence/test/TranslationEntryPersistenceTest.java
@@ -638,4 +638,4 @@ public class TranslationEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:164542002
+// LIFERAY-SERVICE-BUILDER-HASH:637822852

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashEntryPersistenceTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashEntryPersistenceTest.java
@@ -556,4 +556,4 @@ public class TrashEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:496176178
+// LIFERAY-SERVICE-BUILDER-HASH:-1152399192

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashVersionPersistenceTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashVersionPersistenceTest.java
@@ -514,4 +514,4 @@ public class TrashVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2061438851
+// LIFERAY-SERVICE-BUILDER-HASH:-430636691

--- a/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
+++ b/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
@@ -415,4 +415,4 @@ public class ViewCountEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1242377130
+// LIFERAY-SERVICE-BUILDER-HASH:-14567368

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
@@ -693,4 +693,4 @@ public class WikiNodePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1706430213
+// LIFERAY-SERVICE-BUILDER-HASH:-1339829431

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
@@ -1003,4 +1003,4 @@ public class WikiPagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:22655094
+// LIFERAY-SERVICE-BUILDER-HASH:-1635274974

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
@@ -538,4 +538,4 @@ public class WikiPageResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-49912664
+// LIFERAY-SERVICE-BUILDER-HASH:68296160

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-test/src/testIntegration/java/com/liferay/commerce/machine/learning/forecast/alert/service/persistence/test/CommerceMLForecastAlertEntryPersistenceTest.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-test/src/testIntegration/java/com/liferay/commerce/machine/learning/forecast/alert/service/persistence/test/CommerceMLForecastAlertEntryPersistenceTest.java
@@ -692,4 +692,4 @@ public class CommerceMLForecastAlertEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1601129870
+// LIFERAY-SERVICE-BUILDER-HASH:1013613584

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherAccountPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherAccountPersistenceTest.java
@@ -520,4 +520,4 @@ public class PatcherAccountPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1838020886
+// LIFERAY-SERVICE-BUILDER-HASH:1783296430

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildPersistenceTest.java
@@ -861,4 +861,4 @@ public class PatcherBuildPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1067061418
+// LIFERAY-SERVICE-BUILDER-HASH:-626189564

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildRelPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildRelPersistenceTest.java
@@ -421,4 +421,4 @@ public class PatcherBuildRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1194142089
+// LIFERAY-SERVICE-BUILDER-HASH:1586741331

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixComponentPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixComponentPersistenceTest.java
@@ -519,4 +519,4 @@ public class PatcherFixComponentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1354508772
+// LIFERAY-SERVICE-BUILDER-HASH:-651532578

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPackPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPackPersistenceTest.java
@@ -652,4 +652,4 @@ public class PatcherFixPackPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-851539007
+// LIFERAY-SERVICE-BUILDER-HASH:-1902752549

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPersistenceTest.java
@@ -665,4 +665,4 @@ public class PatcherFixPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1802317357
+// LIFERAY-SERVICE-BUILDER-HASH:-245324519

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixRelPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixRelPersistenceTest.java
@@ -419,4 +419,4 @@ public class PatcherFixRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1726004644
+// LIFERAY-SERVICE-BUILDER-HASH:2051747046

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProductVersionPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProductVersionPersistenceTest.java
@@ -562,4 +562,4 @@ public class PatcherProductVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1374297588
+// LIFERAY-SERVICE-BUILDER-HASH:1167712812

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProjectVersionPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProjectVersionPersistenceTest.java
@@ -650,4 +650,4 @@ public class PatcherProjectVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:725493006
+// LIFERAY-SERVICE-BUILDER-HASH:1595521562

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherTicketHintPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherTicketHintPersistenceTest.java
@@ -513,4 +513,4 @@ public class PatcherTicketHintPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:691676855
+// LIFERAY-SERVICE-BUILDER-HASH:937301059

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/DefinitionPersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/DefinitionPersistenceTest.java
@@ -597,4 +597,4 @@ public class DefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1868170343
+// LIFERAY-SERVICE-BUILDER-HASH:1588722727

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/EntryPersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/EntryPersistenceTest.java
@@ -490,4 +490,4 @@ public class EntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-855877625
+// LIFERAY-SERVICE-BUILDER-HASH:-112768687

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/SourcePersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/SourcePersistenceTest.java
@@ -581,4 +581,4 @@ public class SourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1282373680
+// LIFERAY-SERVICE-BUILDER-HASH:-1368100640

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessLinkPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessLinkPersistenceTest.java
@@ -496,4 +496,4 @@ public class KaleoProcessLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1591684145
+// LIFERAY-SERVICE-BUILDER-HASH:-217969029

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessPersistenceTest.java
@@ -598,4 +598,4 @@ public class KaleoProcessPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1864413963
+// LIFERAY-SERVICE-BUILDER-HASH:-1002187197

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionPersistenceTest.java
@@ -798,4 +798,4 @@ public class WorkflowMetricsSLADefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1858835348
+// LIFERAY-SERVICE-BUILDER-HASH:1715948344

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionVersionPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionVersionPersistenceTest.java
@@ -822,4 +822,4 @@ public class WorkflowMetricsSLADefinitionVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-586958223
+// LIFERAY-SERVICE-BUILDER-HASH:896148581

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIbSloMessagePersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIbSloMessagePersistenceTest.java
@@ -492,4 +492,4 @@ public class SamlIbSloMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1133324899
+// LIFERAY-SERVICE-BUILDER-HASH:712032823

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpConnectionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpConnectionPersistenceTest.java
@@ -625,4 +625,4 @@ public class SamlIdpSpConnectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2127855473
+// LIFERAY-SERVICE-BUILDER-HASH:1669108393

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpSessionPersistenceTest.java
@@ -450,4 +450,4 @@ public class SamlIdpSpSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:10343959
+// LIFERAY-SERVICE-BUILDER-HASH:2075055069

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSsoSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSsoSessionPersistenceTest.java
@@ -525,4 +525,4 @@ public class SamlIdpSsoSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-900276253
+// LIFERAY-SERVICE-BUILDER-HASH:-667081887

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlPeerBindingPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlPeerBindingPersistenceTest.java
@@ -494,4 +494,4 @@ public class SamlPeerBindingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-316055613
+// LIFERAY-SERVICE-BUILDER-HASH:256845079

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
@@ -511,4 +511,4 @@ public class SamlSpAuthRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-738323699
+// LIFERAY-SERVICE-BUILDER-HASH:2124156135

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpIdpConnectionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpIdpConnectionPersistenceTest.java
@@ -646,4 +646,4 @@ public class SamlSpIdpConnectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1559130985
+// LIFERAY-SERVICE-BUILDER-HASH:1433240091

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpMessagePersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpMessagePersistenceTest.java
@@ -498,4 +498,4 @@ public class SamlSpMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1035552162
+// LIFERAY-SERVICE-BUILDER-HASH:502647292

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpSessionPersistenceTest.java
@@ -559,4 +559,4 @@ public class SamlSpSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-756478840
+// LIFERAY-SERVICE-BUILDER-HASH:1504653488

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
@@ -621,4 +621,4 @@ public class SXPBlueprintPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-358167130
+// LIFERAY-SERVICE-BUILDER-HASH:-1241004084

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
@@ -646,4 +646,4 @@ public class SXPElementPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1219519392
+// LIFERAY-SERVICE-BUILDER-HASH:177568200

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-oauth2-test/src/testIntegration/java/com/liferay/sharepoint/rest/oauth2/service/persistence/test/SharepointOAuth2TokenEntryPersistenceTest.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-oauth2-test/src/testIntegration/java/com/liferay/sharepoint/rest/oauth2/service/persistence/test/SharepointOAuth2TokenEntryPersistenceTest.java
@@ -588,4 +588,4 @@ public class SharepointOAuth2TokenEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:932257762
+// LIFERAY-SERVICE-BUILDER-HASH:763001746

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
@@ -746,4 +746,4 @@ public class AddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1751152363
+// LIFERAY-SERVICE-BUILDER-HASH:-568103679

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
@@ -470,4 +470,4 @@ public class BrowserTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2093663700
+// LIFERAY-SERVICE-BUILDER-HASH:1805768462

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
@@ -450,4 +450,4 @@ public class ClassNamePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-550688839
+// LIFERAY-SERVICE-BUILDER-HASH:-1912573359

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyInfoPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyInfoPersistenceTest.java
@@ -456,4 +456,4 @@ public class CompanyInfoPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1988050698
+// LIFERAY-SERVICE-BUILDER-HASH:1086181586

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
@@ -572,4 +572,4 @@ public class CompanyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1071339307
+// LIFERAY-SERVICE-BUILDER-HASH:-1203230343

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
@@ -570,4 +570,4 @@ public class ContactPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-660844007
+// LIFERAY-SERVICE-BUILDER-HASH:2122158679

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryLocalizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryLocalizationPersistenceTest.java
@@ -490,4 +490,4 @@ public class CountryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1214360092
+// LIFERAY-SERVICE-BUILDER-HASH:828056412

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
@@ -783,4 +783,4 @@ public class CountryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1333328580
+// LIFERAY-SERVICE-BUILDER-HASH:1377226994

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
@@ -623,4 +623,4 @@ public class EmailAddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1872360413
+// LIFERAY-SERVICE-BUILDER-HASH:-1146629301

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
@@ -944,4 +944,4 @@ public class GroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-927173515
+// LIFERAY-SERVICE-BUILDER-HASH:1996394709

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
@@ -411,4 +411,4 @@ public class ImagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2092644773
+// LIFERAY-SERVICE-BUILDER-HASH:-2008455373

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
@@ -551,4 +551,4 @@ public class LayoutBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:503529191
+// LIFERAY-SERVICE-BUILDER-HASH:883415761

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
@@ -690,4 +690,4 @@ public class LayoutFriendlyURLPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-498516565
+// LIFERAY-SERVICE-BUILDER-HASH:-85683551

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
@@ -1101,4 +1101,4 @@ public class LayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-914034432
+// LIFERAY-SERVICE-BUILDER-HASH:-900558034

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
@@ -494,4 +494,4 @@ public class LayoutPrototypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:784335536
+// LIFERAY-SERVICE-BUILDER-HASH:-856632066

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
@@ -678,4 +678,4 @@ public class LayoutRevisionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:928311025
+// LIFERAY-SERVICE-BUILDER-HASH:-822749943

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
@@ -645,4 +645,4 @@ public class LayoutSetBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1152544426
+// LIFERAY-SERVICE-BUILDER-HASH:102203872

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
@@ -579,4 +579,4 @@ public class LayoutSetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-140773389
+// LIFERAY-SERVICE-BUILDER-HASH:1550424385

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
@@ -509,4 +509,4 @@ public class LayoutSetPrototypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:251212160
+// LIFERAY-SERVICE-BUILDER-HASH:679315346

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
@@ -534,4 +534,4 @@ public class ListTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1600780597
+// LIFERAY-SERVICE-BUILDER-HASH:1230317981

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
@@ -487,4 +487,4 @@ public class MembershipRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:50441065
+// LIFERAY-SERVICE-BUILDER-HASH:-1424465155

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
@@ -487,4 +487,4 @@ public class OrgLaborPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:851558342
+// LIFERAY-SERVICE-BUILDER-HASH:1838092208

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
@@ -709,4 +709,4 @@ public class OrganizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2096060988
+// LIFERAY-SERVICE-BUILDER-HASH:-1328945152

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
@@ -718,4 +718,4 @@ public class PasswordPolicyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1769136977
+// LIFERAY-SERVICE-BUILDER-HASH:-436708279

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
@@ -501,4 +501,4 @@ public class PasswordPolicyRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1664627170
+// LIFERAY-SERVICE-BUILDER-HASH:-1980038460

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
@@ -421,4 +421,4 @@ public class PasswordTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:999081530
+// LIFERAY-SERVICE-BUILDER-HASH:-1144933730

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
@@ -600,4 +600,4 @@ public class PhonePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:154667146
+// LIFERAY-SERVICE-BUILDER-HASH:635602280

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
@@ -502,4 +502,4 @@ public class PluginSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:365344405
+// LIFERAY-SERVICE-BUILDER-HASH:-965387399

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferenceValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferenceValuePersistenceTest.java
@@ -600,4 +600,4 @@ public class PortalPreferenceValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:433008743
+// LIFERAY-SERVICE-BUILDER-HASH:2145948073

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
@@ -493,4 +493,4 @@ public class PortalPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:3701590
+// LIFERAY-SERVICE-BUILDER-HASH:-1282994600

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
@@ -540,4 +540,4 @@ public class PortletItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-246214370
+// LIFERAY-SERVICE-BUILDER-HASH:-1215134118

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
@@ -466,4 +466,4 @@ public class PortletPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:912272619
+// LIFERAY-SERVICE-BUILDER-HASH:554126005

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferenceValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferenceValuePersistenceTest.java
@@ -597,4 +597,4 @@ public class PortletPreferenceValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1570263298
+// LIFERAY-SERVICE-BUILDER-HASH:-1179049396

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
@@ -608,4 +608,4 @@ public class PortletPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1538029920
+// LIFERAY-SERVICE-BUILDER-HASH:862259162

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutBranchPersistenceTest.java
@@ -540,4 +540,4 @@ public class RecentLayoutBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:265311286
+// LIFERAY-SERVICE-BUILDER-HASH:-2064383262

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutRevisionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutRevisionPersistenceTest.java
@@ -561,4 +561,4 @@ public class RecentLayoutRevisionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1068676635
+// LIFERAY-SERVICE-BUILDER-HASH:-1450883165

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutSetBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutSetBranchPersistenceTest.java
@@ -553,4 +553,4 @@ public class RecentLayoutSetBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:287685079
+// LIFERAY-SERVICE-BUILDER-HASH:718889463

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionLocalizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionLocalizationPersistenceTest.java
@@ -484,4 +484,4 @@ public class RegionLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-476112908
+// LIFERAY-SERVICE-BUILDER-HASH:469783804

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
@@ -620,4 +620,4 @@ public class RegionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1580964058
+// LIFERAY-SERVICE-BUILDER-HASH:-232467712

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
@@ -504,4 +504,4 @@ public class ReleasePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:327841356
+// LIFERAY-SERVICE-BUILDER-HASH:-832262532

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RememberMeTokenPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RememberMeTokenPersistenceTest.java
@@ -434,4 +434,4 @@ public class RememberMeTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-916237966
+// LIFERAY-SERVICE-BUILDER-HASH:827317060

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
@@ -594,4 +594,4 @@ public class RepositoryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-622311726
+// LIFERAY-SERVICE-BUILDER-HASH:-411341532

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
@@ -660,4 +660,4 @@ public class RepositoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2125144303
+// LIFERAY-SERVICE-BUILDER-HASH:1589679459

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
@@ -486,4 +486,4 @@ public class ResourceActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:224705682
+// LIFERAY-SERVICE-BUILDER-HASH:-990873896

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
@@ -678,4 +678,4 @@ public class ResourcePermissionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1445748346
+// LIFERAY-SERVICE-BUILDER-HASH:1842114578

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
@@ -712,4 +712,4 @@ public class RolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:981109946
+// LIFERAY-SERVICE-BUILDER-HASH:1191728336

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
@@ -497,4 +497,4 @@ public class ServiceComponentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:171207430
+// LIFERAY-SERVICE-BUILDER-HASH:1392823828

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
@@ -515,4 +515,4 @@ public class SystemEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1568244586
+// LIFERAY-SERVICE-BUILDER-HASH:847940466

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
@@ -582,4 +582,4 @@ public class TeamPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:611739429
+// LIFERAY-SERVICE-BUILDER-HASH:2007068493

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
@@ -526,4 +526,4 @@ public class TicketPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2077138468
+// LIFERAY-SERVICE-BUILDER-HASH:1606166898

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
@@ -549,4 +549,4 @@ public class UserGroupGroupRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-468355383
+// LIFERAY-SERVICE-BUILDER-HASH:761954985

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
@@ -629,4 +629,4 @@ public class UserGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1322531418
+// LIFERAY-SERVICE-BUILDER-HASH:-843022224

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
@@ -531,4 +531,4 @@ public class UserGroupRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2087367734
+// LIFERAY-SERVICE-BUILDER-HASH:1142107340

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
@@ -516,4 +516,4 @@ public class UserIdMapperPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-594981296
+// LIFERAY-SERVICE-BUILDER-HASH:-1555469532

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
@@ -579,4 +579,4 @@ public class UserNotificationDeliveryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:274105569
+// LIFERAY-SERVICE-BUILDER-HASH:-1822370161

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -699,4 +699,4 @@ public class UserNotificationEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:938821427
+// LIFERAY-SERVICE-BUILDER-HASH:-2007732887

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
@@ -903,4 +903,4 @@ public class UserPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2019496854
+// LIFERAY-SERVICE-BUILDER-HASH:-1597367390

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
@@ -420,4 +420,4 @@ public class UserTrackerPathPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-519655772
+// LIFERAY-SERVICE-BUILDER-HASH:1266489598

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
@@ -448,4 +448,4 @@ public class UserTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1343026823
+// LIFERAY-SERVICE-BUILDER-HASH:-1345981373

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
@@ -520,4 +520,4 @@ public class VirtualHostPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:621608833
+// LIFERAY-SERVICE-BUILDER-HASH:1304388921

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
@@ -493,4 +493,4 @@ public class WebDAVPropsPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1942885153
+// LIFERAY-SERVICE-BUILDER-HASH:-1428473767

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
@@ -603,4 +603,4 @@ public class WebsitePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:759185851
+// LIFERAY-SERVICE-BUILDER-HASH:298149603

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
@@ -737,4 +737,4 @@ public class WorkflowDefinitionLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-281089987
+// LIFERAY-SERVICE-BUILDER-HASH:-206007213

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
@@ -587,4 +587,4 @@ public class WorkflowInstanceLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-932931013
+// LIFERAY-SERVICE-BUILDER-HASH:35703701

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
@@ -555,4 +555,4 @@ public class AnnouncementsDeliveryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-234966299
+// LIFERAY-SERVICE-BUILDER-HASH:-547579465

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
@@ -580,4 +580,4 @@ public class AnnouncementsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2091431160
+// LIFERAY-SERVICE-BUILDER-HASH:42058478

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
@@ -520,4 +520,4 @@ public class AnnouncementsFlagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-759314858
+// LIFERAY-SERVICE-BUILDER-HASH:-2037807564

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -801,4 +801,4 @@ public class AssetCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:563891789
+// LIFERAY-SERVICE-BUILDER-HASH:-514919137

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
@@ -717,4 +717,4 @@ public class AssetEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1031356828
+// LIFERAY-SERVICE-BUILDER-HASH:-894708562

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagGroupRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagGroupRelPersistenceTest.java
@@ -547,4 +547,4 @@ public class AssetTagGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1332078337
+// LIFERAY-SERVICE-BUILDER-HASH:-2103746051

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
@@ -632,4 +632,4 @@ public class AssetTagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2015687529
+// LIFERAY-SERVICE-BUILDER-HASH:1595800145

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
@@ -637,4 +637,4 @@ public class AssetVocabularyGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1553590110
+// LIFERAY-SERVICE-BUILDER-HASH:1626054510

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
@@ -725,4 +725,4 @@ public class AssetVocabularyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1620095168
+// LIFERAY-SERVICE-BUILDER-HASH:-1752173730

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
@@ -610,4 +610,4 @@ public class DLFileEntryMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-949263586
+// LIFERAY-SERVICE-BUILDER-HASH:561571646

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
@@ -1001,4 +1001,4 @@ public class DLFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1774967035
+// LIFERAY-SERVICE-BUILDER-HASH:-98036327

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
@@ -713,4 +713,4 @@ public class DLFileEntryTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-62395798
+// LIFERAY-SERVICE-BUILDER-HASH:1730315776

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
@@ -738,4 +738,4 @@ public class DLFileShortcutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:56616404
+// LIFERAY-SERVICE-BUILDER-HASH:-1221094150

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
@@ -818,4 +818,4 @@ public class DLFileVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1296643732
+// LIFERAY-SERVICE-BUILDER-HASH:-1868148186

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
@@ -877,4 +877,4 @@ public class DLFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:908869569
+// LIFERAY-SERVICE-BUILDER-HASH:822366275

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
@@ -523,4 +523,4 @@ public class ExpandoColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2074061614
+// LIFERAY-SERVICE-BUILDER-HASH:382523140

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
@@ -491,4 +491,4 @@ public class ExpandoRowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1771448455
+// LIFERAY-SERVICE-BUILDER-HASH:-592650561

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
@@ -492,4 +492,4 @@ public class ExpandoTablePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-360019419
+// LIFERAY-SERVICE-BUILDER-HASH:-285895117

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
@@ -589,4 +589,4 @@ public class ExpandoValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:472206067
+// LIFERAY-SERVICE-BUILDER-HASH:97490191

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
@@ -581,4 +581,4 @@ public class ExportImportConfigurationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:15955273
+// LIFERAY-SERVICE-BUILDER-HASH:484570563

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
@@ -566,4 +566,4 @@ public class RatingsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1081947800
+// LIFERAY-SERVICE-BUILDER-HASH:1302474162

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
@@ -522,4 +522,4 @@ public class RatingsStatsPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:358866002
+// LIFERAY-SERVICE-BUILDER-HASH:1319246282

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
@@ -609,4 +609,4 @@ public class SocialActivityAchievementPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:820155648
+// LIFERAY-SERVICE-BUILDER-HASH:1869843874

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
@@ -677,4 +677,4 @@ public class SocialActivityCounterPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:154975353
+// LIFERAY-SERVICE-BUILDER-HASH:16584529

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
@@ -585,4 +585,4 @@ public class SocialActivityLimitPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-750468785
+// LIFERAY-SERVICE-BUILDER-HASH:242661081

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
@@ -676,4 +676,4 @@ public class SocialActivityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:692533011
+// LIFERAY-SERVICE-BUILDER-HASH:-549174129

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
@@ -516,4 +516,4 @@ public class SocialActivitySetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1975794375
+// LIFERAY-SERVICE-BUILDER-HASH:1368131997

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
@@ -588,4 +588,4 @@ public class SocialActivitySettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:424809707
+// LIFERAY-SERVICE-BUILDER-HASH:-285414677

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
@@ -588,4 +588,4 @@ public class SocialRelationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1021798
+// LIFERAY-SERVICE-BUILDER-HASH:655464744

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
@@ -660,4 +660,4 @@ public class SocialRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1136392361
+// LIFERAY-SERVICE-BUILDER-HASH:-1005390331

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
@@ -12,6 +12,8 @@ import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionedModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -160,6 +162,20 @@ public interface ERCVersionedEntryModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the blob of this erc versioned entry.
+	 *
+	 * @return the blob of this erc versioned entry
+	 */
+	public Blob getBlob();
+
+	/**
+	 * Sets the blob of this erc versioned entry.
+	 *
+	 * @param blob the blob of this erc versioned entry
+	 */
+	public void setBlob(Blob blob);
+
 	@Override
 	public ERCVersionedEntry cloneWithOriginalValues();
 
@@ -168,4 +184,4 @@ public interface ERCVersionedEntryModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-801384982
+// LIFERAY-SERVICE-BUILDER-HASH:-1688053007

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -43,10 +44,12 @@ public class ERCVersionedEntryTable extends BaseTable<ERCVersionedEntryTable> {
 		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<ERCVersionedEntryTable, Long> companyId = createColumn(
 		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryTable, Blob> blob = createColumn(
+		"blob_", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryTable() {
 		super("ERCVersionedEntry", ERCVersionedEntryTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:489743092
+// LIFERAY-SERVICE-BUILDER-HASH:1767433638

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -157,6 +159,20 @@ public interface ERCVersionedEntryVersionModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the blob of this erc versioned entry version.
+	 *
+	 * @return the blob of this erc versioned entry version
+	 */
+	public Blob getBlob();
+
+	/**
+	 * Sets the blob of this erc versioned entry version.
+	 *
+	 * @param blob the blob of this erc versioned entry version
+	 */
+	public void setBlob(Blob blob);
+
 	@Override
 	public ERCVersionedEntryVersion cloneWithOriginalValues();
 
@@ -165,4 +181,4 @@ public interface ERCVersionedEntryVersionModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:585529757
+// LIFERAY-SERVICE-BUILDER-HASH:-647546140

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -45,10 +46,12 @@ public class ERCVersionedEntryVersionTable
 	public final Column<ERCVersionedEntryVersionTable, Long> companyId =
 		createColumn(
 			"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryVersionTable, Blob> blob =
+		createColumn("blob_", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryVersionTable() {
 		super("ERCVersionedEntryVersion", ERCVersionedEntryVersionTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1336671367
+// LIFERAY-SERVICE-BUILDER-HASH:-71320565

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,6 +45,7 @@ public class ERCVersionedEntryVersionWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("blob", getBlob());
 
 		return attributes;
 	}
@@ -92,11 +95,27 @@ public class ERCVersionedEntryVersionWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob blob = (Blob)attributes.get("blob");
+
+		if (blob != null) {
+			setBlob(blob);
+		}
 	}
 
 	@Override
 	public ERCVersionedEntryVersion cloneWithOriginalValues() {
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the blob of this erc versioned entry version.
+	 *
+	 * @return the blob of this erc versioned entry version
+	 */
+	@Override
+	public Blob getBlob() {
+		return model.getBlob();
 	}
 
 	/**
@@ -177,6 +196,16 @@ public class ERCVersionedEntryVersionWrapper
 	@Override
 	public int getVersion() {
 		return model.getVersion();
+	}
+
+	/**
+	 * Sets the blob of this erc versioned entry version.
+	 *
+	 * @param blob the blob of this erc versioned entry version
+	 */
+	@Override
+	public void setBlob(Blob blob) {
+		model.setBlob(blob);
 	}
 
 	/**
@@ -292,4 +321,4 @@ public class ERCVersionedEntryVersionWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-582979379
+// LIFERAY-SERVICE-BUILDER-HASH:1599941869

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +41,7 @@ public class ERCVersionedEntryWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("blob", getBlob());
 
 		return attributes;
 	}
@@ -87,11 +90,27 @@ public class ERCVersionedEntryWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob blob = (Blob)attributes.get("blob");
+
+		if (blob != null) {
+			setBlob(blob);
+		}
 	}
 
 	@Override
 	public ERCVersionedEntry cloneWithOriginalValues() {
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the blob of this erc versioned entry.
+	 *
+	 * @return the blob of this erc versioned entry
+	 */
+	@Override
+	public Blob getBlob() {
+		return model.getBlob();
 	}
 
 	/**
@@ -177,6 +196,16 @@ public class ERCVersionedEntryWrapper
 	@Override
 	public void persist() {
 		model.persist();
+	}
+
+	/**
+	 * Sets the blob of this erc versioned entry.
+	 *
+	 * @param blob the blob of this erc versioned entry
+	 */
+	@Override
+	public void setBlob(Blob blob) {
+		model.setBlob(blob);
 	}
 
 	/**
@@ -284,4 +313,4 @@ public class ERCVersionedEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1214024493
+// LIFERAY-SERVICE-BUILDER-HASH:352160151

--- a/modules/util/portal-tools-service-builder-test-service/service.xml
+++ b/modules/util/portal-tools-service-builder-test-service/service.xml
@@ -270,6 +270,10 @@
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
+
+		<!-- Other fields -->
+
+		<column lazy="false" name="blob" type="Blob" />
 	</entity>
 	<entity local-service="true" name="FinderWhereClauseEntry" remote-service="false">
 

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
@@ -83,7 +83,6 @@ public class ERCVersionedEntryCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -177,4 +176,4 @@ public class ERCVersionedEntryCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1056414359
+// LIFERAY-SERVICE-BUILDER-HASH:-1407182578

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -61,7 +60,8 @@ public class ERCVersionedEntryModelImpl
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR}, {"headId", Types.BIGINT},
 		{"head", Types.BOOLEAN}, {"ercVersionedEntryId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT}
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"blob_", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -76,10 +76,11 @@ public class ERCVersionedEntryModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("blob_", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG,blob_ BLOB)";
 
 	public static final String TABLE_SQL_DROP = "drop table ERCVersionedEntry";
 
@@ -101,62 +102,13 @@ public class ERCVersionedEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEAD_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEADID_COLUMN_BITMASK = 16L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *		#getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 64L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -274,6 +226,7 @@ public class ERCVersionedEntryModelImpl
 				"groupId", ERCVersionedEntry::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntry::getCompanyId);
+			attributeGetterFunctions.put("blob", ERCVersionedEntry::getBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -320,6 +273,10 @@ public class ERCVersionedEntryModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntry, Long>)
 					ERCVersionedEntry::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"blob",
+				(BiConsumer<ERCVersionedEntry, Blob>)
+					ERCVersionedEntry::setBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -336,6 +293,7 @@ public class ERCVersionedEntryModelImpl
 			getExternalReferenceCode());
 		ercVersionedEntryVersion.setGroupId(getGroupId());
 		ercVersionedEntryVersion.setCompanyId(getCompanyId());
+		ercVersionedEntryVersion.setBlob(getBlob());
 	}
 
 	@Override
@@ -526,28 +484,18 @@ public class ERCVersionedEntryModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getBlob() {
+		return _blob;
+	}
+
+	@Override
+	public void setBlob(Blob blob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
-
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
-			}
-		}
-
-		return _columnBitmask;
+		_blob = blob;
 	}
 
 	@Override
@@ -683,8 +631,6 @@ public class ERCVersionedEntryModelImpl
 	@Override
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
-
-		_columnBitmask = 0;
 	}
 
 	@Override
@@ -795,6 +741,7 @@ public class ERCVersionedEntryModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _blob;
 
 	public <T> T getColumnValue(String columnName) {
 		if (columnName.equals("head")) {
@@ -839,6 +786,7 @@ public class ERCVersionedEntryModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("blob_", _blob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -847,42 +795,13 @@ public class ERCVersionedEntryModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("blob_", "blob");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("mvccVersion", 1L);
-
-		columnBitmasks.put("uuid_", 2L);
-
-		columnBitmasks.put("externalReferenceCode", 4L);
-
-		columnBitmasks.put("headId", 8L);
-
-		columnBitmasks.put("head", 16L);
-
-		columnBitmasks.put("ercVersionedEntryId", 32L);
-
-		columnBitmasks.put("groupId", 64L);
-
-		columnBitmasks.put("companyId", 128L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1043357584
+// LIFERAY-SERVICE-BUILDER-HASH:592943453

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
@@ -69,7 +69,6 @@ public class ERCVersionedEntryVersionCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -159,4 +158,4 @@ public class ERCVersionedEntryVersionCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1146275545
+// LIFERAY-SERVICE-BUILDER-HASH:-1729621124

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -63,7 +62,7 @@ public class ERCVersionedEntryVersionModelImpl
 		{"version", Types.INTEGER}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR},
 		{"ercVersionedEntryId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}
+		{"companyId", Types.BIGINT}, {"blob_", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -77,10 +76,11 @@ public class ERCVersionedEntryVersionModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("blob_", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG,blob_ BLOB)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table ERCVersionedEntryVersion";
@@ -103,49 +103,13 @@ public class ERCVersionedEntryVersionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 16L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -267,6 +231,8 @@ public class ERCVersionedEntryVersionModelImpl
 				"groupId", ERCVersionedEntryVersion::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntryVersion::getCompanyId);
+			attributeGetterFunctions.put(
+				"blob", ERCVersionedEntryVersion::getBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -314,6 +280,10 @@ public class ERCVersionedEntryVersionModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntryVersion, Long>)
 					ERCVersionedEntryVersion::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"blob",
+				(BiConsumer<ERCVersionedEntryVersion, Blob>)
+					ERCVersionedEntryVersion::setBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -332,6 +302,7 @@ public class ERCVersionedEntryVersionModelImpl
 		ercVersionedEntry.setExternalReferenceCode(getExternalReferenceCode());
 		ercVersionedEntry.setGroupId(getGroupId());
 		ercVersionedEntry.setCompanyId(getCompanyId());
+		ercVersionedEntry.setBlob(getBlob());
 	}
 
 	@Override
@@ -507,28 +478,18 @@ public class ERCVersionedEntryVersionModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getBlob() {
+		return _blob;
+	}
+
+	@Override
+	public void setBlob(Blob blob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
-
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
-			}
-		}
-
-		return _columnBitmask;
+		_blob = blob;
 	}
 
 	@Override
@@ -676,8 +637,6 @@ public class ERCVersionedEntryVersionModelImpl
 	@Override
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
-
-		_columnBitmask = 0;
 	}
 
 	@Override
@@ -787,6 +746,7 @@ public class ERCVersionedEntryVersionModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _blob;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -827,6 +787,7 @@ public class ERCVersionedEntryVersionModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("blob_", _blob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -835,40 +796,13 @@ public class ERCVersionedEntryVersionModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("blob_", "blob");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("ercVersionedEntryVersionId", 1L);
-
-		columnBitmasks.put("version", 2L);
-
-		columnBitmasks.put("uuid_", 4L);
-
-		columnBitmasks.put("externalReferenceCode", 8L);
-
-		columnBitmasks.put("ercVersionedEntryId", 16L);
-
-		columnBitmasks.put("groupId", 32L);
-
-		columnBitmasks.put("companyId", 64L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntryVersion _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1636105583
+// LIFERAY-SERVICE-BUILDER-HASH:-1264360358

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
@@ -946,6 +946,7 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 			publishedERCVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(
 			publishedERCVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setBlob(publishedERCVersionedEntry.getBlob());
 
 		draftERCVersionedEntry.resetOriginalValues();
 
@@ -1027,4 +1028,4 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 		ERCVersionedEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:712558739
+// LIFERAY-SERVICE-BUILDER-HASH:1739079984

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
@@ -13,8 +13,7 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryTabl
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntry.
@@ -50,28 +49,9 @@ public class ERCVersionedEntryModelArgumentsResolver
 		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl =
 			(ERCVersionedEntryModelImpl)baseModel;
 
-		long columnBitmask = ercVersionedEntryModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(ercVersionedEntryModelImpl, columnNames)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryModelImpl.getColumnBitmask(columnName);
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
 		}
 
@@ -115,8 +95,26 @@ public class ERCVersionedEntryModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl,
+		String[] columnNames) {
+
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryModelImpl.getColumnValue(columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1682090847
+// LIFERAY-SERVICE-BUILDER-HASH:1792999623

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.DuplicateERCVersionedEntryExternalReferenceCodeException;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
@@ -100,8 +99,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -118,7 +117,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid.findFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -133,7 +132,7 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -144,7 +143,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -156,7 +155,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder
@@ -185,7 +184,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Head.find(
-			finderCache, new Object[] {uuid, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -205,7 +204,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_Head.findFirst(
-			finderCache, new Object[] {uuid, head}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, head}, orderByComparator);
 	}
 
 	/**
@@ -222,7 +221,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Head.fetchFirst(
-			finderCache, new Object[] {uuid, head}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, head}, orderByComparator);
 	}
 
 	/**
@@ -234,7 +233,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_Head(String uuid, boolean head) {
 		_collectionPersistenceFinderByUuid_Head.remove(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	/**
@@ -247,7 +246,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_Head(String uuid, boolean head) {
 		return _collectionPersistenceFinderByUuid_Head.count(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -276,7 +275,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -296,7 +295,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUUID_G.findFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -313,7 +312,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -325,7 +324,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -338,7 +337,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -360,7 +359,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByUUID_G_Head.find(
-			finderCache, new Object[] {uuid, groupId, head});
+			dummyFinderCache, new Object[] {uuid, groupId, head});
 	}
 
 	/**
@@ -377,7 +376,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, long groupId, boolean head, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Head.fetch(
-			finderCache, new Object[] {uuid, groupId, head}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, head},
+			useFinderCache);
 	}
 
 	/**
@@ -410,7 +410,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G_Head(String uuid, long groupId, boolean head) {
 		return _uniquePersistenceFinderByUUID_G_Head.count(
-			finderCache, new Object[] {uuid, groupId, head});
+			dummyFinderCache, new Object[] {uuid, groupId, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -439,7 +439,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -459,7 +459,8 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_C.findFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -476,7 +477,8 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -488,7 +490,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -501,7 +503,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder
@@ -531,7 +533,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.find(
-			finderCache, new Object[] {uuid, companyId, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -552,7 +554,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_C_Head.findFirst(
-			finderCache, new Object[] {uuid, companyId, head},
+			dummyFinderCache, new Object[] {uuid, companyId, head},
 			orderByComparator);
 	}
 
@@ -571,7 +573,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, head},
+			dummyFinderCache, new Object[] {uuid, companyId, head},
 			orderByComparator);
 	}
 
@@ -585,7 +587,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C_Head(String uuid, long companyId, boolean head) {
 		_collectionPersistenceFinderByUuid_C_Head.remove(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	/**
@@ -599,7 +601,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C_Head(String uuid, long companyId, boolean head) {
 		return _collectionPersistenceFinderByUuid_C_Head.count(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -628,8 +630,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByERC_G.find(
-			finderCache, new Object[] {externalReferenceCode, groupId}, start,
-			end, orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -648,7 +650,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByERC_G.findFirst(
-			finderCache, new Object[] {externalReferenceCode, groupId},
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
 			orderByComparator);
 	}
 
@@ -666,7 +668,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByERC_G.fetchFirst(
-			finderCache, new Object[] {externalReferenceCode, groupId},
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
 			orderByComparator);
 	}
 
@@ -679,7 +681,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByERC_G(String externalReferenceCode, long groupId) {
 		_collectionPersistenceFinderByERC_G.remove(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	/**
@@ -692,7 +694,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByERC_G(String externalReferenceCode, long groupId) {
 		return _collectionPersistenceFinderByERC_G.count(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -714,7 +716,8 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByERC_G_Head.find(
-			finderCache, new Object[] {externalReferenceCode, groupId, head});
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head});
 	}
 
 	/**
@@ -732,7 +735,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByERC_G_Head.fetch(
-			finderCache, new Object[] {externalReferenceCode, groupId, head},
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head},
 			useFinderCache);
 	}
 
@@ -768,7 +772,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String externalReferenceCode, long groupId, boolean head) {
 
 		return _uniquePersistenceFinderByERC_G_Head.count(
-			finderCache, new Object[] {externalReferenceCode, groupId, head});
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head});
 	}
 
 	private UniquePersistenceFinder
@@ -787,7 +792,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByHeadId.find(
-			finderCache, new Object[] {headId});
+			dummyFinderCache, new Object[] {headId});
 	}
 
 	/**
@@ -802,7 +807,7 @@ public class ERCVersionedEntryPersistenceImpl
 		long headId, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByHeadId.fetch(
-			finderCache, new Object[] {headId}, useFinderCache);
+			dummyFinderCache, new Object[] {headId}, useFinderCache);
 	}
 
 	/**
@@ -829,13 +834,14 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByHeadId(long headId) {
 		return _uniquePersistenceFinderByHeadId.count(
-			finderCache, new Object[] {headId});
+			dummyFinderCache, new Object[] {headId});
 	}
 
 	public ERCVersionedEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("blob", "blob_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -1073,7 +1079,7 @@ public class ERCVersionedEntryPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1360,14 +1366,8 @@ public class ERCVersionedEntryPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryImpl.class.getName());
+		dummyEntityCache.removeCache(ERCVersionedEntryImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryModelImpl.ENTITY_ALIAS + ".";
@@ -1382,12 +1382,12 @@ public class ERCVersionedEntryPersistenceImpl
 		"SELECT COUNT(ercVersionedEntry) FROM ERCVersionedEntry ercVersionedEntry WHERE ";
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "blob"});
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:647812634
+// LIFERAY-SERVICE-BUILDER-HASH:1578368383

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
@@ -13,8 +13,9 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntryVersion.
@@ -50,39 +51,12 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl =
 			(ERCVersionedEntryVersionModelImpl)baseModel;
 
-		long columnBitmask =
-			ercVersionedEntryVersionModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, columnNames) ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, _ORDER_BY_COLUMNS)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(
-				ercVersionedEntryVersionModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryVersionModelImpl.getColumnBitmask(
-						columnName);
-			}
-
-			if (finderPath.isBaseModelResult() &&
-				(ERCVersionedEntryVersionPersistenceImpl.
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION ==
-						finderPath.getCacheName())) {
-
-				finderPathColumnBitmask |= _ORDER_BY_COLUMNS_BITMASK;
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(
 				ercVersionedEntryVersionModelImpl, finderPath, original);
 		}
@@ -129,19 +103,37 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl,
+		String[] columnNames) {
 
-	private static final long _ORDER_BY_COLUMNS_BITMASK;
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryVersionModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryVersionModelImpl.getColumnValue(
+						columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _ORDER_BY_COLUMNS;
 
 	static {
-		long orderByColumnsBitmask = 0;
+		List<String> orderByColumns = new ArrayList<String>();
 
-		orderByColumnsBitmask |=
-			ERCVersionedEntryVersionModelImpl.getColumnBitmask("version");
+		orderByColumns.add("version");
 
-		_ORDER_BY_COLUMNS_BITMASK = orderByColumnsBitmask;
+		_ORDER_BY_COLUMNS = orderByColumns.toArray(new String[0]);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1814987501
+// LIFERAY-SERVICE-BUILDER-HASH:-808016544

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryVersionException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionTable;
@@ -98,7 +97,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.find(
-			finderCache, new Object[] {ercVersionedEntryId}, start, end,
+			dummyFinderCache, new Object[] {ercVersionedEntryId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -117,7 +116,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.findFirst(
-			finderCache, new Object[] {ercVersionedEntryId}, orderByComparator);
+			dummyFinderCache, new Object[] {ercVersionedEntryId},
+			orderByComparator);
 	}
 
 	/**
@@ -133,7 +133,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.fetchFirst(
-			finderCache, new Object[] {ercVersionedEntryId}, orderByComparator);
+			dummyFinderCache, new Object[] {ercVersionedEntryId},
+			orderByComparator);
 	}
 
 	/**
@@ -144,7 +145,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByErcVersionedEntryId(long ercVersionedEntryId) {
 		_collectionPersistenceFinderByErcVersionedEntryId.remove(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	/**
@@ -156,7 +157,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByErcVersionedEntryId(long ercVersionedEntryId) {
 		return _collectionPersistenceFinderByErcVersionedEntryId.count(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	private UniquePersistenceFinder
@@ -177,7 +178,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.find(
-			finderCache, new Object[] {ercVersionedEntryId, version});
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version});
 	}
 
 	/**
@@ -193,7 +194,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.fetch(
-			finderCache, new Object[] {ercVersionedEntryId, version},
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version},
 			useFinderCache);
 	}
 
@@ -227,7 +228,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.count(
-			finderCache, new Object[] {ercVersionedEntryId, version});
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -255,8 +256,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -274,7 +275,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid.findFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -290,7 +291,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -301,7 +302,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -313,7 +314,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder
@@ -342,7 +343,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Version.find(
-			finderCache, new Object[] {uuid, version}, start, end,
+			dummyFinderCache, new Object[] {uuid, version}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -362,7 +363,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_Version.findFirst(
-			finderCache, new Object[] {uuid, version}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, version}, orderByComparator);
 	}
 
 	/**
@@ -379,7 +380,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Version.fetchFirst(
-			finderCache, new Object[] {uuid, version}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, version}, orderByComparator);
 	}
 
 	/**
@@ -391,7 +392,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_Version(String uuid, int version) {
 		_collectionPersistenceFinderByUuid_Version.remove(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	/**
@@ -404,7 +405,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_Version(String uuid, int version) {
 		return _collectionPersistenceFinderByUuid_Version.count(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -433,7 +434,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -453,7 +454,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUUID_G.findFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -470,7 +471,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -482,7 +483,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -495,7 +496,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -517,7 +518,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _uniquePersistenceFinderByUUID_G_Version.find(
-			finderCache, new Object[] {uuid, groupId, version});
+			dummyFinderCache, new Object[] {uuid, groupId, version});
 	}
 
 	/**
@@ -534,7 +535,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long groupId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Version.fetch(
-			finderCache, new Object[] {uuid, groupId, version}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, version},
+			useFinderCache);
 	}
 
 	/**
@@ -567,7 +569,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G_Version(String uuid, long groupId, int version) {
 		return _uniquePersistenceFinderByUUID_G_Version.count(
-			finderCache, new Object[] {uuid, groupId, version});
+			dummyFinderCache, new Object[] {uuid, groupId, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -596,7 +598,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -616,7 +618,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_C.findFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -633,7 +636,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -645,7 +649,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -658,7 +662,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder
@@ -688,8 +692,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.find(
-			finderCache, new Object[] {uuid, companyId, version}, start, end,
-			orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, companyId, version}, start,
+			end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -709,7 +713,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_C_Version.findFirst(
-			finderCache, new Object[] {uuid, companyId, version},
+			dummyFinderCache, new Object[] {uuid, companyId, version},
 			orderByComparator);
 	}
 
@@ -728,7 +732,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, version},
+			dummyFinderCache, new Object[] {uuid, companyId, version},
 			orderByComparator);
 	}
 
@@ -744,7 +748,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long companyId, int version) {
 
 		_collectionPersistenceFinderByUuid_C_Version.remove(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	/**
@@ -758,13 +762,14 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C_Version(String uuid, long companyId, int version) {
 		return _collectionPersistenceFinderByUuid_C_Version.count(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	public ERCVersionedEntryVersionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("blob", "blob_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -982,7 +987,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1267,14 +1272,9 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryVersionUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryVersionImpl.class.getName());
+		dummyEntityCache.removeCache(
+			ERCVersionedEntryVersionImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryVersionModelImpl.ENTITY_ALIAS + ".";
@@ -1289,12 +1289,12 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		"SELECT COUNT(ercVersionedEntryVersion) FROM ERCVersionedEntryVersion ercVersionedEntryVersion WHERE ";
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "blob"});
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:463778824
+// LIFERAY-SERVICE-BUILDER-HASH:620630497

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
@@ -169,6 +169,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="head" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="blob_" name="blob" type="blob" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl" table="ERCVersionedEntryVersion">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryVersionId" type="long">
@@ -180,6 +181,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="blob_" name="blob" type="blob" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.FinderWhereClauseEntryImpl" table="FinderWhereClauseEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="finderWhereClauseEntryId" type="long">

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -99,6 +99,7 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="blob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion">
 		<field name="ercVersionedEntryVersionId" type="long" />
@@ -108,6 +109,7 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="blob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.FinderWhereClauseEntry">
 		<field name="finderWhereClauseEntryId" type="long" />

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
@@ -110,7 +110,8 @@ create table ERCVersionedEntry (
 	head BOOLEAN,
 	ercVersionedEntryId LONG not null primary key,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	blob_ BLOB
 );
 
 create table ERCVersionedEntryVersion (
@@ -120,7 +121,8 @@ create table ERCVersionedEntryVersion (
 	externalReferenceCode VARCHAR(75) null,
 	ercVersionedEntryId LONG,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	blob_ BLOB
 );
 
 create table EagerBlobEntry (

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.portal.tools.service.builder.test.service
-    build.number=9
-    build.date=1784161219298
+    build.number=10
+    build.date=1785227251278

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
@@ -374,4 +374,4 @@ public class AutoEscapeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1544286561
+// LIFERAY-SERVICE-BUILDER-HASH:-1862800223

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
@@ -395,4 +395,4 @@ public class BigDecimalEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1910733508
+// LIFERAY-SERVICE-BUILDER-HASH:-19423512

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
@@ -472,4 +472,4 @@ public class CacheDisabledEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1703943154
+// LIFERAY-SERVICE-BUILDER-HASH:2037975984

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
@@ -403,4 +403,4 @@ public class CacheFieldEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:532498380
+// LIFERAY-SERVICE-BUILDER-HASH:251291650

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
@@ -392,4 +392,4 @@ public class CacheMissEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1143607712
+// LIFERAY-SERVICE-BUILDER-HASH:687880770

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
@@ -508,4 +508,4 @@ public class CacheReplicatorEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-635750484
+// LIFERAY-SERVICE-BUILDER-HASH:489683320

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ColumnNameEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ColumnNameEntryPersistenceTest.java
@@ -361,4 +361,4 @@ public class ColumnNameEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:12840868
+// LIFERAY-SERVICE-BUILDER-HASH:174225832

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
@@ -386,4 +386,4 @@ public class DSLQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:647863270
+// LIFERAY-SERVICE-BUILDER-HASH:1991246646

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
@@ -429,4 +429,4 @@ public class DSLQueryStatusEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1754040629
+// LIFERAY-SERVICE-BUILDER-HASH:200391167

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
@@ -418,4 +418,4 @@ public class DataLimitEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-571641246
+// LIFERAY-SERVICE-BUILDER-HASH:-1079177210

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
@@ -523,4 +523,4 @@ public class DefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1414399271
+// LIFERAY-SERVICE-BUILDER-HASH:895490381

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
@@ -433,4 +433,4 @@ public class DynamicQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1962705422
+// LIFERAY-SERVICE-BUILDER-HASH:2084055262

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
@@ -542,4 +542,4 @@ public class ERCCompanyEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1827410722
+// LIFERAY-SERVICE-BUILDER-HASH:-178262490

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
@@ -541,4 +541,4 @@ public class ERCGroupEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:913208274
+// LIFERAY-SERVICE-BUILDER-HASH:-2147300514

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
@@ -30,7 +31,10 @@ import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLo
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
+
+import java.sql.Blob;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -127,10 +131,24 @@ public class ERCVersionedEntryPersistenceTest {
 		newERCVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String newBlobString = RandomTestUtil.randomString();
+
+		byte[] newBlobBytes = newBlobString.getBytes("UTF-8");
+
+		Blob newBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newBlobBytes), newBlobBytes.length);
+
+		newERCVersionedEntry.setBlob(newBlobBlob);
 
 		newERCVersionedEntry = _persistence.update(newERCVersionedEntry);
 
 		_ercVersionedEntries.add(newERCVersionedEntry);
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntry existingERCVersionedEntry =
 			_persistence.findByPrimaryKey(newERCVersionedEntry.getPrimaryKey());
@@ -156,6 +174,10 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntry.getCompanyId(),
 			newERCVersionedEntry.getCompanyId());
+		Blob existingBlob = existingERCVersionedEntry.getBlob();
+
+		Assert.assertArrayEquals(
+			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
 	}
 
 	@Test
@@ -172,6 +194,7 @@ public class ERCVersionedEntryPersistenceTest {
 		draftERCVersionedEntry.setHeadId(-ercVersionedEntry.getHeadId());
 		draftERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(ercVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setBlob(ercVersionedEntry.getBlob());
 
 		_ercVersionedEntries.add(_persistence.update(draftERCVersionedEntry));
 
@@ -191,6 +214,12 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			ercVersionedEntry.getCompanyId(),
 			draftERCVersionedEntry.getCompanyId());
+		Blob Blob = ercVersionedEntry.getBlob();
+		Blob draftBlob = draftERCVersionedEntry.getBlob();
+
+		Assert.assertArrayEquals(
+			Blob.getBytes(1, (int)Blob.length()),
+			draftBlob.getBytes(1, (int)draftBlob.length()));
 	}
 
 	@Test(
@@ -215,6 +244,14 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry2.setGroupId(ercVersionedEntry1.getGroupId());
 
 		ercVersionedEntry2.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntry2.setBlob(blobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry2));
 	}
@@ -677,6 +714,14 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntry.setBlob(blobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry));
 
@@ -689,4 +734,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-167456421
+// LIFERAY-SERVICE-BUILDER-HASH:-13325117

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
@@ -26,7 +27,10 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
+
+import java.sql.Blob;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -130,11 +134,25 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		newERCVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String newBlobString = RandomTestUtil.randomString();
+
+		byte[] newBlobBytes = newBlobString.getBytes("UTF-8");
+
+		Blob newBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newBlobBytes), newBlobBytes.length);
+
+		newERCVersionedEntryVersion.setBlob(newBlobBlob);
 
 		newERCVersionedEntryVersion = _persistence.update(
 			newERCVersionedEntryVersion);
 
 		_ercVersionedEntryVersions.add(newERCVersionedEntryVersion);
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntryVersion existingERCVersionedEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -161,6 +179,10 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntryVersion.getCompanyId(),
 			newERCVersionedEntryVersion.getCompanyId());
+		Blob existingBlob = existingERCVersionedEntryVersion.getBlob();
+
+		Assert.assertArrayEquals(
+			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
 	}
 
 	@Test
@@ -585,6 +607,14 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		ercVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntryVersion.setBlob(blobBlob);
 
 		_ercVersionedEntryVersions.add(
 			_persistence.update(ercVersionedEntryVersion));
@@ -598,4 +628,4 @@ public class ERCVersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:935414981
+// LIFERAY-SERVICE-BUILDER-HASH:-300602437

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -153,10 +152,8 @@ public class EagerBlobEntryPersistenceTest {
 			newEagerBlobEntry.getGroupId());
 		Blob existingBlob = existingEagerBlobEntry.getBlob();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob.getBytes(1, (int)existingBlob.length()),
-				newBlobBytes));
+		Assert.assertArrayEquals(
+			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
 	}
 
 	@Test
@@ -511,4 +508,4 @@ public class EagerBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-816442755
+// LIFERAY-SERVICE-BUILDER-HASH:363374027

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
@@ -439,4 +439,4 @@ public class FinderWhereClauseEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1693639358
+// LIFERAY-SERVICE-BUILDER-HASH:1084695872

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
@@ -606,4 +606,4 @@ public class IndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1098283934
+// LIFERAY-SERVICE-BUILDER-HASH:2059835112

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
@@ -514,4 +514,4 @@ public class LVEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2086693931
+// LIFERAY-SERVICE-BUILDER-HASH:-1019249009

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
@@ -592,4 +592,4 @@ public class LVEntryLocalizationVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:910070489
+// LIFERAY-SERVICE-BUILDER-HASH:-34720159

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
@@ -607,4 +607,4 @@ public class LVEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:159555103
+// LIFERAY-SERVICE-BUILDER-HASH:-1097032591

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
@@ -608,4 +608,4 @@ public class LVEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1338181335
+// LIFERAY-SERVICE-BUILDER-HASH:-828825457

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -157,16 +156,14 @@ public class LazyBlobEntryPersistenceTest {
 			existingLazyBlobEntry.getGroupId(), newLazyBlobEntry.getGroupId());
 		Blob existingBlob1 = existingLazyBlobEntry.getBlob1();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob1.getBytes(1, (int)existingBlob1.length()),
-				newBlob1Bytes));
+		Assert.assertArrayEquals(
+			existingBlob1.getBytes(1, (int)existingBlob1.length()),
+			newBlob1Bytes);
 		Blob existingBlob2 = existingLazyBlobEntry.getBlob2();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob2.getBytes(1, (int)existingBlob2.length()),
-				newBlob2Bytes));
+		Assert.assertArrayEquals(
+			existingBlob2.getBytes(1, (int)existingBlob2.length()),
+			newBlob2Bytes);
 	}
 
 	@Test
@@ -528,4 +525,4 @@ public class LazyBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1591886676
+// LIFERAY-SERVICE-BUILDER-HASH:-1422261870

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
@@ -523,4 +523,4 @@ public class LocalizedEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1529263777
+// LIFERAY-SERVICE-BUILDER-HASH:280351175

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
@@ -389,4 +389,4 @@ public class LocalizedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:970680991
+// LIFERAY-SERVICE-BUILDER-HASH:-633391081

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
@@ -850,4 +850,4 @@ public class ManyColumnsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-331931033
+// LIFERAY-SERVICE-BUILDER-HASH:-1539826363

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
@@ -755,4 +755,4 @@ public class NestedSetsTreeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1480070982
+// LIFERAY-SERVICE-BUILDER-HASH:1136942444

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
@@ -494,4 +494,4 @@ public class NullConvertibleEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2035544722
+// LIFERAY-SERVICE-BUILDER-HASH:-688842544

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
@@ -513,4 +513,4 @@ public class PermissionCheckFinderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:770858273
+// LIFERAY-SERVICE-BUILDER-HASH:-1548496291

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ReassociateEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ReassociateEntryPersistenceTest.java
@@ -363,4 +363,4 @@ public class ReassociateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:857119238
+// LIFERAY-SERVICE-BUILDER-HASH:-1094575834

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
@@ -490,4 +490,4 @@ public class RedundantIndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-761136072
+// LIFERAY-SERVICE-BUILDER-HASH:498873980

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
@@ -511,4 +511,4 @@ public class RenameFinderColumnEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:724611151
+// LIFERAY-SERVICE-BUILDER-HASH:87284225

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
@@ -404,4 +404,4 @@ public class UADPartialEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1573662378
+// LIFERAY-SERVICE-BUILDER-HASH:453743134

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
@@ -533,4 +533,4 @@ public class UndefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1763178422
+// LIFERAY-SERVICE-BUILDER-HASH:1143386392

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UniqueFinderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UniqueFinderEntryPersistenceTest.java
@@ -475,4 +475,4 @@ public class UniqueFinderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-465531723
+// LIFERAY-SERVICE-BUILDER-HASH:1353080357

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
@@ -482,4 +482,4 @@ public class VersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-569055808
+// LIFERAY-SERVICE-BUILDER-HASH:-506831184

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
@@ -509,4 +509,4 @@ public class VersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:720558866
+// LIFERAY-SERVICE-BUILDER-HASH:220654446

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -69,7 +69,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -330,7 +329,7 @@ public class ${entity.name}PersistenceTest {
 			<#if stringUtil.equals(entityColumn.type, "Blob")>
 				Blob existing${entityColumn.methodName} = existing${entity.name}.get${entityColumn.methodName}();
 
-				Assert.assertTrue(Arrays.equals(existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()), new${entityColumn.methodName}Bytes));
+				Assert.assertArrayEquals(existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()), new${entityColumn.methodName}Bytes);
 			<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 				Assert.assertEquals(existing${entity.name}.is${entityColumn.methodName}(), new${entity.name}.is${entityColumn.methodName}());
 			<#elseif stringUtil.equals(entityColumn.type, "Date")>
@@ -395,7 +394,7 @@ public class ${entity.name}PersistenceTest {
 							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
 							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertTrue(Arrays.equals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length())));
+							Assert.assertArrayEquals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length()));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -395,7 +395,7 @@ public class ${entity.name}PersistenceTest {
 							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
 							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertTrue(Arrays.equals(${entityColumn.variableName}.getBytes(1, (int)${entityColumn.variableName}.length()), Arrays.equals(draft${entityColumn.name}.getBytes(1, (int)draft${entityColumn.name}.length()));
+							Assert.assertTrue(Arrays.equals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length())));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90963

Resend of #3821, which passed all required suites but was closed at the forwarding step (brianchandotcom#175845) due to rebase errors. The branch is rebased onto current master and the Build Service output regenerated on top of it.

The Blob branch of the ERC-gated testCreateDraft emitted non-compilable Java: a stray inner Arrays.equals call, identifiers that did not match the locals declared two lines above, and unbalanced parentheses. The bug stayed latent because no repository entity combined external-reference-code, versioned=true, and a Blob column — the three preconditions needed to render this branch. ERCVersionedEntry now carries an eager Blob column to keep the branch covered.

Scope note: relative to #3821, this resend keeps the Blob column eager only. Adding a lazy Blob to a versioned entity exposes an unrelated, pre-existing Service Builder generation gap (the version entity's lazy accessor references a LocalServiceUtil that is never generated for *Version entities), which belongs to the Service Builder owners and is reported separately as LPD-99739. The repo-wide LIFERAY-SERVICE-BUILDER-HASH churn updates the stored generator hashes for the changed test template; a second ant build-services run converges with zero drift.

**pr-check: PASS** — tested on `be5207242129352d5ee6ee2d88bf9b0c1925f5b8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "be5207242129352d5ee6ee2d88bf9b0c1925f5b8"} -->
