### PR TITLE
LPD-91936 Fix object definition navigation on virtual instances

### DIFF
--- a/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
@@ -217,8 +217,13 @@ export class GlobalMenuPage {
 		}
 	}
 
-	async goToObjectDefinition(menuItem: string) {
-		await this.goToHome();
+	async goToObjectDefinition(menuItem: string, siteURL?: string) {
+		if (siteURL) {
+			await this.page.goto(siteURL);
+		}
+		else {
+			await this.goToHome();
+		}
 
 		await this.goTo('Control Panel');
 

--- a/modules/test/playwright/tests/export-import-web/main/portlet.exportImport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/portlet.exportImport.spec.ts
@@ -138,11 +138,10 @@ test('Can import object with different classname via portlet', async ({
 	});
 
 	await test.step('Import Object Entry into Virtual Instance & Verify', async () => {
-		await page.goto(
+		await globalMenuPage.goToObjectDefinition(
+			objectDefinition.name,
 			`http://www.able.com:${liferayConfig.environment.port}`
 		);
-
-		await globalMenuPage.goToObjectDefinition(objectDefinition.name);
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91936

## What Is Being Fixed

The Export/Import Playwright test "Can import object with different classname via portlet" creates a fresh virtual instance and navigates there, but its "Import Object Entry into Virtual Instance & Verify" step silently ran against the default instance instead. The UI actions (via GlobalMenuPage.goToObjectDefinition) reported success, while the REST-based entry count check correctly queried the virtual instance and saw 0 — a false failure with no actual product regression.

## How It Is Being Fixed

GlobalMenuPage.goToObjectDefinition() always routed through goToHome(), which navigates to the default instance's home page (liferayConfig.environment.baseUrl) regardless of the page's current host. This silently discarded the test's earlier navigation to the newly created virtual instance. The method now accepts an optional siteURL parameter; when provided, it navigates there directly instead of forcing the return to the default instance. The test's affected call site now passes the virtual instance's URL. The other three call sites in the same spec are unaffected, since they don't pass the new parameter and fall through to the original behavior unchanged.

## PR Check

**pr-check: PASS** — tested on `14efa7a45650927fa6bef359b577dce17112c052`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "14efa7a45650927fa6bef359b577dce17112c052"} -->
