### PR TITLE
LPD-98716 Translate widget group ERCs when publishing to live

### DIFF
--- a/modules/apps/announcements/announcements-test/build.gradle
+++ b/modules/apps/announcements/announcements-test/build.gradle
@@ -4,6 +4,8 @@ dependencies {
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	testIntegrationImplementation project(":apps:announcements:announcements-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/exportimport/test/AnnouncementsExportImportTest.java
+++ b/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/exportimport/test/AnnouncementsExportImportTest.java
@@ -1,0 +1,225 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal.exportimport.test;
+
+import com.liferay.announcements.constants.AnnouncementsPortletKeys;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class AnnouncementsExportImportTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testExportImportScopeGroupExternalReferenceCodesFromStagedGroups()
+		throws Exception {
+
+		_setUpLocalStaging();
+
+		Layout stagingLayout = LayoutTestUtil.addTypePortletLayout(
+			_stagingGroup);
+
+		Group liveGroup1 = _addStagedGroup();
+		Group liveGroup2 = _addStagedGroup();
+
+		String portletId = _addAnnouncementsPortletWithScopeGroups(
+			stagingLayout, liveGroup1.getStagingGroup(),
+			liveGroup2.getStagingGroup());
+
+		try {
+			_publishLayouts(_stagingGroup);
+
+			Layout liveLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
+				stagingLayout.getUuid(), _liveGroup.getGroupId(),
+				stagingLayout.isPrivateLayout());
+
+			PortletPreferences portletPreferences =
+				_portletPreferencesLocalService.getPreferences(
+					_liveGroup.getCompanyId(),
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, liveLayout.getPlid(),
+					portletId);
+
+			_assertScopeGroupExternalReferenceCodesTranslated(
+				portletPreferences.getValue(
+					"selectedScopeGroupExternalReferenceCodes",
+					StringPool.BLANK),
+				liveGroup1, liveGroup2);
+		}
+		finally {
+			GroupTestUtil.deleteGroup(liveGroup1);
+			GroupTestUtil.deleteGroup(liveGroup2);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithLocalStaging() throws Exception {
+		_setUpLocalStaging();
+
+		Layout stagingLayout = LayoutTestUtil.addTypePortletLayout(
+			_stagingGroup);
+
+		Group liveGroup1 = _addStagedGroup();
+		Group liveGroup2 = _addStagedGroup();
+
+		String portletId = _addAnnouncementsPortletWithScopeGroups(
+			stagingLayout, liveGroup1.getStagingGroup(),
+			liveGroup2.getStagingGroup());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Map<String, Object> portletConfiguration =
+				_portletPreferencesPortletConfigurationExporter.
+					getPortletConfiguration(stagingLayout.getPlid(), portletId);
+
+			_assertScopeGroupExternalReferenceCodesTranslated(
+				(String)portletConfiguration.get(
+					"selectedScopeGroupExternalReferenceCodes"),
+				liveGroup1, liveGroup2);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+
+			GroupTestUtil.deleteGroup(liveGroup1);
+			GroupTestUtil.deleteGroup(liveGroup2);
+		}
+	}
+
+	private String _addAnnouncementsPortletWithScopeGroups(
+			Layout layout, Group... scopeGroups)
+		throws Exception {
+
+		return LayoutTestUtil.addPortletToLayout(
+			layout, AnnouncementsPortletKeys.ANNOUNCEMENTS,
+			HashMapBuilder.put(
+				"selectedScopeGroupExternalReferenceCodes",
+				new String[] {
+					String.valueOf(
+						JSONUtil.putAll(
+							(Object[])TransformUtil.transform(
+								scopeGroups, Group::getExternalReferenceCode,
+								String.class)))
+				}
+			).build());
+	}
+
+	private Group _addStagedGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(group, TestPropsValues.getUserId());
+
+		return group;
+	}
+
+	private void _assertScopeGroupExternalReferenceCodesTranslated(
+			String selectedScopeGroupExternalReferenceCodes,
+			Group... expectedScopeGroups)
+		throws Exception {
+
+		List<String> externalReferenceCodes = JSONUtil.toStringList(
+			JSONFactoryUtil.createJSONArray(
+				selectedScopeGroupExternalReferenceCodes));
+
+		Assert.assertEquals(
+			externalReferenceCodes.toString(), expectedScopeGroups.length,
+			externalReferenceCodes.size());
+
+		for (Group expectedScopeGroup : expectedScopeGroups) {
+			Assert.assertTrue(
+				selectedScopeGroupExternalReferenceCodes,
+				externalReferenceCodes.contains(
+					expectedScopeGroup.getExternalReferenceCode()));
+		}
+	}
+
+	private void _publishLayouts(Group stagingGroup) throws Exception {
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.TRUE.toString()});
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.TRUE.toString()});
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), false, parameterMap);
+	}
+
+	private void _setUpLocalStaging() throws Exception {
+		_liveGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(
+			_liveGroup, TestPropsValues.getUserId());
+
+		_stagingGroup = _liveGroup.getStagingGroup();
+	}
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@DeleteAfterTestRun
+	private Group _liveGroup;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private PortletPreferencesPortletConfigurationExporter
+		_portletPreferencesPortletConfigurationExporter;
+
+	private Group _stagingGroup;
+
+}

