### PR TITLE
LPD-101195 Cover the selective import and delete two legacy tests

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -50,15 +50,17 @@ export default function DataSelectionStep({
 				)}
 			</ClayLayout.Sheet>
 
-			<FormikFieldContentSelector
-				commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-				lookAndFeelEnabled={lookAndFeelEnabled}
-				name="contentSelection"
-				previewPortletDataHandlerSections={
-					importPreview.previewPortletDataHandlerSections
-				}
-				process="import"
-			/>
+			<div data-testid="data-selection-section">
+				<FormikFieldContentSelector
+					commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+					lookAndFeelEnabled={lookAndFeelEnabled}
+					name="contentSelection"
+					previewPortletDataHandlerSections={
+						importPreview.previewPortletDataHandlerSections
+					}
+					process="import"
+				/>
+			</div>
 		</>
 	);
 }

--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -16,12 +16,7 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../../fixtures/pageTemplatesPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
-import {getRandomInt} from '../../../utils/getRandomInt';
 import {normalizeRestPath} from '../../../utils/normalizeRestPath';
-import performLogin, {
-	performLogout,
-	userData,
-} from '../../../utils/performLogin';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
 import {portletExportImportPageTest} from './fixtures/portletExportImportPageTest';
@@ -102,102 +97,3 @@ test('Can see corresponding elements at instance level', async ({
 
 	await expect(page.getByText('Copy as New:')).not.toBeVisible();
 });
-
-test(
-	'Can/not view Import menu item in Application menu depending on permissions',
-	{tag: '@LPD-99799'},
-	async ({apiHelpers, exportImportPage, globalMenuPage, page}) => {
-		const companyId = await page.evaluate(() => {
-			return Liferay.ThemeDisplay.getCompanyId();
-		});
-
-		const roleWithPermissions = await apiHelpers.headlessAdminUser.postRole(
-			{
-				name: 'role' + getRandomInt(),
-				rolePermissions: [
-					{
-						actionIds: ['VIEW_CONTROL_PANEL'],
-						primaryKey: companyId,
-						resourceName: '90',
-						scope: 1,
-					},
-					{
-						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
-						primaryKey: companyId,
-						resourceName:
-							'com_liferay_exportimport_web_portlet_CompanyImportPortlet',
-						scope: 1,
-					},
-				],
-			}
-		);
-
-		const roleWithoutPermissions =
-			await apiHelpers.headlessAdminUser.postRole({
-				name: 'role' + getRandomInt(),
-				rolePermissions: [
-					{
-						actionIds: ['VIEW_CONTROL_PANEL'],
-						primaryKey: companyId,
-						resourceName: '90',
-						scope: 1,
-					},
-				],
-			});
-
-		const user1 = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		userData[user1.alternateName] = {
-			name: user1.givenName,
-			password: 'test',
-			surname: user1.familyName,
-		};
-
-		await apiHelpers.headlessAdminUser.assignUserToRole(
-			roleWithPermissions.externalReferenceCode,
-			user1.id
-		);
-
-		const user2 = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		userData[user2.alternateName] = {
-			name: user2.givenName,
-			password: 'test',
-			surname: user2.familyName,
-		};
-
-		await apiHelpers.headlessAdminUser.assignUserToRole(
-			roleWithoutPermissions.externalReferenceCode,
-			user2.id
-		);
-
-		await performLogout(page);
-
-		await performLogin(page, user1.alternateName);
-
-		await globalMenuPage.goToApplications();
-
-		const importMenuItem = page.getByRole('menuitem', {
-			exact: true,
-			name: 'Import',
-		});
-
-		const importUrl = await importMenuItem.getAttribute('href');
-
-		await expect(importMenuItem).toBeVisible();
-
-		await globalMenuPage.goToApplications('Import');
-
-		await expect(exportImportPage.newImportButton).toBeVisible();
-
-		await performLogout(page);
-
-		await performLogin(page, user2.alternateName);
-
-		await expect(globalMenuPage.globalMenuButton).toBeHidden();
-
-		await page.goto(importUrl);
-
-		await expect(exportImportPage.newImportButton).toBeHidden();
-	}
-);

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -217,18 +217,6 @@ test(
 	}
 );
 
