### PR TITLE
LPD-99947 Fix flaky PublishAPIApplication tests

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -262,6 +262,8 @@ definition {
 		}
 
 		Click(locator1 = "APIBuilder#CREATE_BUTTON");
+
+		WaitForElementPresent(locator1 = "APIBuilder#PUBLISH_BUTTON");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99947

## What Is Being Fixed

The `PublishAPIApplication` functional tests (API Builder) fail intermittently in CI with `ElementNotFoundPoshiRunnerException`, unable to find the Actions button on the `App-test` application row. Every test in the file fails together because they share a `setUp` that creates the application through the UI via `APIBuilderUI.createAPIApplication`. That macro clicks Create and returns immediately, without waiting for the create to complete; under CI load the next navigation reaches the applications list before the new application has been committed, so the row and its Actions button are not present.

## How It Is Being Fixed

After clicking Create, the macro now waits for the new application's edit page to render (the Publish button), which the UI opens only after the create request succeeds. This guarantees the application exists before any later navigation, closing the race. Because the fix lives in the shared create macro, it stabilizes every test that relies on it. Running the full `PublishAPIApplication` testcase locally passes all seven tests.

## Why Are There No Tests?

This change is itself a fix to test infrastructure — a Poshi test macro — that removes flakiness from existing functional tests rather than adding new behavior. Its correctness is verified by the existing `PublishAPIApplication` tests passing reliably.

## PR Check

**pr-check: PASS** — tested on `0130b0b20c91ab0f995c11004a29459b494aeeb4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "0130b0b20c91ab0f995c11004a29459b494aeeb4"} -->
