### PR TITLE
LPD-99377 Restore not-visible-to-guest icon in React item selector

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/getAssetEntriesItemSelectorProps.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/getAssetEntriesItemSelectorProps.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import {sub} from 'frontend-js-web';
 import React from 'react';
@@ -57,12 +58,33 @@ function StatusCell({value}) {
 	);
 }
 
+function TitleCell({itemData, value}) {
+	if (itemData?.viewableByGuest === false) {
+		return (
+			<span className="align-items-center d-flex">
+				{value}
+
+				<ClayIcon
+					aria-label={Liferay.Language.get(
+						'not-visible-to-guest-users'
+					)}
+					className="inline-item inline-item-after"
+					symbol="password-policies"
+				/>
+			</span>
+		);
+	}
+
+	return value;
+}
+
 function buildAPIURL(groupIds, classNameIds, excludedAssetEntry) {
 	const url = new URL(ASSET_ENTRIES_API_URL, window.location.origin);
 
 	String(groupIds)
 		.split(',')
 		.forEach((groupId) => url.searchParams.append('groupIds', groupId));
+	url.searchParams.set('nestedFields', 'viewableByGuest');
 	url.searchParams.set('showNonindexable', 'true');
 
 	const filters = [];
@@ -115,6 +137,11 @@ export default function getAssetEntriesItemSelectorProps({
 						name: 'assetEntryStatus',
 						type: 'internal',
 					},
+					{
+						component: TitleCell,
+						name: 'assetEntryTitle',
+						type: 'internal',
+					},
 				],
 			},
 			filters: singleAssetEntryType
