### PR TITLE
LPD-100530 Restore the embedded payload on the bulk action preview

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -99,6 +99,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -369,8 +370,10 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			null, true, null, null, search, filter, pagination,
 			new Sort[] {sort});
 
+		Collection<SearchResult> searchResults = searchPage.getItems();
+
 		List<BulkActionItem> bulkActionItems = transform(
-			searchPage.getItems(),
+			searchResults,
 			searchResult -> {
 				JSONObject jsonObject = _jsonFactory.createJSONObject(
 					String.valueOf(searchResult.getEmbedded()));
@@ -382,7 +385,11 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			bulkActionItems = _sortBulkActionItems(bulkActionItems, sort);
 		}
 
-		return Page.of(bulkActionItems, pagination, searchPage.getTotalCount());
+		int unresolvedCount = searchResults.size() - bulkActionItems.size();
+
+		return Page.of(
+			bulkActionItems, pagination,
+			searchPage.getTotalCount() - unresolvedCount);
 	}
 
 	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
@@ -394,20 +401,16 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			bulkActionItem -> _toBulkActionItem(
 				GetterUtil.getLong(bulkActionItem.getClassPK())));
 
-		long totalCount = bulkActionItems1.size();
-
 		if (Validator.isNotNull(search)) {
 			bulkActionItems2 = ListUtil.filter(
 				bulkActionItems2,
 				bulkActionItem -> StringUtil.containsIgnoreCase(
 					bulkActionItem.getName(), search, StringPool.BLANK));
-
-			totalCount = bulkActionItems2.size();
 		}
 
 		return Page.of(
 			_sortBulkActionItems(bulkActionItems2, sort), pagination,
-			totalCount);
+			bulkActionItems2.size());
 	}
 
 	private BulkSelectionAction<Object> _getBulkSelectionAction(
@@ -1037,8 +1040,14 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			return _toBulkActionItem(objectEntry);
 		}
 
-		return _toBulkActionItem(
-			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK));
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK);
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		return _toBulkActionItem(objectEntryFolder);
 	}
 
 	private BulkActionItem _toBulkActionItem(ObjectEntry objectEntry) {

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BulkActionResourceTest.java
@@ -195,6 +195,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 	public void testPostBulkActionItemPreviewPage() throws Exception {
 		_testPostBulkActionItemPreviewPage(_depotEntry1, "RECYCLE_BIN");
 		_testPostBulkActionItemPreviewPage(_depotEntry2, "PERMANENT_DELETION");
+		_testPostBulkActionItemPreviewPageWithNonexistentClassPK();
 	}
 
 	private DepotEntry _addDepotEntry(boolean trashEnabled) throws Exception {
@@ -669,6 +670,41 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			items2.get(1), objectEntryFolder2.getObjectEntryFolderId(),
 			expectedDeletionType, 0L, null, objectEntryFolder2.getName(),
 			"FOLDER", null);
+	}
+
+	private void _testPostBulkActionItemPreviewPageWithNonexistentClassPK()
+		throws Exception {
+
+		BulkAction bulkAction = new DeleteObjectBulkSelectionAction();
+
+		bulkAction.setBulkActionItems(
+			new BulkActionItem[] {
+				new BulkActionItem() {
+					{
+						setClassName(
+							_cmsBasicWebContentObjectDefinition.getClassName());
+						setClassPK(RandomTestUtil.randomLong());
+					}
+				}
+			});
+		bulkAction.setType(BulkAction.Type.DELETE_OBJECT_BULK_SELECTION_ACTION);
+
+		SelectionScope selectionScope = new SelectionScope();
+
+		selectionScope.setSelectAll(false);
+
+		bulkAction.setSelectionScope(selectionScope);
+
+		Page<BulkActionItem> page =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				false, null, null, Pagination.of(1, 10), "name:desc",
+				bulkAction);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 0, items.size());
 	}
 
 	private void _testPostBulkActionItemPreviewPageWithSelectAllAndFilter(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
@@ -92,11 +92,17 @@ public class NestedFieldsSupplier<T> {
 			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 
 		if (oldNestedFieldsContext == null) {
-			return () -> null;
+			return unsafeSupplier;
 		}
 
 		NestedFieldsContext nestedFieldsContext = _createNestedFieldsContext(
 			nestedField, oldNestedFieldsContext);
+
+		List<String> nestedFields = nestedFieldsContext.getNestedFields();
+
+		if (!nestedFields.contains(nestedField)) {
+			nestedFieldsContext.addNestedField(nestedField);
+		}
 
 		return () -> {
 			try (SafeCloseable safeCloseable =

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngin
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LongWrapper;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity;
@@ -364,39 +365,49 @@ public class BatchTestEntityResourceImpl
 							return customField;
 						},
 						CustomField.class));
-				setEmbeddedNestedField(
-					NestedFieldsSupplier.supplyScopedUnsafeSupplier(
-						"embeddedNestedField",
-						() -> {
-							VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-								_vulcanCRUDItemDelegateBuilderRegistry.builder(
-									contextCompany,
-									BatchTestEntity.class.getName()
-								).acceptLanguage(
-									contextAcceptLanguage
-								).groupLocalService(
-									groupLocalService
-								).httpServletRequest(
-									contextHttpServletRequest
-								).httpServletResponse(
-									contextHttpServletResponse
-								).resourceActionLocalService(
-									resourceActionLocalService
-								).resourcePermissionLocalService(
-									resourcePermissionLocalService
-								).roleLocalService(
-									roleLocalService
-								).scopeChecker(
-									contextScopeChecker
-								).uriInfo(
-									contextUriInfo
-								).user(
-									contextUser
-								).build();
 
-							return vulcanCRUDItemDelegate.fetchItem(
-								originalBatchTestEntity.getId());
-						}));
+				if ((contextHttpServletRequest != null) &&
+					StringUtil.contains(
+						ParamUtil.getString(
+							contextHttpServletRequest, "nestedFields"),
+						"embeddedNestedField")) {
+
+					setEmbeddedNestedField(
+						NestedFieldsSupplier.supplyScopedUnsafeSupplier(
+							"embeddedNestedField",
+							() -> {
+								VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+									_vulcanCRUDItemDelegateBuilderRegistry.
+										builder(
+											contextCompany,
+											BatchTestEntity.class.getName()
+										).acceptLanguage(
+											contextAcceptLanguage
+										).groupLocalService(
+											groupLocalService
+										).httpServletRequest(
+											contextHttpServletRequest
+										).httpServletResponse(
+											contextHttpServletResponse
+										).resourceActionLocalService(
+											resourceActionLocalService
+										).resourcePermissionLocalService(
+											resourcePermissionLocalService
+										).roleLocalService(
+											roleLocalService
+										).scopeChecker(
+											contextScopeChecker
+										).uriInfo(
+											contextUriInfo
+										).user(
+											contextUser
+										).build();
+
+								return vulcanCRUDItemDelegate.fetchItem(
+									originalBatchTestEntity.getId());
+							}));
+				}
+
 				setExternalReferenceCode(
 					originalBatchTestEntity.getExternalReferenceCode());
 				setId(originalBatchTestEntity.getId());

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.BatchTestEntity;
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.BatchTestEntityResource;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
@@ -29,6 +30,7 @@ import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -112,6 +114,63 @@ public class BatchTestEntityResourceTest
 			JSONUtil.getValueAsString(
 				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
 				"Object/nestedField2"));
