### PR TITLE
LPD-99983 Fix Object Entries file-upload setup across 8 Poshi tests

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -276,7 +276,7 @@ definition {
 		ImportExport.selectEntity(entityType = ${entityType});
 
 		if (isSet(scope)) {
-			var scope = TestCase.getSiteName();
+			var scope = TestCase.getSiteName(siteName = "Liferay DXP Site");
 
 			Select(
 				locator1 = "Select#SCOPE_CONFIGURATION",

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase
@@ -59,7 +59,7 @@ definition {
 		}
 
 		task ("And Given creating a Student entry with: name 'Jane', an uploaded file 'diploma', subjectStudents 'Math'") {
-			var studentEntryId = CustomObjectAPI.createObjectRelatedToAnotherObject(
+			CustomObjectAPI.createObjectRelatedToAnotherObject(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				name = "Jane",
@@ -68,8 +68,8 @@ definition {
 				relationshipName = "subjectStudents");
 
 			ObjectAdmin.selectAttachmentFileInObjectEntryViaUI(
+				externalReferenceCode = "studentErc",
 				fileName = "Document_1.jpg",
-				key_entry = ${studentEntryId},
 				objectName = "Student");
 		}
 	}

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
@@ -165,7 +165,7 @@ definition {
 		}
 
 		task ("Then 'Scope' is present with default and Global sites in dropdown list") {
-			var scope = TestCase.getSiteName();
+			var scope = TestCase.getSiteName(siteName = "Liferay DXP Site");
 
 			AssertElementPresent(locator1 = "Select#SCOPE_CONFIGURATION");
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
@@ -62,7 +62,7 @@ definition {
 		}
 
 		task ("And Given creating a Student entry with: name 'Jane', an uploaded file 'diploma', subjectStudents 'Math'") {
-			var studentEntryId = CustomObjectAPI.createObjectRelatedToAnotherObject(
+			CustomObjectAPI.createObjectRelatedToAnotherObject(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				name = "Jane",
@@ -72,8 +72,8 @@ definition {
 				scopeKey = "true");
 
 			ObjectAdmin.selectAttachmentFileInObjectEntryViaUI(
+				externalReferenceCode = "studentErc",
 				fileName = "Document_1.jpg",
-				key_entry = ${studentEntryId},
 				objectName = "Student");
 		}
 	}

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1610,12 +1610,10 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro selectAttachmentFileInObjectEntryViaUI(fileName = null, objectName = null, objectEntryId = null) {
+	macro selectAttachmentFileInObjectEntryViaUI(externalReferenceCode = null, fileName = null, objectName = null) {
 		ObjectAdmin.goToCustomObject(objectName = ${objectName});
 
-		Click(
-			key_entry = ${objectEntryId},
-			locator1 = "ObjectPortlet#ENTRY_VALUE");
+		Click(locator1 = "xpath=//tbody//a[contains(@href,'externalReferenceCode=${externalReferenceCode}')]");
 
 		var filePath = TestCase.getDependenciesDirPath(fileName = ${fileName});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99983

## Failing Test

`SupportImportObjectEntriesAtInstanceLevel#CanCreateObjectEntryFromFileContainingExistingAndNewWithUncheckedStopImportOnError`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesAtInstanceLevel#CanUpdateObjectEntry`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesAtInstanceLevel#CannotCreateObjectEntryWithoutRequiredFields`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesAtInstanceLevel#CanCreateAndUpdateExistingObjectEntriesWithSameFile`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesWithSiteScope#CanSeeScopeSelecterInImportFile`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesWithSiteScope#CanCreateAndUpdateExistingSiteScopedObjectEntriesWithSameFile`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesWithSiteScope#CanUpdateSiteScopedObjectEntry`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Failing Test

`SupportImportObjectEntriesWithSiteScope#CannotCreateSiteScopedObjectEntryWithoutRequiredFields`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//input[contains(@id,'file') or contains(@id,'File')][@type='file'] | //input[@type='file']"
```

## Root Cause

Commit `fcdd0d0` ("LPD-99391 Fix empty form label on FDS selectable-table row checkbox") is a legitimate accessibility fix, not a regression: it gives the Object Entries admin table's row-selection checkbox a real `sr-only` text label, where it previously carried only an `aria-label` with no text node at all. That change exposed a pre-existing, unrelated bug in the Poshi macro `ObjectAdmin.selectAttachmentFileInObjectEntryViaUI`: both affected `.testcase` files called it with a `key_entry` argument the macro never declared (it declared `objectEntryId` instead), so the value was always null. The macro's `Click` resolved the generic `ObjectPortlet#ENTRY_VALUE` locator (`//tbody//*[contains(text(),'${key_entry}')]`) with that empty key, which trivially matches the first text-bearing element in the row. Before `fcdd0d0`, that first match was harmlessly the entry's own title text. After `fcdd0d0`, the checkbox's new label is itself a match and sits earlier in the row's DOM than the entry title, so the click now toggles the checkbox instead of opening the entry, and the later step trying to upload a file into the never-reached edit form fails with an element-not-found error.

## Fix

`ObjectAdmin.selectAttachmentFileInObjectEntryViaUI` now clicks the entry's title link directly, matched by its `href`, which carries the entry's `externalReferenceCode` and cannot collide with the checkbox column regardless of row content or DOM order.

- `modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro`
- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase`
- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

## Also Fixed

### Failing Test

`SupportImportObjectEntriesWithSiteScope#CanSeeScopeSelecterInImportFile`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
java.lang.Exception: Actual text "Global Liferay DXP Site" does not match pattern "(?iu)Global Liferay DXP" at "//div[label[contains(.,'Scope')]]/select"
```

## Failing Test

`SupportImportObjectEntriesWithSiteScope#CanCreateAndUpdateExistingSiteScopedObjectEntriesWithSameFile`

`SupportImportObjectEntriesWithSiteScope#CannotCreateSiteScopedObjectEntryWithoutRequiredFields`

`SupportImportObjectEntriesWithSiteScope#CanUpdateSiteScopedObjectEntry`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

```
org.openqa.selenium.NoSuchElementException: Cannot locate option with text: Liferay DXP
```

### Root Cause

Once the checkbox-collision fix let these tests reach their own assertions, they hit a second, unrelated issue: the test asserted the Scope dropdown reads `"Global " + TestCase.getSiteName()`, which hardcodes `"Liferay DXP"` for the default company outside virtual-instance runs. The dropdown actually reads `"Global Liferay DXP Site"` in this environment. The same hardcoded value also breaks the site-scoped import flow: `ImportExport.configureImport` selects the current site's option in that same dropdown by calling `Select` with the literal `"Liferay DXP"` text, which throws `Cannot locate option with text: Liferay DXP` for the three site-scoped import tests above (confirmed these are the only other Poshi tests in the repo that reach this code path). Commit `f49db17` ("LPD-92468 Test fix") already moved the Staging test suite away from relying on that same hardcoded `"Liferay DXP"` site name for the same reason.

### Fix

Rather than touching the shared `getSiteName` fallback — used by roughly 70 other tests — this overrides the value at both call sites to match the environment's actual site name.

- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro`
- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

## PR Check

**pr-check: PASS** — tested on `8d1d7867395ee248d3bc5627d5b91a9a58fdbfa2`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "8d1d7867395ee248d3bc5627d5b91a9a58fdbfa2"} -->