@@ -145,6 +172,7 @@ export default function getAssetEntriesItemSelectorProps({
 					schema: {
 						fields: [
 							{
+								contentRenderer: 'assetEntryTitle',
 								fieldName: 'title',
 								label: Liferay.Language.get('title'),
 							},

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 57.2.1
+Bundle-Version: 57.3.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetEntry.java
@@ -544,6 +544,51 @@ public class AssetEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _titleSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Whether the asset entry is viewable by the guest role. Only populated when requested via nestedFields."
+	)
+	public Boolean getViewableByGuest() {
+		if (_viewableByGuestSupplier != null) {
+			viewableByGuest = _viewableByGuestSupplier.get();
+
+			_viewableByGuestSupplier = null;
+		}
+
+		return viewableByGuest;
+	}
+
+	public void setViewableByGuest(Boolean viewableByGuest) {
+		this.viewableByGuest = viewableByGuest;
+
+		_viewableByGuestSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setViewableByGuest(
+		UnsafeSupplier<Boolean, Exception> viewableByGuestUnsafeSupplier) {
+
+		_viewableByGuestSupplier = () -> {
+			try {
+				return viewableByGuestUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Whether the asset entry is viewable by the guest role. Only populated when requested via nestedFields."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Boolean viewableByGuest;
+
+	@JsonIgnore
+	private Supplier<Boolean> _viewableByGuestSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -730,6 +775,18 @@ public class AssetEntry implements Serializable {
 			sb.append("\"");
 		}
 
+		Boolean viewableByGuest = getViewableByGuest();
+
+		if (viewableByGuest != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"viewableByGuest\": ");
+
+			sb.append(viewableByGuest);
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -831,4 +888,4 @@ public class AssetEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1847726870
+// LIFERAY-REST-BUILDER-HASH:265762407

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 35.6.0
+version 35.7.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetEntry.java
@@ -257,6 +257,27 @@ public class AssetEntry implements Cloneable, Serializable {
 
 	protected String title;
 
+	public Boolean getViewableByGuest() {
+		return viewableByGuest;
+	}
+
+	public void setViewableByGuest(Boolean viewableByGuest) {
+		this.viewableByGuest = viewableByGuest;
+	}
+
+	public void setViewableByGuest(
+		UnsafeSupplier<Boolean, Exception> viewableByGuestUnsafeSupplier) {
+
+		try {
+			viewableByGuest = viewableByGuestUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean viewableByGuest;
+
 	@Override
 	public AssetEntry clone() throws CloneNotSupportedException {
 		return (AssetEntry)super.clone();
@@ -289,4 +310,4 @@ public class AssetEntry implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1471080213
+// LIFERAY-REST-BUILDER-HASH:444265614

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetEntrySerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetEntrySerDes.java
@@ -185,6 +185,16 @@ public class AssetEntrySerDes {
 			sb.append("\"");
 		}
 
+		if (assetEntry.getViewableByGuest() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"viewableByGuest\": ");
+
+			sb.append(assetEntry.getViewableByGuest());
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -288,6 +298,15 @@ public class AssetEntrySerDes {
 			map.put("title", String.valueOf(assetEntry.getTitle()));
 		}
 
+		if (assetEntry.getViewableByGuest() == null) {
+			map.put("viewableByGuest", null);
+		}
+		else {
+			map.put(
+				"viewableByGuest",
+				String.valueOf(assetEntry.getViewableByGuest()));
+		}
+
 		return map;
 	}
 
@@ -339,6 +358,9 @@ public class AssetEntrySerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "viewableByGuest")) {
 				return false;
 			}
 
@@ -412,6 +434,12 @@ public class AssetEntrySerDes {
 			else if (Objects.equals(jsonParserFieldName, "title")) {
 				if (jsonParserFieldValue != null) {
 					assetEntry.setTitle((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "viewableByGuest")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setViewableByGuest(
+						(Boolean)jsonParserFieldValue);
 				}
 			}
 		}
@@ -495,4 +523,4 @@ public class AssetEntrySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-600015839
+// LIFERAY-REST-BUILDER-HASH:975162010

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -119,6 +119,11 @@ components:
                         The asset entry's title in the requesting locale.
                     readOnly: true
                     type: string
+                viewableByGuest:
+                    description:
+                        Whether the asset entry is viewable by the guest role. Only populated when requested via nestedFields.
+                    readOnly: true
+                    type: boolean
             type: object
         BlogPosting:
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetEntryDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetEntryDTOConverter.java
@@ -13,11 +13,18 @@ import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 
 import java.util.Locale;
 
@@ -106,6 +113,23 @@ public class AssetEntryDTOConverter
 						return assetRenderer.getStatus();
 					});
 				setTitle(() -> serviceBuilderAssetEntry.getTitle(locale));
+				setViewableByGuest(
+					() -> NestedFieldsSupplier.supply(
+						"viewableByGuest",
+						nestedField -> {
+							Role guestRole = _roleLocalService.getRole(
+								serviceBuilderAssetEntry.getCompanyId(),
+								RoleConstants.GUEST);
+
+							return _resourcePermissionLocalService.
+								hasResourcePermission(
+									serviceBuilderAssetEntry.getCompanyId(),
+									serviceBuilderAssetEntry.getClassName(),
+									ResourceConstants.SCOPE_INDIVIDUAL,
+									String.valueOf(
+										serviceBuilderAssetEntry.getClassPK()),
+									guestRole.getRoleId(), ActionKeys.VIEW);
+						}));
 			}
 		};
 	}
@@ -115,6 +139,12 @@ public class AssetEntryDTOConverter
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
@@ -13,14 +13,22 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.headless.delivery.client.dto.v1_0.AssetEntry;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.resource.v1_0.AssetEntryResource;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 
@@ -42,6 +50,7 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 		super.testGetAssetEntriesPage();
 
 		_testGetAssetEntriesPageAssetEntryFields();
+		_testGetAssetEntriesPageViewableByGuest();
 		_testGetAssetEntriesPageWithClassNameIdFilter();
 		_testGetAssetEntriesPageWithClassPKFilter();
 		_testGetAssetEntriesPageWithClassTypeIdFilter();
@@ -77,6 +86,20 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				groupId, TestPropsValues.getUserId()));
+	}
+
+	private AssetEntry _getAssetEntry(
+		List<AssetEntry> assetEntries, long classPK) {
+
+		for (AssetEntry assetEntry : assetEntries) {
+			Long assetEntryClassPK = assetEntry.getClassPK();
+
+			if ((assetEntryClassPK != null) && (assetEntryClassPK == classPK)) {
+				return assetEntry;
+			}
+		}
+
+		return null;
 	}
 
 	private boolean _hasClassPK(List<AssetEntry> assetEntries, long classPK) {
@@ -119,6 +142,62 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 		Assert.assertEquals(
 			Integer.valueOf(WorkflowConstants.STATUS_APPROVED),
 			assetEntry.getStatus());
+	}
+
+	private void _testGetAssetEntriesPageViewableByGuest() throws Exception {
+		Long groupId = testGroup.getGroupId();
+
+		BlogsEntry viewableByGuestBlogsEntry = _addBlogsEntry(groupId);
+		BlogsEntry notViewableByGuestBlogsEntry = _addBlogsEntry(groupId);
+
+		Role guestRole = _roleLocalService.getRole(
+			testCompany.getCompanyId(), RoleConstants.GUEST);
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			testCompany.getCompanyId(), BlogsEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(notViewableByGuestBlogsEntry.getEntryId()),
+			guestRole.getRoleId(), ActionKeys.VIEW);
+
+		AssetEntryResource nestedFieldsAssetEntryResource =
+			AssetEntryResource.builder(
+			).authentication(
+				"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+			).locale(
+				LocaleUtil.getDefault()
+			).parameters(
+				"nestedFields", "viewableByGuest"
+			).build();
+
+		Page<AssetEntry> nestedFieldsPage =
+			nestedFieldsAssetEntryResource.getAssetEntriesPage(
+				new Long[] {groupId}, null, null, null, Pagination.of(1, 50),
+				null);
+
+		List<AssetEntry> nestedFieldsAssetEntries =
+			(List<AssetEntry>)nestedFieldsPage.getItems();
+
+		Assert.assertEquals(
+			Boolean.TRUE,
+			_getAssetEntry(
+				nestedFieldsAssetEntries, viewableByGuestBlogsEntry.getEntryId()
+			).getViewableByGuest());
+		Assert.assertEquals(
+			Boolean.FALSE,
+			_getAssetEntry(
+				nestedFieldsAssetEntries,
+				notViewableByGuestBlogsEntry.getEntryId()
+			).getViewableByGuest());
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId}, null, null, null, Pagination.of(1, 50), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertNull(
+			_getAssetEntry(
+				assetEntries, viewableByGuestBlogsEntry.getEntryId()
+			).getViewableByGuest());
 	}
 
 	private void _testGetAssetEntriesPageWithClassNameIdFilter()