-test('Can import a lar file selecting some items to import', async ({
-	exportImportPage,
-}) => {
-	await exportImportPage.goToExport();
-
-	const exportFilePath = await exportImportPage.export();
-
-	await exportImportPage.goToImport();
-
-	await exportImportPage.import({filePath: exportFilePath});
-});
-
 test('Can see corresponding elements at site level', async ({
 	apiHelpers,
 	exportImportPage,

--- a/modules/test/playwright/tests/export-import-web/revamp/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/revamp/pages/ExportImportPage.ts
@@ -283,14 +283,20 @@ export class ExportImportPage {
 		folderPath,
 		includeDeletions = false,
 		name,
+		selectData,
 		taskStatus = 'success',
 	}: {
 		folderPath: string;
 		includeDeletions?: boolean;
 		name: string;
+		selectData?: () => Promise<void>;
 		taskStatus?: taskStatus;
 	}) {
 		await this.goToImportDataSelection({folderPath, name});
+
+		if (selectData) {
+			await selectData();
+		}
 
 		if (includeDeletions) {
 			await this.replicateSelectedDeletionsCheckbox.check();

--- a/modules/test/playwright/tests/export-import-web/revamp/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/revamp/site.import.spec.ts
@@ -179,3 +179,55 @@ testWithWiki(
 		);
 	}
 );
+
+test(
+	'Can import a lar file selecting some of its content',
+	{tag: '@LPD-101195'},
+	async ({
+		apiHelpers,
+		exportImportDataSelectionPage,
+		exportImportPage,
+		site,
+	}) => {
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				scope: 'site',
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{},
+			`${normalizeRestPath(objectDefinition.restContextPath)}/scopes/${site.friendlyUrlPath.slice(1)}`
+		);
+
+		await exportImportPage.goToExport(site.friendlyUrlPath);
+
+		const name = `MyExport-${getRandomString()}`;
+
+		await exportImportPage.export(name);
+
+		await expect(exportImportPage.taskStatusLabel(name)).toBeVisible();
+
+		const folderPath = await exportImportPage.download(name);
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.newButton.click();
+
+		await exportImportPage.import({
+			folderPath,
+			name,
+			selectData: () =>
+				exportImportDataSelectionPage.selectOnlyObjectDefinition(
+					objectDefinition.name
+				),
+		});
+
+		await expect(exportImportPage.taskStatusLabel(name)).toBeVisible();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101195

## What Is Being Fixed

An audit of the legacy Playwright folder found tests still running in main/ that
the migration had treated as done. One of them turned out never to have been
migrated at all, although the tracker marked it as migrated.

That one is easy to misread: 'Can import a lar file selecting some items to
import' looks like a plain round trip, because the selection is hidden in the
legacy page object — its import() helper opens the Content Options dropdown and
clicks Comments and Ratings before importing. No revamp test covered a selective
import.

## How It Is Being Fixed

The selective import is now covered in revamp/site.import.spec.ts: it exports a
site scoped object definition, downloads the LAR, and imports it while picking a
subset in the import wizard's data selection step, asserting the process ends
Successful — the same final assertion the legacy test made. Its legacy
counterpart is deleted in the same commit.

Two page objects grew to make that possible. ExportImportPage.import() takes an
optional selectData callback that runs between the wizard's two Continue clicks,
so callers that do not pass it behave exactly as before. And
ExportImportDataSelectionPage worked only for the export flow: its locators are
anchored to the data-selection-section test id, which the import wizard does not
render. Its methods now take the process as an optional argument, defaulting to
export, and the class resolves the matching section internally.

The second deletion is a verified duplicate, with its successor named in the
commit: Can/not view Import menu item in Application menu depending on
permissions, whose four assertions match the revamp version except for a page
object rename. Deleting it also orphaned three imports (performLogin,
performLogout, userData), which are pruned.

The ticket's two remaining deletions, both in the import report specs, are
delivered by LPD-99982, so nothing is left open here.

## Why This Pull Request Carries LPD-99982

The first three commits belong to LPD-99982, already merged into
brianchandotcom/master. They are here as the base this branch was developed
against, because that pull request removes the same import report spec this
ticket touches. Review the last two commits.

## PR Check

**pr-check: PASS** — tested on `fcf264993835fd73b33291c7fc3ad49947f63339`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

The Playwright specs themselves are out of pr-check scope. The new test was run
in the browser against a live portal — 2/2 passing, plus a 10x flake check on the
new one, all green — on a tree whose only later change was a page object refactor
that resolves to the same locators.

<!-- pr-check {"result": "success", "sha": "fcf264993835fd73b33291c7fc3ad49947f63339"} -->