--- a/modules/apps/announcements/announcements-web/build.gradle
+++ b/modules/apps/announcements/announcements-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:announcements:announcements-api")
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
+	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/exportimport/portlet/preferences/processor/AnnouncementsExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/exportimport/portlet/preferences/processor/AnnouncementsExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.announcements.constants.AnnouncementsPortletKeys;
+import com.liferay.announcements.web.internal.util.AnnouncementsUtil;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
+import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "jakarta.portlet.name=" + AnnouncementsPortletKeys.ANNOUNCEMENTS,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class AnnouncementsExportImportPortletPreferencesProcessor
+	implements ExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return null;
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return null;
+	}
+
+	@Override
+	public void processExportPortletPreferences(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_updateSelectedScopeGroupExternalReferenceCodes(
+			companyId, portletPreferences);
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_updateSelectedScopeGroupExternalReferenceCodes(
+			portletDataContext.getCompanyId(), portletPreferences);
+
+		return portletPreferences;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+		PortletDataContext portletDataContext,
+		PortletPreferences portletPreferences) {
+
+		return portletPreferences;
+	}
+
+	private void _updateSelectedScopeGroupExternalReferenceCodes(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		String selectedScopeGroupExternalReferenceCodes =
+			portletPreferences.getValue(
+				"selectedScopeGroupExternalReferenceCodes", null);
+
+		if (Validator.isBlank(selectedScopeGroupExternalReferenceCodes)) {
+			return;
+		}
+
+		try {
+			List<String> externalReferenceCodes =
+				AnnouncementsUtil.toStringList(
+					selectedScopeGroupExternalReferenceCodes);
+
+			List<String> newExternalReferenceCodes = new ArrayList<>(
+				externalReferenceCodes.size());
+
+			for (String externalReferenceCode : externalReferenceCodes) {
+				newExternalReferenceCodes.add(
+					_exportImportPortletPreferencesProcessorHelper.
+						getGroupExportPortletPreferencesExternalReferenceCode(
+							companyId, externalReferenceCode));
+			}
+
+			portletPreferences.setValue(
+				"selectedScopeGroupExternalReferenceCodes",
+				AnnouncementsUtil.toJSON(newExternalReferenceCodes));
+		}
+		catch (Exception exception) {
+			throw new PortletDataException(
+				"Unable to update portlet preferences during export",
+				exception);
+		}
+	}
+
+	@Reference
+	private ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
+
+}

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -28,7 +28,9 @@ import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
@@ -57,6 +59,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockPortletRequest;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -71,12 +74,14 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.test.rule.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portlet.PortletPreferencesImpl;
+import com.liferay.portlet.display.template.PortletDisplayTemplate;
 import com.liferay.portlet.display.template.test.util.BaseExportImportTestCase;
 
 import jakarta.portlet.PortletPreferences;
@@ -698,6 +703,57 @@ public class AssetPublisherExportImportTest extends BaseExportImportTestCase {
 		Assert.assertNull(
 			portletPreferences.getValue(
 				"assetListEntryGroupExternalReferenceCode", null));
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testExportImportDisplayStyleFromStagedGroup() throws Exception {
+		Group displayStyleLiveGroup = GroupTestUtil.addGroup();
+
+		try {
+			StagingLocalServiceUtil.enableLocalStaging(
+				TestPropsValues.getUserId(), displayStyleLiveGroup, false,
+				false, new ServiceContext());
+
+			Group displayStyleStagingGroup =
+				displayStyleLiveGroup.getStagingGroup();
+
+			DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+				displayStyleStagingGroup.getGroupId(),
+				PortalUtil.getClassNameId(getClassName(group.getCompanyId())),
+				0,
+				PortalUtil.getClassNameId(
+					PortletDisplayTemplate.class.getName()),
+				TemplateConstants.LANG_TYPE_FTL, RandomTestUtil.randomString(),
+				PortalUtil.getSiteDefaultLocale(displayStyleStagingGroup));
+
+			String displayStyle =
+				PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +
+					ddmTemplate.getTemplateKey();
+
+			PortletPreferences portletPreferences =
+				getImportedPortletPreferences(
+					HashMapBuilder.put(
+						"displayStyle", new String[] {displayStyle}
+					).put(
+						"displayStyleGroupExternalReferenceCode",
+						new String[] {
+							displayStyleStagingGroup.getExternalReferenceCode()
+						}
+					).build());
+
+			Assert.assertEquals(
+				displayStyle,
+				portletPreferences.getValue("displayStyle", null));
+
+			Assert.assertEquals(
+				displayStyleLiveGroup.getExternalReferenceCode(),
+				portletPreferences.getValue(
+					"displayStyleGroupExternalReferenceCode", null));
+		}
+		finally {
+			GroupTestUtil.deleteGroup(displayStyleLiveGroup);
+		}
 	}
 
 	@Ignore

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/exportimport/portlet/preferences/processor/DDMFormExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/exportimport/portlet/preferences/processor/DDMFormExportImportPortletPreferencesProcessor.java
@@ -19,6 +19,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -59,6 +60,16 @@ public class DDMFormExportImportPortletPreferencesProcessor
 	@Override
 	public boolean isPublishDisplayedContent() {
 		return false;
+	}
+
+	@Override
+	public void processExportPortletPreferences(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				companyId, "groupExternalReferenceCode", portletPreferences);
 	}
 
 	@Override
@@ -148,6 +159,11 @@ public class DDMFormExportImportPortletPreferencesProcessor
 				portletDataContext, portletId, ddmFormInstance);
 		}
 
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				portletDataContext.getCompanyId(), "groupExternalReferenceCode",
+				portletPreferences);
+
 		return portletPreferences;
 	}
 
@@ -234,6 +250,10 @@ public class DDMFormExportImportPortletPreferencesProcessor
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:item-selector:item-selector-api")
 	testIntegrationImplementation project(":apps:journal:journal-article-dynamic-data-mapping-form-field-type-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/test/DDMFormDisplayExportImportTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/test/DDMFormDisplayExportImportTest.java
@@ -12,17 +12,26 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceRecordTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
+import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.portlet.PortletPreferences;
+
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -109,5 +118,42 @@ public class DDMFormDisplayExportImportTest
 	@Test
 	public void testExportImportAssetLinks() throws Exception {
 	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithLocalStaging() throws Exception {
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			new ServiceContext());
+
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), layout, getPortletId(), "column-1",
+			HashMapBuilder.put(
+				"groupExternalReferenceCode",
+				new String[] {
+					group.getStagingGroup(
+					).getExternalReferenceCode()
+				}
+			).build());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Map<String, Object> portletConfiguration =
+				_portletPreferencesPortletConfigurationExporter.
+					getPortletConfiguration(layout.getPlid(), portletId);
+
+			Assert.assertEquals(
+				group.getExternalReferenceCode(),
+				portletConfiguration.get("groupExternalReferenceCode"));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@Inject
+	private PortletPreferencesPortletConfigurationExporter
+		_portletPreferencesPortletConfigurationExporter;
 
 }