@@ -278,5 +357,11 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 
 	@Inject
 	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
@@ -698,6 +698,14 @@ public abstract class BaseAssetEntryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("viewableByGuest", additionalAssertFieldName)) {
+				if (assetEntry.getViewableByGuest() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -928,6 +936,17 @@ public abstract class BaseAssetEntryResourceTestCase {
 			if (Objects.equals("title", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						assetEntry1.getTitle(), assetEntry2.getTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("viewableByGuest", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getViewableByGuest(),
+						assetEntry2.getViewableByGuest())) {
 
 					return false;
 				}
@@ -1327,6 +1346,11 @@ public abstract class BaseAssetEntryResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("viewableByGuest")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -1388,6 +1412,7 @@ public abstract class BaseAssetEntryResourceTestCase {
 					RandomTestUtil.randomString());
 				status = RandomTestUtil.randomInt();
 				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				viewableByGuest = RandomTestUtil.randomBoolean();
 			}
 		};
 	}
@@ -1612,4 +1637,4 @@ public abstract class BaseAssetEntryResourceTestCase {
 		_assetEntryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:459243281
+// LIFERAY-REST-BUILDER-HASH:1536099398

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -1060,18 +1060,7 @@ privateContentIconTest(
 
 		await journalEditArticlePage.openRelatedAsset();
 
-		await journalEditArticlePage.assertPrivateContentIconInRelatedAssetPopUp(
-			'Basic Web Content'
-		);
-
-		await journalEditArticlePage.changeViewInRelatedAssetPopUp(
-			'Basic Web Content',
-			'table'
-		);
-
-		await journalEditArticlePage.assertPrivateContentIconInRelatedAssetPopUp(
-			'Basic Web Content'
-		);
+		await journalEditArticlePage.assertPrivateContentIconInRelatedAssetPopUp();
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -83,10 +83,10 @@ export class JournalEditArticlePage {
 		this.undoButton = page.getByTitle('Undo', {exact: true});
 	}
 
-	async assertPrivateContentIconInRelatedAssetPopUp(assetType: string) {
+	async assertPrivateContentIconInRelatedAssetPopUp() {
 		await expect(
 			this.page
-				.frameLocator(`iframe[title="Select ${assetType}"]`)
+				.getByRole('dialog')
 				.getByLabel('Not Visible to Guest Users')
 				.locator('use')
 				.first()
@@ -144,21 +144,6 @@ export class JournalEditArticlePage {
 			.click();
 
 		await this.page.locator(`button[id="${languageId}"]`).click();
-	}
-
-	async changeViewInRelatedAssetPopUp(assetType: string, viewType: string) {
-		await this.page
-			.frameLocator(`iframe[title="Select ${assetType}"]`)
-			.getByLabel('Select View, Currently Selected: ')
-			.waitFor();
-		await this.page
-			.frameLocator(`iframe[title="Select ${assetType}"]`)
-			.getByLabel('Select View, Currently Selected: ')
-			.click();
-		await this.page
-			.frameLocator(`iframe[title="Select ${assetType}"]`)
-			.getByRole('menuitem', {name: viewType})
-			.click();
 	}
 
 	async clearAllCategories(vocabulary: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99377

## What Is Being Fixed

In the legacy item selector, content not visible to guest users showed a "Not Visible to Guest Users" icon next to its title (LPD-15807), so authors could tell at a glance which content was private while picking related assets. After the item selector was migrated to the new React content picker, that icon was no longer rendered — no React component referenced the label, and item-selector rows showed the content without the icon. This regression was surfaced by the failing daily Playwright test journalArticle.spec.ts "Identify at a glance if a Web Content is visible for guests in the item selector".

## How It Is Being Fixed

The React item selector has no access to portal permission APIs, so the guest-visibility signal is exposed through the headless API that feeds the picker. A viewableByGuest field is added to the AssetEntry REST schema, computed in the DTO converter from the guest role's view permission on the entry. The field is opt-in: it is only populated when the caller requests it via nestedFields, so the extra permission check is not paid on every asset listing. The taglib props builder for the item selector requests the field and the React rows render the not-visible-to-guest icon when it is false, restoring the legacy behavior across both card and table views. The Playwright page object and spec are updated for the React dialog picker (single table view, no view switcher), matching the migrated UI.

## PR Check

**pr-check: PASS** — tested on `996ad9fbd5b77845c7878ad750098cba6023d357`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "996ad9fbd5b77845c7878ad750098cba6023d357"} -->
