### PR TITLE
LPD-100204 Fix prompts.spec.ts failures on clean portals

### DIFF
--- a/modules/test/playwright/pages/mcp-server-web/PromptsPage.ts
+++ b/modules/test/playwright/pages/mcp-server-web/PromptsPage.ts
@@ -20,9 +20,7 @@ export class PromptsPage extends FDSTablePage {
 	constructor(page: Page) {
 		super(page);
 
-		this.newPromptButton = page.getByRole('button', {
-			name: 'New Prompt',
-		});
+		this.newPromptButton = page.getByLabel('New Prompt');
 	}
 
 	async goto() {

--- a/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
@@ -156,7 +156,7 @@ test.describe('Prompts - List View', () => {
 			await expect(promptsPage.dialog).toBeVisible();
 			await expect(promptsPage.dialog).toContainText('Delete MCP Prompt');
 			await expect(promptsPage.dialog).toContainText(
-				`This will permanently delete "${name}" prompt from your MCP Server configuration.`
+				`This will permanently delete "${name}" prompt from your MCP server configuration.`
 			);
 			await expect(promptsPage.dialog).toContainText(
 				'Do you want to proceed?'

--- a/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
@@ -9,7 +9,6 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {mcpServerWebPagesTest} from '../../../fixtures/mcpServerWebPagesTest';
-import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {FDSTablePage} from '../../../pages/mcp-server-web/FDSTablePage';
 import getRandomString from '../../../utils/getRandomString';
 import {createFDSTableTests} from './utils/createFDSTableTests';
@@ -30,28 +29,6 @@ function promptName() {
 	return `pwprompt-${getRandomString()}`;
 }
 
-async function createPrompt(
-	apiHelpers: DataApiHelpers,
-	name: string
-): Promise<ObjectEntry> {
-	const prompt = await apiHelpers.objectEntry.postObjectEntry(
-		{
-			description: `Created by Playwright ${name}`,
-			name,
-			prompt: 'Prompt body created by Playwright',
-		},
-		PROMPTS_API
-	);
-
-	apiHelpers.data.push({
-		applicationName: PROMPTS_API,
-		id: prompt.id,
-		type: 'objectEntry',
-	});
-
-	return prompt;
-}
-
 const test = baseTest.extend<{
 	createFDSItem: () => Promise<string>;
 	fdsTablePage: FDSTablePage;
@@ -60,7 +37,20 @@ const test = baseTest.extend<{
 		await use(async () => {
 			const name = promptName();
 
-			await createPrompt(apiHelpers, name);
+			const prompt = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					description: `Created by Playwright ${name}`,
+					name,
+					prompt: 'Prompt body created by Playwright',
+				},
+				PROMPTS_API
+			);
+
+			apiHelpers.data.push({
+				applicationName: PROMPTS_API,
+				id: prompt.id,
+				type: 'objectEntry',
+			});
 
 			return name;
 		});
@@ -81,9 +71,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Opens a prompt in edit when clicking its name',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -98,9 +87,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Edits a prompt from the three-dot menu',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -115,9 +103,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Duplicates a prompt into a Copy of prompt from the three-dot menu',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({apiHelpers, createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -144,9 +131,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Asks for confirmation with the prompt name before deleting',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -167,9 +153,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Keeps the prompt when the delete confirmation is cancelled',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -188,9 +173,8 @@ test.describe('Prompts - List View', () => {
 	test(
 		'Deletes a prompt after confirming in the modal',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -291,9 +275,8 @@ test.describe('Prompts - Detail (Create / Edit)', () => {
 	test(
 		'Edits a prompt and persists the change',
 		{tag: '@LPD-98309'},
-		async ({apiHelpers, promptsPage}) => {
-			const name = promptName();
-			await createPrompt(apiHelpers, name);
+		async ({apiHelpers, createFDSItem, promptsPage}) => {
+			const name = await createFDSItem();
 
 			await promptsPage.goto();
 			await promptsPage.search(name);
@@ -322,7 +305,7 @@ test.describe('Prompts - Detail (Create / Edit)', () => {
 
 			await promptsPage.cancelButton.click();
 
-			await promptsPage.table.waitFor({state: 'visible'});
+			await promptsPage.waitForTable();
 			await expect(promptsPage.newPromptButton).toBeVisible();
 		}
 	);

--- a/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
@@ -209,6 +209,10 @@ test.describe('Prompts - List View', () => {
 });
 
 test.describe('Prompts - Detail (Create / Edit)', () => {
+	test.beforeEach(async ({createFDSItem}) => {
+		await createFDSItem();
+	});
+
 	test(
 		'Creates a prompt from the New Prompt button',
 		{tag: '@LPD-98309'},


### PR DESCRIPTION
# Issue: [LPD-100204](https://liferay.atlassian.net/browse/LPD-100204)

> [!NOTE]
> **Feature flags** — the Prompts UI under test is behind feature flags (the specs enable them per test through `featureFlagsTest`). To exercise it manually, enable:
> - **`LPD-89575`** (dev) — the MCP Server control panel entry / UI.
> - **`LPD-63311`** (beta) — the MCP backend (system object definitions and the `/o/mcp/*` APIs the UI consumes).

Five Playwright tests in `mcp-server-web/main/prompts.spec.ts` fail on clean CI portals (routine `[master] ci:test:headless`, build #342, Analysis Task 504094405, subtasks ST-34 to ST-38) after LPD-98309 was merged. Two root causes:

1. The delete-modal assertion expects "MCP Server configuration" while the rendered copy is "MCP server configuration"; `toContainText` is case sensitive (ST-34).
2. Clean portals provision no MCP prompts, so the list renders the FDS empty state; the detail tests navigated without seeding data and `waitForTable` timed out waiting for `.fds .table` (ST-35 to ST-38).

One commit per concern:

- **Match the reworded delete confirmation copy** — updates the assertion to the current copy.
- **Seed a prompt before the detail tests** — a `beforeEach` seeds one prompt through the existing `createFDSItem` fixture so the table always renders, and `newPromptButton` is targeted by its aria-label because the empty state renders a second creation button.
- **Create prompts through the createFDSItem fixture** — removes the duplicated module-level helper so the fixture is the single creation path.

Validated locally against a clean portal (empty prompts list, the CI condition): 16/16 `prompts.spec.ts` and 22/22 `dataMasks.spec.ts` with `--workers=1`, and no leftover data.