--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 18.0.1
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessor.java
@@ -25,6 +25,11 @@ public interface ExportImportPortletPreferencesProcessor {
 		return true;
 	}
 
+	public default void processExportPortletPreferences(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+	}
+
 	public PortletPreferences processExportPortletPreferences(
 			PortletDataContext portletDataContext,
 			PortletPreferences portletPreferences)

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelper.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelper.java
@@ -6,6 +6,7 @@
 package com.liferay.exportimport.portlet.preferences.processor;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.model.Portlet;
 
 import jakarta.portlet.PortletPreferences;
@@ -20,11 +21,19 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ExportImportPortletPreferencesProcessorHelper {
 
+	public String getGroupExportPortletPreferencesExternalReferenceCode(
+		long companyId, String externalReferenceCode);
+
 	public void updateExportPortletPreferencesClassPKs(
 			PortletDataContext portletDataContext, Portlet portlet,
 			PortletPreferences portletPreferences, String key, String className,
 			Function<String, String> exportPortletPreferencesNewValueFunction)
 		throws Exception;
+
+	public void updateGroupExportPortletPreferencesExternalReferenceCode(
+			long companyId, String externalReferenceCodePreferenceKey,
+			PortletPreferences portletPreferences)
+		throws PortletDataException;
 
 	public void updateImportPortletPreferencesClassPKs(
 			PortletDataContext portletDataContext,

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
@@ -5,28 +5,18 @@
 
 package com.liferay.exportimport.portlet.preferences.processor.base;
 
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.exportimport.kernel.staging.StagingURLHelperUtil;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
-import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.HttpPrincipal;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.service.http.GroupServiceHttp;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -34,6 +24,9 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Máté Thurzó
@@ -57,46 +50,13 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 	protected String getGroupExportPortletPreferencesExternalReferenceCode(
 		PortletDataContext portletDataContext, String externalReferenceCode) {
 
-		Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, portletDataContext.getCompanyId());
+		ExportImportPortletPreferencesProcessorHelper
+			exportImportPortletPreferencesProcessorHelper =
+				_serviceTracker.getService();
 
-		if (group == null) {
-			return externalReferenceCode;
-		}
-
-		if (ExportImportThreadLocal.isStagingInProcess() &&
-			group.isStagedRemotely()) {
-
-			UnicodeProperties typeSettingsUnicodeProperties =
-				group.getTypeSettingsProperties();
-
-			String remoteGroupExternalReferenceCode =
-				typeSettingsUnicodeProperties.get(
-					"remoteGroupExternalReferenceCode");
-
-			if (Validator.isNull(remoteGroupExternalReferenceCode)) {
-				remoteGroupExternalReferenceCode =
-					_getRemoteGroupExternalReferenceCode(
-						typeSettingsUnicodeProperties);
-			}
-
-			if (Validator.isNotNull(remoteGroupExternalReferenceCode)) {
-				externalReferenceCode = remoteGroupExternalReferenceCode;
-			}
-		}
-
-		if (!group.isStagingGroup()) {
-			return externalReferenceCode;
-		}
-
-		Group liveGroup = GroupLocalServiceUtil.fetchGroup(
-			group.getLiveGroupId());
-
-		if (liveGroup == null) {
-			return externalReferenceCode;
-		}
-
-		return liveGroup.getExternalReferenceCode();
+		return exportImportPortletPreferencesProcessorHelper.
+			getGroupExportPortletPreferencesExternalReferenceCode(
+				portletDataContext.getCompanyId(), externalReferenceCode);
 	}
 
 	protected String getImportPortletPreferencesNewExternalReferenceCode(
@@ -326,58 +286,19 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 		portletPreferences.setValues(key, newValues);
 	}
 
-	private String _getRemoteGroupExternalReferenceCode(
-		UnicodeProperties typeSettingsUnicodeProperties) {
-
-		String remoteAddress = GetterUtil.getString(
-			typeSettingsUnicodeProperties.get("remoteAddress"));
-		long remoteGroupId = GetterUtil.getLong(
-			typeSettingsUnicodeProperties.get("remoteGroupId"));
-
-		if (Validator.isNull(remoteAddress) || (remoteGroupId <= 0)) {
-			return null;
-		}
-
-		int remotePort = GetterUtil.getInteger(
-			typeSettingsUnicodeProperties.get("remotePort"));
-		String remotePathContext = GetterUtil.getString(
-			typeSettingsUnicodeProperties.get("remotePathContext"));
-		boolean secureConnection = GetterUtil.getBoolean(
-			typeSettingsUnicodeProperties.get("secureConnection"));
-
-		String remoteURL = StagingURLHelperUtil.buildRemoteURL(
-			remoteAddress, remotePort, remotePathContext, secureConnection);
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		User user = permissionChecker.getUser();
-
-		try {
-			HttpPrincipal httpPrincipal = new HttpPrincipal(
-				remoteURL, user.getLogin(), user.getPassword(),
-				user.isPasswordEncrypted());
-
-			try (SafeCloseable safeCloseable =
-					ThreadContextClassLoaderUtil.swap(
-						PortalClassLoaderUtil.getClassLoader())) {
-
-				Group group = GroupServiceHttp.getGroup(
-					httpPrincipal, remoteGroupId);
-
-				return group.getExternalReferenceCode();
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
-
-		return null;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseExportImportPortletPreferencesProcessor.class);
+
+	private static final ServiceTracker
+		<ExportImportPortletPreferencesProcessorHelper,
+		 ExportImportPortletPreferencesProcessorHelper> _serviceTracker;
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(
+			BaseExportImportPortletPreferencesProcessor.class);
+
+		_serviceTracker = ServiceTrackerFactory.open(
+			bundle, ExportImportPortletPreferencesProcessorHelper.class);
+	}
 
 }

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
@@ -8,12 +8,12 @@ package com.liferay.exportimport.portlet.preferences.processor.base;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
-import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -24,9 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.annotation.versioning.ProviderType;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Máté Thurzó
@@ -52,7 +49,7 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 
 		ExportImportPortletPreferencesProcessorHelper
 			exportImportPortletPreferencesProcessorHelper =
-				_serviceTracker.getService();
+				_exportImportPortletPreferencesProcessorHelperSnapshot.get();
 
 		return exportImportPortletPreferencesProcessorHelper.
 			getGroupExportPortletPreferencesExternalReferenceCode(
@@ -289,16 +286,9 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseExportImportPortletPreferencesProcessor.class);
 
-	private static final ServiceTracker
-		<ExportImportPortletPreferencesProcessorHelper,
-		 ExportImportPortletPreferencesProcessorHelper> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			BaseExportImportPortletPreferencesProcessor.class);
-
-		_serviceTracker = ServiceTrackerFactory.open(
-			bundle, ExportImportPortletPreferencesProcessorHelper.class);
-	}
+	private static final Snapshot<ExportImportPortletPreferencesProcessorHelper>
+		_exportImportPortletPreferencesProcessorHelperSnapshot = new Snapshot<>(
+			BaseExportImportPortletPreferencesProcessor.class,
+			ExportImportPortletPreferencesProcessorHelper.class);
 
 }

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/base/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/base/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelperImpl.java
@@ -48,6 +48,10 @@ public class ExportImportPortletPreferencesProcessorHelperImpl
 	public String getGroupExportPortletPreferencesExternalReferenceCode(
 		long companyId, String externalReferenceCode) {
 
+		if (!ExportImportThreadLocal.isStagingInProcess()) {
+			return externalReferenceCode;
+		}
+
 		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
 			externalReferenceCode, companyId);
 
