### PR TITLE
LPD-42559 Require a related entry for a mandatory relationship field

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -3277,6 +3277,48 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testAddObjectEntryWithRequiredRelationshipObjectField()
+		throws Exception {
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			_objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipFieldName);
+
+		_objectFieldLocalService.updateRequired(
+			objectField.getObjectFieldId(), true);
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field \"" +
+				_objectRelationshipFieldName + "\"",
+			() -> _addObjectEntry(
+				_objectDefinition2,
+				HashMapBuilder.<String, Object>put(
+					_objectRelationshipFieldName, 0
+				).build()));
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Object>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Object>put(
+				_objectRelationshipFieldName, objectEntry1.getId()
+			).build());
+
+		Assert.assertEquals(
+			GetterUtil.getLong(objectEntry1.getId()),
+			GetterUtil.getLong(
+				objectEntry2.getProperties(
+				).get(
+					_objectRelationshipFieldName
+				)));
+	}
+
+	@Test
 	public void testAddObjectEntryWithRichTextObjectField() throws Exception {
 		ObjectDefinition objectDefinition = _addObjectDefinition(
 			Collections.singletonList(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -3291,10 +3291,26 @@ public class DefaultObjectEntryManagerImplTest
 			ObjectEntryValuesException.Required.class,
 			"No value was provided for required object field \"" +
 				_objectRelationshipFieldName + "\"",
+			() -> _addObjectEntry(_objectDefinition2, new HashMap<>()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field \"" +
+				_objectRelationshipFieldName + "\"",
 			() -> _addObjectEntry(
 				_objectDefinition2,
 				HashMapBuilder.<String, Object>put(
 					_objectRelationshipFieldName, 0
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field \"" +
+				_objectRelationshipFieldName + "\"",
+			() -> _addObjectEntry(
+				_objectDefinition2,
+				HashMapBuilder.<String, Object>put(
+					_objectRelationshipFieldName, 0L
 				).build()));
 
 		ObjectEntry objectEntry1 = _addObjectEntry(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -174,12 +174,20 @@ public class RelationshipObjectFieldBusinessType
 			Object value = valueEntry.getValue();
 
 			if (value == null) {
+				if (objectField.isRequired()) {
+					return null;
+				}
+
 				return 0;
 			}
 
 			long valueLong = GetterUtil.getLong(value);
 
 			if (valueLong == 0) {
+				if (objectField.isRequired()) {
+					return null;
+				}
+
 				return value;
 			}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -171,24 +171,10 @@ public class RelationshipObjectFieldBusinessType
 			values, objectField.getName());
 
 		if (valueEntry != null) {
-			Object value = valueEntry.getValue();
-
-			if (value == null) {
-				if (objectField.isRequired()) {
-					return null;
-				}
-
-				return 0;
-			}
-
-			long valueLong = GetterUtil.getLong(value);
+			long valueLong = GetterUtil.getLong(valueEntry.getValue());
 
 			if (valueLong == 0) {
-				if (objectField.isRequired()) {
-					return null;
-				}
-
-				return value;
+				return valueLong;
 			}
 
 			ObjectDefinition objectDefinition = _getObjectDefinition(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42559

Supersedes https://github.com/liferay-headless/liferay-portal/pull/4065.

## What Is Being Fixed

A required many-to-one relationship field accepted a foreign key value of 0 (no related entry selected) instead of raising the expected validation error, so a mandatory relationship could be saved without a related entry.

## How It Is Being Fixed

The required-field check in the object service relies on Validator.isNull, which treats 0 as empty only when the value is a java.lang.Long. A relationship foreign key arriving from JSON is deserialized by Jackson as an Integer (or BigDecimal), so a zero foreign key was considered provided and the mandatory relationship went unvalidated.

RelationshipObjectFieldBusinessType.getValue now normalizes the incoming foreign key with GetterUtil.getLong and always returns a Long, so a missing, null, or zero foreign key uniformly resolves to 0 and the existing required-value check rejects it for mandatory fields. No isRequired special casing is needed: non-required fields keep accepting 0 to clear the relationship, and the deferred-linking flow (LPD-49175), where the many-side entry is created first with foreign key 0 and linked to a newly created parent afterwards, keeps working because 0 still flows through unchanged.

The change is covered by an integration test in DefaultObjectEntryManagerImplTest that exercises the missing field, the Integer 0, and the Long 0 cases, and verifies that a valid related entry is still accepted.

## PR Check

**pr-check: PASS** — tested on `8b0bc7fe534dc6b7dd4c5797d53baf84a78eabc3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8b0bc7fe534dc6b7dd4c5797d53baf84a78eabc3"} -->

