### PR TITLE
LPD-101371 Restore the embedded payload for resources invoked in process

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -86,7 +86,6 @@ import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
-import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.Permission;
@@ -346,8 +345,6 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			contextHttpServletRequest);
 
 		dynamicServletRequest.setParameter("nestedFields", "embedded");
-
-		NestedFieldsSupplier.addNestedField("embedded");
 
 		SearchResultResource searchResultResource =
 			_searchResultResourceFactory.create(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
@@ -92,11 +92,17 @@ public class NestedFieldsSupplier<T> {
 			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 
 		if (oldNestedFieldsContext == null) {
-			return () -> null;
+			return unsafeSupplier;
 		}
 
 		NestedFieldsContext nestedFieldsContext = _createNestedFieldsContext(
 			nestedField, oldNestedFieldsContext);
+
+		List<String> nestedFields = nestedFieldsContext.getNestedFields();
+
+		if (!nestedFields.contains(nestedField)) {
+			nestedFieldsContext.addNestedField(nestedField);
+		}
 
 		return () -> {
 			try (SafeCloseable safeCloseable =

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngin
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LongWrapper;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity;
@@ -364,39 +365,49 @@ public class BatchTestEntityResourceImpl
 							return customField;
 						},
 						CustomField.class));
-				setEmbeddedNestedField(
-					NestedFieldsSupplier.supplyScopedUnsafeSupplier(
-						"embeddedNestedField",
-						() -> {
-							VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-								_vulcanCRUDItemDelegateBuilderRegistry.builder(
-									contextCompany,
-									BatchTestEntity.class.getName()
-								).acceptLanguage(
-									contextAcceptLanguage
-								).groupLocalService(
-									groupLocalService
-								).httpServletRequest(
-									contextHttpServletRequest
-								).httpServletResponse(
-									contextHttpServletResponse
-								).resourceActionLocalService(
-									resourceActionLocalService
-								).resourcePermissionLocalService(
-									resourcePermissionLocalService
-								).roleLocalService(
-									roleLocalService
-								).scopeChecker(
-									contextScopeChecker
-								).uriInfo(
-									contextUriInfo
-								).user(
-									contextUser
-								).build();
 
-							return vulcanCRUDItemDelegate.fetchItem(
-								originalBatchTestEntity.getId());
-						}));
+				if ((contextHttpServletRequest != null) &&
+					StringUtil.contains(
+						ParamUtil.getString(
+							contextHttpServletRequest, "nestedFields"),
+						"embeddedNestedField")) {
+
+					setEmbeddedNestedField(
+						NestedFieldsSupplier.supplyScopedUnsafeSupplier(
+							"embeddedNestedField",
+							() -> {
+								VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+									_vulcanCRUDItemDelegateBuilderRegistry.
+										builder(
+											contextCompany,
+											BatchTestEntity.class.getName()
+										).acceptLanguage(
+											contextAcceptLanguage
+										).groupLocalService(
+											groupLocalService
+										).httpServletRequest(
+											contextHttpServletRequest
+										).httpServletResponse(
+											contextHttpServletResponse
+										).resourceActionLocalService(
+											resourceActionLocalService
+										).resourcePermissionLocalService(
+											resourcePermissionLocalService
+										).roleLocalService(
+											roleLocalService
+										).scopeChecker(
+											contextScopeChecker
+										).uriInfo(
+											contextUriInfo
+										).user(
+											contextUser
+										).build();
+
+								return vulcanCRUDItemDelegate.fetchItem(
+									originalBatchTestEntity.getId());
+							}));
+				}
+
 				setExternalReferenceCode(
 					originalBatchTestEntity.getExternalReferenceCode());
 				setId(originalBatchTestEntity.getId());

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.BatchTestEntity;
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.BatchTestEntityResource;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
@@ -29,6 +30,7 @@ import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -112,6 +114,63 @@ public class BatchTestEntityResourceTest
 			JSONUtil.getValueAsString(
 				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
 				"Object/nestedField2"));
+
+		try (SafeCloseable safeCloseable =
+				NestedFieldsContextThreadLocal.
+					setNestedFieldsContextWithSafeCloseable(
+						new NestedFieldsContext(
+							1, Collections.emptyList(), "v1.0"))) {
+
+			BatchTestEntityResource batchTestEntityResource1 =
+				_batchTestEntityResourceFactory.create(
+				).httpServletRequest(
+					new MockHttpServletRequest()
+				).httpServletResponse(
+					new MockHttpServletResponse()
+				).uriInfo(
+					testVulcanCRUDItemDelegate_getUriInfo()
+				).user(
+					testVulcanCRUDItemDelegate_getUser()
+				).build();
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity1 = batchTestEntityResource1.getBatchTestEntity(
+					postBatchTestEntity.getId());
+
+			Assert.assertNull(batchTestEntity1.getEmbeddedNestedField());
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.setParameter(
+				"nestedFields", "embeddedNestedField");
+
+			BatchTestEntityResource batchTestEntityResource2 =
+				_batchTestEntityResourceFactory.create(
+				).httpServletRequest(
+					mockHttpServletRequest
+				).httpServletResponse(
+					new MockHttpServletResponse()
+				).uriInfo(
+					testVulcanCRUDItemDelegate_getUriInfo()
+				).user(
+					testVulcanCRUDItemDelegate_getUser()
+				).build();
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity2 = batchTestEntityResource2.getBatchTestEntity(
+					postBatchTestEntity.getId());
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				embeddedBatchTestEntity =
+					(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+						BatchTestEntity)
+							batchTestEntity2.getEmbeddedNestedField();
+
+			Assert.assertEquals(
+				postBatchTestEntity.getName(),
+				embeddedBatchTestEntity.getName());
+		}
 	}
 
 	@Override
@@ -314,6 +373,9 @@ public class BatchTestEntityResourceTest
 				batchTestEntityId, "?", queryString),
 			Http.Method.GET);
 	}
+
+	@Inject
+	private BatchTestEntityResource.Factory _batchTestEntityResourceFactory;
 
 	@Inject
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101371

## What Is Being Fixed

The bulk action preview resolves each item from the embedded payload that the search REST API attaches to every result. LPD-96726 started supplying that payload through NestedFieldsSupplier.supplyScopedUnsafeSupplier, which computes it only when the nested fields context lists the field. That context is populated by NestedFieldsContainerRequestFilter from the HTTP request that entered the JAX-RS layer, so when the preview invokes the search resource in process the context still reflects the bulk request, which never asks for the embedded field. Every item resolved to nothing and the preview came back empty.

This was originally reported as LPD-100530, which is closed, so the work is tracked here instead.

## How It Is Being Fixed

supplyScopedUnsafeSupplier bundled two decisions together, scoping the nested fields that apply inside the payload and gating on the nested fields context listing the field. A resource already decides whether to attach the payload from the nestedFields parameter on its own request, so the second gate duplicated that decision against a different source and vetoed it for every in process caller. The method now adds the nested field to the context it derives for the payload, so the scoping introduced by LPD-96726 is preserved while the decision stays with the resource, and it evaluates the supplier directly when there is no context at all.

The rest-builder test bed resource had no gate of its own and relied on the removed gating, so it grows the same check the search resource makes. The bulk action preview drops its addNestedField call, which mutated state belonging to the whole request and was read back when the response was serialized.

## PR Check

**pr-check: PASS** — tested on `acf09587125163d2bc6aab2d64e796f07a4bf994`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "acf09587125163d2bc6aab2d64e796f07a4bf994"} -->