@@ -55,9 +59,7 @@ public class ExportImportPortletPreferencesProcessorHelperImpl
 			return externalReferenceCode;
 		}
 
-		if (ExportImportThreadLocal.isStagingInProcess() &&
-			group.isStagedRemotely()) {
-
+		if (group.isStagedRemotely()) {
 			String remoteGroupExternalReferenceCode =
 				_getRemoteGroupExternalReferenceCode(group);
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/portlet/preferences/processor/ExportImportPortletPreferencesProcessorHelperImpl.java
@@ -5,21 +5,37 @@
 
 package com.liferay.exportimport.internal.portlet.preferences.processor;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.staging.StagingURLHelperUtil;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.HttpPrincipal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.service.http.GroupServiceHttp;
 
 import jakarta.portlet.PortletPreferences;
+import jakarta.portlet.ReadOnlyException;
 
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Máté Thurzó
@@ -27,6 +43,41 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ExportImportPortletPreferencesProcessorHelper.class)
 public class ExportImportPortletPreferencesProcessorHelperImpl
 	implements ExportImportPortletPreferencesProcessorHelper {
+
+	@Override
+	public String getGroupExportPortletPreferencesExternalReferenceCode(
+		long companyId, String externalReferenceCode) {
+
+		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+
+		if (group == null) {
+			return externalReferenceCode;
+		}
+
+		if (ExportImportThreadLocal.isStagingInProcess() &&
+			group.isStagedRemotely()) {
+
+			String remoteGroupExternalReferenceCode =
+				_getRemoteGroupExternalReferenceCode(group);
+
+			if (Validator.isNotNull(remoteGroupExternalReferenceCode)) {
+				externalReferenceCode = remoteGroupExternalReferenceCode;
+			}
+		}
+
+		if (!group.isStagingGroup()) {
+			return externalReferenceCode;
+		}
+
+		Group liveGroup = _groupLocalService.fetchGroup(group.getLiveGroupId());
+
+		if (liveGroup == null) {
+			return externalReferenceCode;
+		}
+
+		return liveGroup.getExternalReferenceCode();
+	}
 
 	@Override
 	public void updateExportPortletPreferencesClassPKs(
@@ -83,6 +134,30 @@ public class ExportImportPortletPreferencesProcessorHelperImpl
 	}
 
 	@Override
+	public void updateGroupExportPortletPreferencesExternalReferenceCode(
+			long companyId, String externalReferenceCodePreferenceKey,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		String externalReferenceCode = portletPreferences.getValue(
+			externalReferenceCodePreferenceKey, null);
+
+		if (Validator.isBlank(externalReferenceCode)) {
+			return;
+		}
+
+		try {
+			portletPreferences.setValue(
+				externalReferenceCodePreferenceKey,
+				getGroupExportPortletPreferencesExternalReferenceCode(
+					companyId, externalReferenceCode));
+		}
+		catch (ReadOnlyException readOnlyException) {
+			throw new PortletDataException(readOnlyException);
+		}
+	}
+
+	@Override
 	public void updateImportPortletPreferencesClassPKs(
 			PortletDataContext portletDataContext,
 			PortletPreferences portletPreferences, String key,
@@ -132,7 +207,70 @@ public class ExportImportPortletPreferencesProcessorHelperImpl
 		portletPreferences.setValues(key, newValues);
 	}
 
+	private String _getRemoteGroupExternalReferenceCode(Group group) {
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		String remoteGroupExternalReferenceCode =
+			typeSettingsUnicodeProperties.get(
+				"remoteGroupExternalReferenceCode");
+
+		if (Validator.isNotNull(remoteGroupExternalReferenceCode)) {
+			return remoteGroupExternalReferenceCode;
+		}
+
+		String remoteAddress = GetterUtil.getString(
+			typeSettingsUnicodeProperties.get("remoteAddress"));
+		long remoteGroupId = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("remoteGroupId"));
+
+		if (Validator.isNull(remoteAddress) || (remoteGroupId <= 0)) {
+			return null;
+		}
+
+		int remotePort = GetterUtil.getInteger(
+			typeSettingsUnicodeProperties.get("remotePort"));
+		String remotePathContext = GetterUtil.getString(
+			typeSettingsUnicodeProperties.get("remotePathContext"));
+		boolean secureConnection = GetterUtil.getBoolean(
+			typeSettingsUnicodeProperties.get("secureConnection"));
+
+		String remoteURL = StagingURLHelperUtil.buildRemoteURL(
+			remoteAddress, remotePort, remotePathContext, secureConnection);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		User user = permissionChecker.getUser();
+
+		try {
+			HttpPrincipal httpPrincipal = new HttpPrincipal(
+				remoteURL, user.getLogin(), user.getPassword(),
+				user.isPasswordEncrypted());
+
+			try (SafeCloseable safeCloseable =
+					ThreadContextClassLoaderUtil.swap(
+						PortalClassLoaderUtil.getClassLoader())) {
+
+				Group remoteGroup = GroupServiceHttp.getGroup(
+					httpPrincipal, remoteGroupId);
+
+				return remoteGroup.getExternalReferenceCode();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return null;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportImportPortletPreferencesProcessorHelperImpl.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
@@ -8,23 +8,14 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
 import com.liferay.layout.exporter.PortletPermissionsExporter;
+import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
-
-import jakarta.portlet.PortletPreferences;
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
@@ -52,52 +43,17 @@ public class WidgetInstanceUtil {
 	private static Map<String, Object> _getWidgetConfig(
 		long plid, String portletId) {
 
-		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
+		PortletPreferencesPortletConfigurationExporter
+			portletPreferencesPortletConfigurationExporter =
+				_portletPreferencesPortletConfigurationExporterServiceTracker.
+					getService();
 
-		if (layout == null) {
+		if (portletPreferencesPortletConfigurationExporter == null) {
 			return null;
 		}
 
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			PortletIdCodec.decodePortletName(portletId));
-
-		if (portlet == null) {
-			return null;
-		}
-
-		PortletPreferences portletPreferences =
-			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-				layout.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
-				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
-				portletId, portlet.getDefaultPreferences());
-
-		if (portletPreferences == null) {
-			return null;
-		}
-
-		Map<String, Object> portletConfigurationMap = new TreeMap<>();
-
-		Map<String, String[]> portletPreferencesMap =
-			portletPreferences.getMap();
-
-		for (Map.Entry<String, String[]> entrySet :
-				portletPreferencesMap.entrySet()) {
-
-			String[] values = entrySet.getValue();
-
-			if (values == null) {
-				portletConfigurationMap.put(
-					entrySet.getKey(), StringPool.BLANK);
-			}
-			else if (values.length == 1) {
-				portletConfigurationMap.put(entrySet.getKey(), values[0]);
-			}
-			else {
-				portletConfigurationMap.put(entrySet.getKey(), values);
-			}
-		}
-
-		return portletConfigurationMap;
+		return portletPreferencesPortletConfigurationExporter.
+			getPortletConfiguration(plid, portletId);
 	}
 
 	private static WidgetPermission[] _getWidgetPermissions(
@@ -140,5 +96,12 @@ public class WidgetInstanceUtil {
 				ServiceTrackerFactory.open(
 					FrameworkUtil.getBundle(WidgetInstanceUtil.class),
 					PortletPermissionsExporter.class);
+	private static final ServiceTracker
+		<PortletPreferencesPortletConfigurationExporter,
+		 PortletPreferencesPortletConfigurationExporter>
+			_portletPreferencesPortletConfigurationExporterServiceTracker =
+				ServiceTrackerFactory.open(
+					FrameworkUtil.getBundle(WidgetInstanceUtil.class),
+					PortletPreferencesPortletConfigurationExporter.class);
 
 }

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.content.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
+import com.liferay.exportimport.portlet.preferences.processor.base.BaseExportImportPortletPreferencesProcessor;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "jakarta.portlet.name=" + JournalContentPortletKeys.JOURNAL_CONTENT,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class JournalContentExportImportPortletPreferencesProcessor
+	extends BaseExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void processExportPortletPreferences(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				companyId, "groupExternalReferenceCode", portletPreferences);
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			Portlet portlet = _portletLocalService.getPortletById(
+				portletDataContext.getCompanyId(),
+				portletDataContext.getPortletId());
+
+			updateExportPortletPreferencesExternalReferenceCodes(
+				portletDataContext, portlet, portletPreferences,
+				"groupExternalReferenceCode", Group.class.getName());
+
+			return portletPreferences;
+		}
+		catch (Exception exception) {
+			PortletDataException portletDataException =
+				new PortletDataException(
+					"Unable to update portlet preferences during export",
+					exception);
+
+			portletDataException.setPortletId(
+				JournalContentPortletKeys.JOURNAL_CONTENT);
+			portletDataException.setType(
+				PortletDataException.EXPORT_PORTLET_DATA);
+
+			throw portletDataException;
+		}
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			Company company = _companyLocalService.getCompanyById(
+				portletDataContext.getCompanyId());
+
+			Group companyGroup = company.getGroup();
+
+			updateImportPortletPreferencesExternalReferenceCodes(
+				portletDataContext, portletPreferences,
+				"groupExternalReferenceCode", Group.class,
+				companyGroup.getGroupId());
+
+			return portletPreferences;
+		}
+		catch (Exception exception) {
+			PortletDataException portletDataException =
+				new PortletDataException(
+					"Unable to update portlet preferences during import",
+					exception);
+
+			portletDataException.setPortletId(
+				JournalContentPortletKeys.JOURNAL_CONTENT);
+			portletDataException.setType(
+				PortletDataException.IMPORT_PORTLET_DATA);
+
+			throw portletDataException;
+		}
+	}
+
+	@Override
+	protected String getExportPortletPreferencesValue(
+		PortletDataContext portletDataContext, Portlet portlet,
+		String className, long primaryKeyLong) {
+
+		return null;
+	}
+
+	@Override
+	protected String getImportPortletPreferencesNewExternalReferenceCode(
+		PortletDataContext portletDataContext, Class<?> clazz,
+		long companyGroupId, Map<String, String[]> primaryKeys,
+		String externalReferenceCode) {
+
+		if (!clazz.equals(Group.class)) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+			externalReferenceCode, portletDataContext.getCompanyId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	@Override
+	protected Long getImportPortletPreferencesNewValue(
+		PortletDataContext portletDataContext, Class<?> clazz,
+		long companyGroupId, Map<Long, Long> primaryKeys,
+		String portletPreferencesOldValue) {
+
+		return null;
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
@@ -72,20 +72,45 @@ public class JournalContentExportImportTest
 			TestPropsValues.getUserId(), group, false, false,
 			new ServiceContext());
 
+		Group stagingGroup = group.getStagingGroup();
+
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
 			HashMapBuilder.put(
 				"articleExternalReferenceCode",
 				new String[] {RandomTestUtil.randomString()}
 			).put(
 				"groupExternalReferenceCode",
-				new String[] {
-					group.getStagingGroup(
-					).getExternalReferenceCode()
-				}
+				new String[] {stagingGroup.getExternalReferenceCode()}
 			).build());
 
 		Assert.assertEquals(
 			group.getExternalReferenceCode(),
+			portletPreferences.getValue("groupExternalReferenceCode", null));
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testExportImportGroupExternalReferenceCodeWithoutStaging()
+		throws Exception {
+
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			new ServiceContext());
+
+		Group stagingGroup = group.getStagingGroup();
+
+		PortletPreferences portletPreferences = getImportedPortletPreferences(
+			HashMapBuilder.put(
+				"articleExternalReferenceCode",
+				new String[] {RandomTestUtil.randomString()}
+			).put(
+				"groupExternalReferenceCode",
+				new String[] {stagingGroup.getExternalReferenceCode()}
+			).build(),
+			false);
+
+		Assert.assertEquals(
+			stagingGroup.getExternalReferenceCode(),
 			portletPreferences.getValue("groupExternalReferenceCode", null));
 	}
 
@@ -96,14 +121,15 @@ public class JournalContentExportImportTest
 			TestPropsValues.getUserId(), group, false, false,
 			new ServiceContext());
 