+
+		try (SafeCloseable safeCloseable =
+				NestedFieldsContextThreadLocal.
+					setNestedFieldsContextWithSafeCloseable(
+						new NestedFieldsContext(
+							1, Collections.emptyList(), "v1.0"))) {
+
+			BatchTestEntityResource batchTestEntityResource1 =
+				_batchTestEntityResourceFactory.create(
+				).httpServletRequest(
+					new MockHttpServletRequest()
+				).httpServletResponse(
+					new MockHttpServletResponse()
+				).uriInfo(
+					testVulcanCRUDItemDelegate_getUriInfo()
+				).user(
+					testVulcanCRUDItemDelegate_getUser()
+				).build();
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity1 = batchTestEntityResource1.getBatchTestEntity(
+					postBatchTestEntity.getId());
+
+			Assert.assertNull(batchTestEntity1.getEmbeddedNestedField());
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.setParameter(
+				"nestedFields", "embeddedNestedField");
+
+			BatchTestEntityResource batchTestEntityResource2 =
+				_batchTestEntityResourceFactory.create(
+				).httpServletRequest(
+					mockHttpServletRequest
+				).httpServletResponse(
+					new MockHttpServletResponse()
+				).uriInfo(
+					testVulcanCRUDItemDelegate_getUriInfo()
+				).user(
+					testVulcanCRUDItemDelegate_getUser()
+				).build();
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity2 = batchTestEntityResource2.getBatchTestEntity(
+					postBatchTestEntity.getId());
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				embeddedBatchTestEntity =
+					(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+						BatchTestEntity)
+							batchTestEntity2.getEmbeddedNestedField();
+
+			Assert.assertEquals(
+				postBatchTestEntity.getName(),
+				embeddedBatchTestEntity.getName());
+		}
 	}
 
 	@Override
@@ -314,6 +373,9 @@ public class BatchTestEntityResourceTest
 				batchTestEntityId, "?", queryString),
 			Http.Method.GET);
 	}
+
+	@Inject
+	private BatchTestEntityResource.Factory _batchTestEntityResourceFactory;
 
 	@Inject
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100530

## What Is Being Fixed

The bulk action preview resolves each item from the embedded payload that the search REST API attaches to every result. LPD-96726 started supplying that payload through NestedFieldsSupplier.supplyScopedUnsafeSupplier, which computes it only when the nested fields context lists the field. That context is populated by NestedFieldsContainerRequestFilter from the HTTP request that entered the JAX-RS layer, so when the preview invokes the search resource in process the context still reflects the bulk request, which never asks for the embedded field. Every item resolved to nothing and the preview came back empty.

## How It Is Being Fixed

supplyScopedUnsafeSupplier bundled two decisions together, scoping the nested fields that apply inside the payload and gating on the nested fields context listing the field. A resource already decides whether to attach the payload from the nestedFields parameter on its own request, so the second gate duplicated that decision against a different source and vetoed it for every in process caller. The method now adds the nested field to the context it derives for the payload, so the scoping introduced by LPD-96726 is preserved while the decision stays with the resource, and it evaluates the supplier directly when there is no context at all.

The rest-builder test bed resource had no gate of its own and relied on the removed gating, so it grows the same check the search resource makes. The bulk action preview drops its addNestedField call, which mutated state belonging to the whole request and was read back when the response was serialized.

## PR Check

**pr-check: PASS** — tested on `2c95933175bde90e86974de17929a35fe781bf3a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2c95933175bde90e86974de17929a35fe781bf3a"} -->
