### PR TITLE
LPD-99942 Invoke MCP tools and prompts in the request thread

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -206,6 +206,8 @@ public class MCPServerServlet extends HttpServlet {
 			).tools(
 				true
 			).build()
+		).immediateExecution(
+			true
 		).prompts(
 			_getSyncPromptSpecifications(companyId)
 		).tools(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -20,6 +20,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -173,6 +175,7 @@ public class MCPServerServletTest {
 							Base64.encode(userNameAndPassword.getBytes()),
 						"Bearer " + _getAccessToken())) {
 
+				_testServiceWithoutAuthTokenCheck(authorization);
 				_testServiceWithDataMasks(authorization);
 				_testServiceWithModifiedProfile(authorization);
 				_testServiceWithNoContentResponse(authorization);
@@ -763,6 +766,36 @@ public class MCPServerServletTest {
 
 		Assert.assertFalse(textContent.text(), callToolResult.isError());
 		Assert.assertEquals("Status code: 204", textContent.text());
+
+		mcpSyncClient.closeGracefully();
+	}
+
+	private void _testServiceWithoutAuthTokenCheck(String authorization)
+		throws Exception {
+
+		String name = RandomTestUtil.randomString();
+
+		_addObjectEntry(name, "mcp-server-profiles getMCPServerProfilesPage");
+
+		McpSyncClient mcpSyncClient = _getMcpSyncClient(authorization, name);
+
+		mcpSyncClient.initialize();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"AUTH_TOKEN_CHECK_ENABLED", false)) {
+
+			McpSchema.CallToolResult callToolResult = mcpSyncClient.callTool(
+				new McpSchema.CallToolRequest(
+					"getMCPServerProfilesPage", Collections.emptyMap()));
+
+			List<McpSchema.Content> contents = callToolResult.content();
+
+			McpSchema.TextContent textContent =
+				(McpSchema.TextContent)contents.get(0);
+
+			Assert.assertFalse(textContent.text(), callToolResult.isError());
+		}
 
 		mcpSyncClient.closeGracefully();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99942

## What Is Being Fixed

MCP tool calls fail with `AuthException: No User exists with the key {companyId=0, userId=...}` on instances that set `auth.token.check.enabled=false`. The token and the user are both valid — the company is what is missing.

`MCPServerServlet` builds its server with `McpServer.sync(...)`, but "sync" in the MCP Java SDK describes the callback signature, not the thread. Unless `immediateExecution` is set, the SDK wraps every sync tool and prompt specification in `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())` and the servlet transport blocks on the result, so handlers run on a Reactor worker that carries none of the thread locals the request established. `CompanyThreadLocal` is `0` there, since it is a non-inheritable short-lived thread local and `PortalInstancesFilter` is mapped only to the REQUEST and ERROR dispatchers. The in-process REST forward's `AccessControlImpl.initContextUser` then calls `getUserById(0, userId)` and throws.

This normally goes unnoticed because the CSRF check in `PortalSessionAuthVerifier` calls `PortalUtil.getCompanyId(request)`, which sets `CompanyThreadLocal` as a side effect. `SessionAuthToken.checkCSRFToken` returns on its first line when `auth.token.check.enabled` is false, so that side effect disappears and every tool call in every tool set fails regardless of auth state.

## How It Is Being Fixed

`immediateExecution(true)` on the `McpServer.sync(...)` builder keeps sync tool and prompt handlers on the thread that serves the request, where the company, principal, permission checker, and change tracking collection are already established. The transport blocks on the servlet thread either way, so the Reactor hop bought nothing. The company repair is no longer load-bearing.

The test disables the CSRF check for the duration of a real tool call, which reproduces the exact failure on the unfixed build. It runs first in the existing authorization loop because `CompanyThreadLocal.setCompanyId` is never restored and `boundedElastic` workers are pooled, so any earlier tool call leaves a valid company on the worker and masks the defect.

## PR Check

**pr-check: PASS** — tested on `5fea97d30b623f0c5bc4aa080096be736f67e5f3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5fea97d30b623f0c5bc4aa080096be736f67e5f3"} -->