+		Group stagingGroup = group.getStagingGroup();
+
 		ExportImportThreadLocal.setPortletStagingInProcess(true);
 
 		try {
 			Assert.assertEquals(
 				group.getExternalReferenceCode(),
 				_getExportedGroupExternalReferenceCode(
-					group.getStagingGroup(
-					).getExternalReferenceCode()));
+					stagingGroup.getExternalReferenceCode()));
 		}
 		finally {
 			ExportImportThreadLocal.setPortletStagingInProcess(false);
@@ -121,14 +147,15 @@ public class JournalContentExportImportTest
 			TestPropsValues.getUserId(), contentGroup, false, false,
 			new ServiceContext());
 
+		Group stagingGroup = contentGroup.getStagingGroup();
+
 		ExportImportThreadLocal.setPortletStagingInProcess(true);
 
 		try {
 			Assert.assertEquals(
 				contentGroup.getExternalReferenceCode(),
 				_getExportedGroupExternalReferenceCode(
-					contentGroup.getStagingGroup(
-					).getExternalReferenceCode()));
+					stagingGroup.getExternalReferenceCode()));
 		}
 		finally {
 			ExportImportThreadLocal.setPortletStagingInProcess(false);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.content.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
+import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class JournalContentExportImportTest
+	extends BasePortletExportImportTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public String getPortletId() throws Exception {
+		return PortletIdCodec.encode(
+			JournalContentPortletKeys.JOURNAL_CONTENT,
+			RandomTestUtil.randomString());
+	}
+
+	@Override
+	@Test
+	public void testExportImportAssetLinks() throws Exception {
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testExportImportGroupExternalReferenceCodeFromStagedGroup()
+		throws Exception {
+
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			new ServiceContext());
+
+		PortletPreferences portletPreferences = getImportedPortletPreferences(
+			HashMapBuilder.put(
+				"articleExternalReferenceCode",
+				new String[] {RandomTestUtil.randomString()}
+			).put(
+				"groupExternalReferenceCode",
+				new String[] {
+					group.getStagingGroup(
+					).getExternalReferenceCode()
+				}
+			).build());
+
+		Assert.assertEquals(
+			group.getExternalReferenceCode(),
+			portletPreferences.getValue("groupExternalReferenceCode", null));
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithLocalStaging() throws Exception {
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			new ServiceContext());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Assert.assertEquals(
+				group.getExternalReferenceCode(),
+				_getExportedGroupExternalReferenceCode(
+					group.getStagingGroup(
+					).getExternalReferenceCode()));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithLocalStagingFromDifferentGroup()
+		throws Exception {
+
+		Group contentGroup = GroupTestUtil.addGroup();
+
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), contentGroup, false, false,
+			new ServiceContext());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Assert.assertEquals(
+				contentGroup.getExternalReferenceCode(),
+				_getExportedGroupExternalReferenceCode(
+					contentGroup.getStagingGroup(
+					).getExternalReferenceCode()));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+
+			GroupTestUtil.deleteGroup(contentGroup);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithoutStaging() throws Exception {
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			new ServiceContext());
+
+		Group stagingGroup = group.getStagingGroup();
+
+		Assert.assertEquals(
+			stagingGroup.getExternalReferenceCode(),
+			_getExportedGroupExternalReferenceCode(
+				stagingGroup.getExternalReferenceCode()));
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithRemoteStaging()
+		throws Exception {
+
+		String remoteGroupExternalReferenceCode = RandomTestUtil.randomString();
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"remoteGroupExternalReferenceCode",
+			remoteGroupExternalReferenceCode);
+		typeSettingsUnicodeProperties.setProperty("staged", "true");
+		typeSettingsUnicodeProperties.setProperty("stagedRemotely", "true");
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Assert.assertEquals(
+				remoteGroupExternalReferenceCode,
+				_getExportedGroupExternalReferenceCode(
+					group.getExternalReferenceCode()));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	private Object _getExportedGroupExternalReferenceCode(
+			String groupExternalReferenceCode)
+		throws Exception {
+
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), layout, getPortletId(), "column-1",
+			HashMapBuilder.put(
+				"groupExternalReferenceCode",
+				new String[] {groupExternalReferenceCode}
+			).build());
+
+		Map<String, Object> portletConfiguration =
+			_portletPreferencesPortletConfigurationExporter.
+				getPortletConfiguration(layout.getPlid(), portletId);
+
+		return portletConfiguration.get("groupExternalReferenceCode");
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private PortletPreferencesPortletConfigurationExporter
+		_portletPreferencesPortletConfigurationExporter;
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exporter/PortletPreferencesPortletConfigurationExporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exporter/PortletPreferencesPortletConfigurationExporterImpl.java
@@ -5,7 +5,12 @@
 
 package com.liferay.layout.internal.exporter;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorRegistryUtil;
 import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
@@ -41,9 +46,8 @@ public class PortletPreferencesPortletConfigurationExporterImpl
 			return null;
 		}
 
-		String portletName = PortletIdCodec.decodePortletName(portletId);
-
-		Portlet portlet = _portletLocalService.getPortletById(portletName);
+		Portlet portlet = _portletLocalService.getPortletById(
+			PortletIdCodec.decodePortletName(portletId));
 
 		if (portlet == null) {
 			return null;
@@ -58,6 +62,42 @@ public class PortletPreferencesPortletConfigurationExporterImpl
 		if (portletPreferences == null) {
 			return null;
 		}
+
+		_processExportPortletPreferences(
+			layout.getCompanyId(), portletId, portletPreferences);
+
+		return _toPortletConfigurationMap(portletPreferences);
+	}
+
+	private void _processExportPortletPreferences(
+		long companyId, String portletId,
+		PortletPreferences portletPreferences) {
+
+		if (!ExportImportThreadLocal.isStagingInProcess()) {
+			return;
+		}
+
+		ExportImportPortletPreferencesProcessor
+			exportImportPortletPreferencesProcessor =
+				ExportImportPortletPreferencesProcessorRegistryUtil.
+					getExportImportPortletPreferencesProcessor(
+						PortletIdCodec.decodePortletName(portletId));
+
+		if (exportImportPortletPreferencesProcessor == null) {
+			return;
+		}
+
+		try {
+			exportImportPortletPreferencesProcessor.
+				processExportPortletPreferences(companyId, portletPreferences);
+		}
+		catch (PortletDataException portletDataException) {
+			ReflectionUtil.throwException(portletDataException);
+		}
+	}
+
+	private Map<String, Object> _toPortletConfigurationMap(
+		PortletPreferences portletPreferences) {
 
 		Map<String, Object> portletConfigurationMap = new TreeMap<>();
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exporter/PortletPreferencesPortletConfigurationExporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exporter/PortletPreferencesPortletConfigurationExporterImpl.java
@@ -51,7 +51,7 @@ public class PortletPreferencesPortletConfigurationExporterImpl
 
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-				layout.getPlid(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				layout.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
 				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid, portletId,
 				portlet.getDefaultPreferences());
 

--- a/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/exportimport/portlet/preferences/processor/PortletDisplayTemplateExportCapability.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/exportimport/portlet/preferences/processor/PortletDisplayTemplateExportCapability.java
@@ -10,6 +10,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.template.TemplateHandler;
@@ -26,10 +27,14 @@ import jakarta.portlet.PortletPreferences;
 public class PortletDisplayTemplateExportCapability implements Capability {
 
 	public PortletDisplayTemplateExportCapability(
+		ExportImportPortletPreferencesProcessorHelper
+			exportImportPortletPreferencesProcessorHelper,
 		Portal portal, PortletLocalService portletLocalService,
 		PortletDisplayTemplate portletDisplayTemplate,
 		PortletDisplayTemplateRegister portletDisplayTemplateExportRegister) {
 
+		_exportImportPortletPreferencesProcessorHelper =
+			exportImportPortletPreferencesProcessorHelper;
 		_portal = portal;
 		_portletLocalService = portletLocalService;
 		_portletDisplayTemplate = portletDisplayTemplate;
@@ -105,8 +110,15 @@ public class PortletDisplayTemplateExportCapability implements Capability {
 		}
 
 		portletDataContext.setScopeGroupId(previousScopeGroupId);
+
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				portletDataContext.getCompanyId(),
+				"displayStyleGroupExternalReferenceCode", portletPreferences);
 	}
 
+	private final ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
 	private final Portal _portal;
 	private final PortletDisplayTemplate _portletDisplayTemplate;
 	private final PortletDisplayTemplateRegister

--- a/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/exportimport/portlet/preferences/processor/PortletDisplayTemplateServiceTracker.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/exportimport/portlet/preferences/processor/PortletDisplayTemplateServiceTracker.java
@@ -6,6 +6,7 @@
 package com.liferay.portlet.display.template.internal.exportimport.portlet.preferences.processor;
 
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -111,6 +112,7 @@ public class PortletDisplayTemplateServiceTracker {
 					return bundleContext.registerService(
 						Capability.class,
 						new PortletDisplayTemplateExportCapability(
+							_exportImportPortletPreferencesProcessorHelper,
 							_portal, _portletLocalService,
 							_portletDisplayTemplate,
 							bundleContext.getService(serviceReference)),
@@ -159,6 +161,10 @@ public class PortletDisplayTemplateServiceTracker {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortletDisplayTemplateServiceTracker.class);
+
+	@Reference(unbind = "-")
+	private ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
 
 	@Reference(unbind = "-")
 	private Portal _portal;

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -12,6 +12,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -59,6 +60,17 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 	}
 
 	@Override
+	public void processExportPortletPreferences(
+			long companyId, PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				companyId, "siteNavigationMenuGroupExternalReferenceCode",
+				portletPreferences);
+	}
+
+	@Override
 	public PortletPreferences processExportPortletPreferences(
 			PortletDataContext portletDataContext,
 			PortletPreferences portletPreferences)
@@ -89,6 +101,12 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 				portletDataContext, portletDataContext.getPortletId(),
 				siteNavigationMenu);
 		}
+
+		_exportImportPortletPreferencesProcessorHelper.
+			updateGroupExportPortletPreferencesExternalReferenceCode(
+				portletDataContext.getCompanyId(),
+				"siteNavigationMenuGroupExternalReferenceCode",
+				portletPreferences);
 
 		return portletPreferences;
 	}
@@ -261,6 +279,10 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 
 	@Reference(target = "(name=CommonPortletDisplayTemplateExportCapability)")
 	private Capability _exportCapability;
+
+	@Reference
+	private ExportImportPortletPreferencesProcessorHelper
+		_exportImportPortletPreferencesProcessorHelper;
 
 	@Reference(unbind = "-")
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/site-navigation/site-navigation-test/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-api")
 	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:object:object-api")

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
@@ -7,8 +7,10 @@ package com.liferay.site.navigation.menu.web.internal.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -459,6 +461,82 @@ public class SiteNavigationMenuExportImportTest
 				"rootMenuItemExternalReferenceCode", StringPool.BLANK));
 	}
 
+	@Test
+	@TestInfo("LPD-98716")
+	public void testExportImportWithSiteNavigationMenuFromStagedGroup()
+		throws Exception {
+
+		_setUpLocalStaging();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_stagingGroup);
+
+		_setUpSiteNavigationMenu(_stagingGroup);
+
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"rootMenuItemExternalReferenceCode",
+				new String[] {
+					_siteNavigationMenuItem.getExternalReferenceCode()
+				}
+			).put(
+				"siteNavigationMenuExternalReferenceCode",
+				new String[] {_siteNavigationMenu.getExternalReferenceCode()}
+			).put(
+				"siteNavigationMenuGroupExternalReferenceCode",
+				new String[] {_stagingGroup.getExternalReferenceCode()}
+			).build());
+
+		_publishAllLayouts();
+
+		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
+			_layout.getUuid(), _liveGroup.getGroupId(),
+			_layout.isPrivateLayout());
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_liveGroup.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				portletId);
+
+		Assert.assertEquals(
+			_liveGroup.getExternalReferenceCode(),
+			portletPreferences.getValue(
+				"siteNavigationMenuGroupExternalReferenceCode",
+				StringPool.BLANK));
+	}
+
+	@Test
+	@TestInfo("LPD-98716")
+	public void testGetPortletConfigurationWithLocalStaging() throws Exception {
+		_setUpLocalStaging();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_stagingGroup);
+
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"siteNavigationMenuGroupExternalReferenceCode",
+				new String[] {_stagingGroup.getExternalReferenceCode()}
+			).build());
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Map<String, Object> portletConfiguration =
+				_portletPreferencesPortletConfigurationExporter.
+					getPortletConfiguration(_layout.getPlid(), portletId);
+
+			Assert.assertEquals(
+				_liveGroup.getExternalReferenceCode(),
+				portletConfiguration.get(
+					"siteNavigationMenuGroupExternalReferenceCode"));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
 	private void _addGroupEmbeddedPortlet(
 		String portletInstanceId, Portlet portlet, String portletPreferences) {
 
@@ -567,6 +645,10 @@ public class SiteNavigationMenuExportImportTest
 
 	@Inject
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private PortletPreferencesPortletConfigurationExporter
+		_portletPreferencesPortletConfigurationExporter;
 
 	private SiteNavigationMenu _siteNavigationMenu;
 	private SiteNavigationMenuItem _siteNavigationMenuItem;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98716

## What Is Being Fixed

When a page widget references content that lives in another site — Web Content Display, Site Navigation Menu, DDM Form, Announcements, or any widget using a display template — its configuration stores the referenced site's group external reference code. When the page was published to a live or remote live environment, that code was carried over unchanged, so it still pointed at the source site's group and could not be resolved on the target. The widget then failed to find its content and rendered blank.

This affected two export paths. The classic LAR export ran portlet preferences processors, but several widgets translated no group reference at all. Content pages and the headless widget configuration export bypass the processor chain entirely and go through the configuration exporter, so even widgets that did translate on the classic path leaked the source code there.

## How It Is Being Fixed

The portlet preferences processor API gains a company-scoped processExportPortletPreferences overload, and the helper gains primitives that translate a group external reference code from its staging group to its live group — or, when the group is staged remotely, to the remote live group's code read from the group's type settings. The configuration exporter now dispatches exported preferences to the registered processor for the portlet, gated on a staging publish being in process, so the content page and headless paths translate exactly as the classic path does. The headless widget configuration export was routed through the shared exporter so it benefits from the same translation.

Each affected widget — Web Content Display, DDM Form, Site Navigation Menu, and Announcements — now translates its group external reference code on both the classic and the exporter paths, and the display template capability translates its display style group reference. A latent bug where the configuration exporter passed the layout PLID where getLayoutPortletSetup expects the company ID was also fixed.

## Behavior Change Reviewers Should Note

The helper now gates the whole translation on a staging publish being in process, rather than checking that only in the remotely staged branch. Previously the staging group to live group rewrite ran on every export, so a LAR export taken outside a publish also rewrote the reference. That was already the behavior for the Document Library and Category Facet widgets, and this pull request would have extended it to Web Content Display and the other widgets it touches, including the widget most used in the product.

The configuration exporter already returned early unless a staging publish was in process, so without this gate the same preference would be translated on the classic path and left untouched on the exporter path. Making the helper the single place that enforces "translate only during a publish" keeps the two paths in agreement, and it skips the group lookup entirely outside a publish. `JournalContentExportImportTest` covers both sides of the gate.

The base processor also resolves the helper through a `Snapshot` rather than a static service tracker, so it degrades to the untranslated reference instead of throwing when the helper is momentarily unavailable, and there is no tracker left open.

## PR Check

**pr-check: PASS** — tested on `84f081a27e680dd2064a711911ac2ed6956603b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "84f081a27e680dd2064a711911ac2ed6956603b6"} -->
