### PR TITLE
LPD-101137 Compare the blob read back from the database

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
@@ -689,4 +689,4 @@ public class AccountEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2069400825
+// LIFERAY-SERVICE-BUILDER-HASH:1421274829

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
@@ -623,4 +623,4 @@ public class AccountGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1463035009
+// LIFERAY-SERVICE-BUILDER-HASH:433306853

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
@@ -548,4 +548,4 @@ public class AccountRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:351597970
+// LIFERAY-SERVICE-BUILDER-HASH:1447211096

--- a/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
+++ b/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
@@ -645,4 +645,4 @@ public class AssetCategoryPropertyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:23396136
+// LIFERAY-SERVICE-BUILDER-HASH:-2035078418

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
@@ -803,4 +803,4 @@ public class AssetListEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1340684435
+// LIFERAY-SERVICE-BUILDER-HASH:2108673667

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
@@ -554,4 +554,4 @@ public class AudiencesEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1727085347
+// LIFERAY-SERVICE-BUILDER-HASH:1331802761

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -962,4 +962,4 @@ public class BlogsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1100644895
+// LIFERAY-SERVICE-BUILDER-HASH:1326341773

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
@@ -834,4 +834,4 @@ public class CalendarBookingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:380495095
+// LIFERAY-SERVICE-BUILDER-HASH:934884845

--- a/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
@@ -167,7 +167,7 @@ public class CTSContentPersistenceTest {
 		Blob existingData = existingCTSContent.getData();
 
 		Assert.assertArrayEquals(
-			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
+			newDataBytes, existingData.getBytes(1, (int)existingData.length()));
 		Assert.assertEquals(
 			existingCTSContent.getSize(), newCTSContent.getSize());
 		Assert.assertEquals(
@@ -578,4 +578,4 @@ public class CTSContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1473486047
+// LIFERAY-SERVICE-BUILDER-HASH:826348001

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
@@ -637,4 +637,4 @@ public class CTCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-359539616
+// LIFERAY-SERVICE-BUILDER-HASH:779748222

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
@@ -618,4 +618,4 @@ public class CTEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-133881066
+// LIFERAY-SERVICE-BUILDER-HASH:-1127359020

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
@@ -691,4 +691,4 @@ public class ClientExtensionEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1423701461
+// LIFERAY-SERVICE-BUILDER-HASH:-1087557097

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
@@ -725,4 +725,4 @@ public class ClientExtensionEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:399679866
+// LIFERAY-SERVICE-BUILDER-HASH:-660424252

--- a/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
+++ b/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
@@ -706,4 +706,4 @@ public class CommerceCurrencyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1525736261
+// LIFERAY-SERVICE-BUILDER-HASH:1955398181

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
@@ -815,4 +815,4 @@ public class CommerceDiscountPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-539636407
+// LIFERAY-SERVICE-BUILDER-HASH:1183361289

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
@@ -758,4 +758,4 @@ public class CommerceInventoryReplenishmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1964170772
+// LIFERAY-SERVICE-BUILDER-HASH:1352631320

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
@@ -731,4 +731,4 @@ public class CommerceInventoryWarehouseItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:316791305
+// LIFERAY-SERVICE-BUILDER-HASH:264505187

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
@@ -756,4 +756,4 @@ public class CommerceInventoryWarehousePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1636296815
+// LIFERAY-SERVICE-BUILDER-HASH:48017621

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
@@ -665,4 +665,4 @@ public class COREntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-796077067
+// LIFERAY-SERVICE-BUILDER-HASH:-1055645291

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
@@ -749,4 +749,4 @@ public class CommercePaymentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1442691452
+// LIFERAY-SERVICE-BUILDER-HASH:-665996874

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
@@ -838,4 +838,4 @@ public class CommercePriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-818217499
+// LIFERAY-SERVICE-BUILDER-HASH:-333039851

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
@@ -846,4 +846,4 @@ public class CommercePriceListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1902118147
+// LIFERAY-SERVICE-BUILDER-HASH:493308229

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
@@ -826,4 +826,4 @@ public class CommerceTierPriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-606172556
+// LIFERAY-SERVICE-BUILDER-HASH:-1863694960

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
@@ -821,4 +821,4 @@ public class CommercePriceModifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-597161225
+// LIFERAY-SERVICE-BUILDER-HASH:-1247180051

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
@@ -638,4 +638,4 @@ public class CommercePricingClassPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2107409333
+// LIFERAY-SERVICE-BUILDER-HASH:-752994817

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
@@ -868,4 +868,4 @@ public class CPAttachmentFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-275561754
+// LIFERAY-SERVICE-BUILDER-HASH:-309118598

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
@@ -887,4 +887,4 @@ public class CPConfigurationEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-63419317
+// LIFERAY-SERVICE-BUILDER-HASH:1556284073

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
@@ -776,4 +776,4 @@ public class CPConfigurationListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-804965261
+// LIFERAY-SERVICE-BUILDER-HASH:534873473

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
@@ -881,4 +881,4 @@ public class CPDefinitionSpecificationOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1544734001
+// LIFERAY-SERVICE-BUILDER-HASH:1203366993

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
@@ -996,4 +996,4 @@ public class CPInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:487147822
+// LIFERAY-SERVICE-BUILDER-HASH:608285418

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
@@ -699,4 +699,4 @@ public class CPMeasurementUnitPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1072606144
+// LIFERAY-SERVICE-BUILDER-HASH:-1516075366

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
@@ -635,4 +635,4 @@ public class CPOptionCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1837429045
+// LIFERAY-SERVICE-BUILDER-HASH:-1726270435

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
@@ -625,4 +625,4 @@ public class CPOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:901031617
+// LIFERAY-SERVICE-BUILDER-HASH:234068677

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
@@ -630,4 +630,4 @@ public class CPOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1893416348
+// LIFERAY-SERVICE-BUILDER-HASH:-763445050

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
@@ -709,4 +709,4 @@ public class CPSpecificationOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1204727235
+// LIFERAY-SERVICE-BUILDER-HASH:595868825

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
@@ -581,4 +581,4 @@ public class CPTaxCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1609437737
+// LIFERAY-SERVICE-BUILDER-HASH:-1675628399

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
@@ -588,4 +588,4 @@ public class CProductPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1586055079
+// LIFERAY-SERVICE-BUILDER-HASH:1610242887

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
@@ -627,4 +627,4 @@ public class CommerceCatalogPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-565766648
+// LIFERAY-SERVICE-BUILDER-HASH:1748839460

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
@@ -648,4 +648,4 @@ public class CommerceChannelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1930838379
+// LIFERAY-SERVICE-BUILDER-HASH:-2109042245

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
@@ -624,4 +624,4 @@ public class CSDiagramEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:208864640
+// LIFERAY-SERVICE-BUILDER-HASH:-735852194

--- a/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
@@ -690,4 +690,4 @@ public class CommerceTaxCategoryMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1155136862
+// LIFERAY-SERVICE-BUILDER-HASH:-1456463366

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
@@ -752,4 +752,4 @@ public class CommerceTermEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1661615149
+// LIFERAY-SERVICE-BUILDER-HASH:95260585

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
@@ -665,4 +665,4 @@ public class CommerceAvailabilityEstimatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1706558911
+// LIFERAY-SERVICE-BUILDER-HASH:1407751317

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
@@ -693,4 +693,4 @@ public class CommerceOrderAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1137200550
+// LIFERAY-SERVICE-BUILDER-HASH:-1559361306

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
@@ -1167,4 +1167,4 @@ public class CommerceOrderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1666211597
+// LIFERAY-SERVICE-BUILDER-HASH:-1683525383

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
@@ -626,4 +626,4 @@ public class CommerceOrderNotePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2027228004
+// LIFERAY-SERVICE-BUILDER-HASH:-694193126

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
@@ -1311,4 +1311,4 @@ public class CommerceOrderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1645718528
+// LIFERAY-SERVICE-BUILDER-HASH:801045734

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
@@ -676,4 +676,4 @@ public class CommerceOrderTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1572989271
+// LIFERAY-SERVICE-BUILDER-HASH:-498183695

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
@@ -654,4 +654,4 @@ public class CommerceOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:750345891
+// LIFERAY-SERVICE-BUILDER-HASH:398384515

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
@@ -729,4 +729,4 @@ public class CommerceShipmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1546777861
+// LIFERAY-SERVICE-BUILDER-HASH:-900524467

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
@@ -728,4 +728,4 @@ public class CommerceShipmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1085593738
+// LIFERAY-SERVICE-BUILDER-HASH:-1670913820

--- a/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
+++ b/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
@@ -167,7 +167,7 @@ public class DLContentPersistenceTest {
 		Blob existingData = existingDLContent.getData();
 
 		Assert.assertArrayEquals(
-			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
+			newDataBytes, existingData.getBytes(1, (int)existingData.length()));
 		Assert.assertEquals(
 			existingDLContent.getSize(), newDLContent.getSize());
 	}
@@ -556,4 +556,4 @@ public class DLContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1728301549
+// LIFERAY-SERVICE-BUILDER-HASH:289783635

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
@@ -874,4 +874,4 @@ public class DDMTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1465699254
+// LIFERAY-SERVICE-BUILDER-HASH:-1782269124

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
@@ -724,4 +724,4 @@ public class FragmentCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1837523644
+// LIFERAY-SERVICE-BUILDER-HASH:728589200

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
@@ -775,4 +775,4 @@ public class FragmentCompositionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1396529147
+// LIFERAY-SERVICE-BUILDER-HASH:268631207

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
@@ -946,4 +946,4 @@ public class FragmentEntryLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1539095228
+// LIFERAY-SERVICE-BUILDER-HASH:1288998044

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
@@ -1170,4 +1170,4 @@ public class FragmentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:790758245
+// LIFERAY-SERVICE-BUILDER-HASH:1163124556

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
@@ -779,4 +779,4 @@ public class JournalFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:63747973
+// LIFERAY-SERVICE-BUILDER-HASH:1676016443

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
@@ -703,4 +703,4 @@ public class KBFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2026540294
+// LIFERAY-SERVICE-BUILDER-HASH:-238358516

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
@@ -859,4 +859,4 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-851004623
+// LIFERAY-SERVICE-BUILDER-HASH:-293153117

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
@@ -1112,4 +1112,4 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1880568637
+// LIFERAY-SERVICE-BUILDER-HASH:-1732224641

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
@@ -865,4 +865,4 @@ public class
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:844105925
+// LIFERAY-SERVICE-BUILDER-HASH:-1976310929

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
@@ -873,4 +873,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1262746037
+// LIFERAY-SERVICE-BUILDER-HASH:747214275

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
@@ -805,4 +805,4 @@ public class LayoutUtilityPageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:156035521
+// LIFERAY-SERVICE-BUILDER-HASH:-474327085

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
@@ -598,4 +598,4 @@ public class ListTypeDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:679683249
+// LIFERAY-SERVICE-BUILDER-HASH:-1283888217

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
@@ -805,4 +805,4 @@ public class MBCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1244912962
+// LIFERAY-SERVICE-BUILDER-HASH:-1220467320

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
@@ -983,4 +983,4 @@ public class MBMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2049504174
+// LIFERAY-SERVICE-BUILDER-HASH:729430762

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
@@ -665,4 +665,4 @@ public class NotificationTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1686283784
+// LIFERAY-SERVICE-BUILDER-HASH:-1738195854

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
@@ -754,4 +754,4 @@ public class OAuthClientASLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:250224358
+// LIFERAY-SERVICE-BUILDER-HASH:1095086402

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
@@ -686,4 +686,4 @@ public class OAuthClientEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:251064728
+// LIFERAY-SERVICE-BUILDER-HASH:89569616

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
@@ -718,4 +718,4 @@ public class OAuthClientPRLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1397138195
+// LIFERAY-SERVICE-BUILDER-HASH:1729157263

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
@@ -988,4 +988,4 @@ public class ObjectDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1990168429
+// LIFERAY-SERVICE-BUILDER-HASH:-932054519

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
@@ -589,4 +589,4 @@ public class ObjectFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1047035788
+// LIFERAY-SERVICE-BUILDER-HASH:-1333223550

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
@@ -571,4 +571,4 @@ public class PLOEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1481192143
+// LIFERAY-SERVICE-BUILDER-HASH:850902319

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
@@ -766,4 +766,4 @@ public class KaleoDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1146105507
+// LIFERAY-SERVICE-BUILDER-HASH:66830007

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
@@ -789,4 +789,4 @@ public class SegmentsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:695376250
+// LIFERAY-SERVICE-BUILDER-HASH:-1645171650

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
@@ -864,4 +864,4 @@ public class SegmentsExperiencePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1613056766
+// LIFERAY-SERVICE-BUILDER-HASH:-1847227214

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -732,4 +732,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-201598475
+// LIFERAY-SERVICE-BUILDER-HASH:718730673

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
@@ -741,4 +741,4 @@ public class SiteNavigationMenuItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1740702342
+// LIFERAY-SERVICE-BUILDER-HASH:346758852

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
@@ -731,4 +731,4 @@ public class SiteNavigationMenuPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1374653525
+// LIFERAY-SERVICE-BUILDER-HASH:676639039

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -1040,4 +1040,4 @@ public class StyleBookEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1718179673
+// LIFERAY-SERVICE-BUILDER-HASH:-757194958

--- a/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
+++ b/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
@@ -662,4 +662,4 @@ public class TemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:606805336
+// LIFERAY-SERVICE-BUILDER-HASH:1371616616

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
@@ -693,4 +693,4 @@ public class WikiNodePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1339829431
+// LIFERAY-SERVICE-BUILDER-HASH:938660837

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
@@ -621,4 +621,4 @@ public class SXPBlueprintPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1241004084
+// LIFERAY-SERVICE-BUILDER-HASH:1829012244

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
@@ -646,4 +646,4 @@ public class SXPElementPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:177568200
+// LIFERAY-SERVICE-BUILDER-HASH:-1431297962

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
@@ -746,4 +746,4 @@ public class AddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-568103679
+// LIFERAY-SERVICE-BUILDER-HASH:2066891977

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
@@ -783,4 +783,4 @@ public class CountryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1377226994
+// LIFERAY-SERVICE-BUILDER-HASH:311387174

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
@@ -623,4 +623,4 @@ public class EmailAddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1146629301
+// LIFERAY-SERVICE-BUILDER-HASH:1328660963

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
@@ -944,4 +944,4 @@ public class GroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1996394709
+// LIFERAY-SERVICE-BUILDER-HASH:-452767721

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
@@ -1101,4 +1101,4 @@ public class LayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-900558034
+// LIFERAY-SERVICE-BUILDER-HASH:-19188678

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
@@ -709,4 +709,4 @@ public class OrganizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1328945152
+// LIFERAY-SERVICE-BUILDER-HASH:2130425210

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
@@ -600,4 +600,4 @@ public class PhonePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:635602280
+// LIFERAY-SERVICE-BUILDER-HASH:-1915490844

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
@@ -620,4 +620,4 @@ public class RegionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-232467712
+// LIFERAY-SERVICE-BUILDER-HASH:590988656

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
@@ -660,4 +660,4 @@ public class RepositoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1589679459
+// LIFERAY-SERVICE-BUILDER-HASH:-294853201

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
@@ -712,4 +712,4 @@ public class RolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1191728336
+// LIFERAY-SERVICE-BUILDER-HASH:1682720524

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
@@ -629,4 +629,4 @@ public class UserGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-843022224
+// LIFERAY-SERVICE-BUILDER-HASH:-1741744072

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
@@ -903,4 +903,4 @@ public class UserPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1597367390
+// LIFERAY-SERVICE-BUILDER-HASH:-1492236072

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
@@ -603,4 +603,4 @@ public class WebsitePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:298149603
+// LIFERAY-SERVICE-BUILDER-HASH:-262828243

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
@@ -737,4 +737,4 @@ public class WorkflowDefinitionLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-206007213
+// LIFERAY-SERVICE-BUILDER-HASH:746524979

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -801,4 +801,4 @@ public class AssetCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-514919137
+// LIFERAY-SERVICE-BUILDER-HASH:-1156536029

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
@@ -632,4 +632,4 @@ public class AssetTagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1595800145
+// LIFERAY-SERVICE-BUILDER-HASH:1663578181

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
@@ -725,4 +725,4 @@ public class AssetVocabularyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1752173730
+// LIFERAY-SERVICE-BUILDER-HASH:1472907946

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
@@ -610,4 +610,4 @@ public class DLFileEntryMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:561571646
+// LIFERAY-SERVICE-BUILDER-HASH:1562316804

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
@@ -1001,4 +1001,4 @@ public class DLFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-98036327
+// LIFERAY-SERVICE-BUILDER-HASH:-625924395

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
@@ -713,4 +713,4 @@ public class DLFileEntryTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1730315776
+// LIFERAY-SERVICE-BUILDER-HASH:157207824

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
@@ -738,4 +738,4 @@ public class DLFileShortcutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1221094150
+// LIFERAY-SERVICE-BUILDER-HASH:1505347270

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
@@ -877,4 +877,4 @@ public class DLFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:822366275
+// LIFERAY-SERVICE-BUILDER-HASH:-390643385

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
@@ -542,4 +542,4 @@ public class ERCCompanyEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-178262490
+// LIFERAY-SERVICE-BUILDER-HASH:14794364

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
@@ -541,4 +541,4 @@ public class ERCGroupEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2147300514
+// LIFERAY-SERVICE-BUILDER-HASH:1410283148

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -194,9 +194,26 @@ public class ERCVersionedEntryPersistenceTest {
 		draftERCVersionedEntry.setHeadId(-ercVersionedEntry.getHeadId());
 		draftERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(ercVersionedEntry.getCompanyId());
-		draftERCVersionedEntry.setBlob(ercVersionedEntry.getBlob());
+
+		String draftBlobString = RandomTestUtil.randomString();
+
+		byte[] draftBlobBytes = draftBlobString.getBytes("UTF-8");
+
+		draftERCVersionedEntry.setBlob(
+			new OutputBlob(
+				new ByteArrayInputStream(draftBlobBytes),
+				draftBlobBytes.length));
 
 		_ercVersionedEntries.add(_persistence.update(draftERCVersionedEntry));
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
+
+		ERCVersionedEntry persistedDraftERCVersionedEntry =
+			_persistence.findByPrimaryKey(pk);
 
 		Assert.assertEquals(
 			ercVersionedEntry.getMvccVersion(),
@@ -214,12 +231,11 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			ercVersionedEntry.getCompanyId(),
 			draftERCVersionedEntry.getCompanyId());
-		Blob Blob = ercVersionedEntry.getBlob();
-		Blob draftBlob = draftERCVersionedEntry.getBlob();
+		Blob persistedDraftBlob = persistedDraftERCVersionedEntry.getBlob();
 
 		Assert.assertArrayEquals(
-			Blob.getBytes(1, (int)Blob.length()),
-			draftBlob.getBytes(1, (int)draftBlob.length()));
+			persistedDraftBlob.getBytes(1, (int)persistedDraftBlob.length()),
+			draftBlobBytes);
 	}
 
 	@Test(
@@ -266,6 +282,14 @@ public class ERCVersionedEntryPersistenceTest {
 
 		newERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
 
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		newERCVersionedEntry.setBlob(
+			new OutputBlob(
+				new ByteArrayInputStream(blobBytes), blobBytes.length));
+
 		newERCVersionedEntry = _persistence.update(newERCVersionedEntry);
 
 		Session session = _persistence.getCurrentSession();
@@ -274,6 +298,10 @@ public class ERCVersionedEntryPersistenceTest {
 
 		newERCVersionedEntry.setExternalReferenceCode(
 			ercVersionedEntry.getExternalReferenceCode());
+
+		newERCVersionedEntry.setBlob(
+			new OutputBlob(
+				new ByteArrayInputStream(blobBytes), blobBytes.length));
 
 		_persistence.update(newERCVersionedEntry);
 	}
@@ -734,4 +762,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-13325117
+// LIFERAY-SERVICE-BUILDER-HASH:-499275962

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -177,7 +177,7 @@ public class ERCVersionedEntryPersistenceTest {
 		Blob existingBlob = existingERCVersionedEntry.getBlob();
 
 		Assert.assertArrayEquals(
-			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
+			newBlobBytes, existingBlob.getBytes(1, (int)existingBlob.length()));
 	}
 
 	@Test
@@ -234,8 +234,8 @@ public class ERCVersionedEntryPersistenceTest {
 		Blob persistedDraftBlob = persistedDraftERCVersionedEntry.getBlob();
 
 		Assert.assertArrayEquals(
-			persistedDraftBlob.getBytes(1, (int)persistedDraftBlob.length()),
-			draftBlobBytes);
+			draftBlobBytes,
+			persistedDraftBlob.getBytes(1, (int)persistedDraftBlob.length()));
 	}
 
 	@Test(
@@ -762,4 +762,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-499275962
+// LIFERAY-SERVICE-BUILDER-HASH:2132282118

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
@@ -182,7 +182,7 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		Blob existingBlob = existingERCVersionedEntryVersion.getBlob();
 
 		Assert.assertArrayEquals(
-			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
+			newBlobBytes, existingBlob.getBytes(1, (int)existingBlob.length()));
 	}
 
 	@Test
@@ -628,4 +628,4 @@ public class ERCVersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-300602437
+// LIFERAY-SERVICE-BUILDER-HASH:-1540875333

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
@@ -153,7 +153,7 @@ public class EagerBlobEntryPersistenceTest {
 		Blob existingBlob = existingEagerBlobEntry.getBlob();
 
 		Assert.assertArrayEquals(
-			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
+			newBlobBytes, existingBlob.getBytes(1, (int)existingBlob.length()));
 	}
 
 	@Test
@@ -508,4 +508,4 @@ public class EagerBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:363374027
+// LIFERAY-SERVICE-BUILDER-HASH:-673466933

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
@@ -606,4 +606,4 @@ public class IndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2059835112
+// LIFERAY-SERVICE-BUILDER-HASH:-656914288

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
@@ -157,13 +157,13 @@ public class LazyBlobEntryPersistenceTest {
 		Blob existingBlob1 = existingLazyBlobEntry.getBlob1();
 
 		Assert.assertArrayEquals(
-			existingBlob1.getBytes(1, (int)existingBlob1.length()),
-			newBlob1Bytes);
+			newBlob1Bytes,
+			existingBlob1.getBytes(1, (int)existingBlob1.length()));
 		Blob existingBlob2 = existingLazyBlobEntry.getBlob2();
 
 		Assert.assertArrayEquals(
-			existingBlob2.getBytes(1, (int)existingBlob2.length()),
-			newBlob2Bytes);
+			newBlob2Bytes,
+			existingBlob2.getBytes(1, (int)existingBlob2.length()));
 	}
 
 	@Test
@@ -525,4 +525,4 @@ public class LazyBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1422261870
+// LIFERAY-SERVICE-BUILDER-HASH:-1473817262

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -370,19 +370,41 @@ public class ${entity.name}PersistenceTest {
 
 				${entity.name} draft${entity.name} = _persistence.create(pk);
 
+				<#assign hasBlobEntityColumn = false />
+
 				<#list entity.regularEntityColumns as entityColumn>
 					<#if !entityColumn.primary && (validator.isNull(parentPKColumn) || (parentPKColumn.name != entityColumn.name)) && !(serviceBuilder.isVersionGTE_7_4_0() && stringUtil.equals(entityColumn.name, "mvccVersion"))>
-						draft${entity.name}.set${entityColumn.methodName}(
+						<#if stringUtil.equals(entityColumn.type, "Blob")>
+							<#assign hasBlobEntityColumn = true />
 
-						<#if stringUtil.equals(entityColumn.name, "headId")>
-							-
+							String draft${entityColumn.methodName}String = RandomTestUtil.randomString();
+
+							byte[] draft${entityColumn.methodName}Bytes = draft${entityColumn.methodName}String.getBytes("UTF-8");
+
+							draft${entity.name}.set${entityColumn.methodName}(new OutputBlob(new ByteArrayInputStream(draft${entityColumn.methodName}Bytes), draft${entityColumn.methodName}Bytes.length));
+						<#else>
+							draft${entity.name}.set${entityColumn.methodName}(
+
+							<#if stringUtil.equals(entityColumn.name, "headId")>
+								-
+							</#if>
+
+							${entity.variableName}.get${entityColumn.methodName}());
 						</#if>
-
-						${entity.variableName}.get${entityColumn.methodName}());
 					</#if>
 				</#list>
 
 				_${entity.pluralVariableName}.add(_persistence.update(draft${entity.name}));
+
+				<#if hasBlobEntityColumn>
+					Session session = _persistence.openSession();
+
+					session.flush();
+
+					session.clear();
+
+					${entity.name} persistedDraft${entity.name} = _persistence.findByPrimaryKey(pk);
+				</#if>
 
 				<#list entity.regularEntityColumns as entityColumn>
 					<#if !entityColumn.primary && (validator.isNull(parentPKColumn) || (parentPKColumn.name != entityColumn.name))>
@@ -391,10 +413,9 @@ public class ${entity.name}PersistenceTest {
 						<#elseif stringUtil.equals(entityColumn.name, "status")>
 							Assert.assertEquals(2, draft${entity.name}.get${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Blob")>
-							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
-							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
+							Blob persistedDraft${entityColumn.methodName} = persistedDraft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertArrayEquals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length()));
+							Assert.assertArrayEquals(persistedDraft${entityColumn.methodName}.getBytes(1, (int)persistedDraft${entityColumn.methodName}.length()), draft${entityColumn.methodName}Bytes);
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>
@@ -495,6 +516,16 @@ public class ${entity.name}PersistenceTest {
 
 			new${entity.name}.set${entity.externalReferenceCode?cap_first}Id(${entity.variableName}.get${entity.externalReferenceCode?cap_first}Id());
 
+			<#list entity.regularEntityColumns as entityColumn>
+				<#if stringUtil.equals(entityColumn.type, "Blob")>
+					String ${entityColumn.name}String = RandomTestUtil.randomString();
+
+					byte[] ${entityColumn.name}Bytes = ${entityColumn.name}String.getBytes("UTF-8");
+
+					new${entity.name}.set${entityColumn.methodName}(new OutputBlob(new ByteArrayInputStream(${entityColumn.name}Bytes), ${entityColumn.name}Bytes.length));
+				</#if>
+			</#list>
+
 			new${entity.name} = _persistence.update(new${entity.name});
 
 			Session session = _persistence.getCurrentSession();
@@ -502,6 +533,12 @@ public class ${entity.name}PersistenceTest {
 			session.evict(new${entity.name});
 
 			new${entity.name}.setExternalReferenceCode(${entity.variableName}.getExternalReferenceCode());
+
+			<#list entity.regularEntityColumns as entityColumn>
+				<#if stringUtil.equals(entityColumn.type, "Blob")>
+					new${entity.name}.set${entityColumn.methodName}(new OutputBlob(new ByteArrayInputStream(${entityColumn.name}Bytes), ${entityColumn.name}Bytes.length));
+				</#if>
+			</#list>
 
 			_persistence.update(new${entity.name});
 		}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -329,7 +329,7 @@ public class ${entity.name}PersistenceTest {
 			<#if stringUtil.equals(entityColumn.type, "Blob")>
 				Blob existing${entityColumn.methodName} = existing${entity.name}.get${entityColumn.methodName}();
 
-				Assert.assertArrayEquals(existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()), new${entityColumn.methodName}Bytes);
+				Assert.assertArrayEquals(new${entityColumn.methodName}Bytes, existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()));
 			<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 				Assert.assertEquals(existing${entity.name}.is${entityColumn.methodName}(), new${entity.name}.is${entityColumn.methodName}());
 			<#elseif stringUtil.equals(entityColumn.type, "Date")>
@@ -415,7 +415,7 @@ public class ${entity.name}PersistenceTest {
 						<#elseif stringUtil.equals(entityColumn.type, "Blob")>
 							Blob persistedDraft${entityColumn.methodName} = persistedDraft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertArrayEquals(persistedDraft${entityColumn.methodName}.getBytes(1, (int)persistedDraft${entityColumn.methodName}.length()), draft${entityColumn.methodName}Bytes);
+							Assert.assertArrayEquals(draft${entityColumn.methodName}Bytes, persistedDraft${entityColumn.methodName}.getBytes(1, (int)persistedDraft${entityColumn.methodName}.length()));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101137

## What Is Being Fixed

The generated `testCreateDraft` never checked a blob. `OutputBlob` wraps a single `InputStream`, so it survives exactly one save, while `length()` keeps reporting the constructor's length no matter what the stream has left. `testCreateDraft` copied the head entity's columns onto the draft, and copying a `Blob` column copies the reference, so both entities held the same `OutputBlob`. The head save spent the stream, the draft row was written from an empty one, and the assertion then read that one spent object twice and compared the two reads against each other — so it passed on two empty arrays.

`ERCVersionedEntry` has therefore been storing eight bytes in its head row and none in its draft row since the Blob branch of the template first rendered (LPD-90963, closed PR liferay-headless#4074), on Hibernate 5 as well as Hibernate 7. Hibernate 7 only changed the read order enough that one side still held bytes, which turned a silent hole into a visible failure.

`testUpdateWithExistingExternalReferenceCode` had the same defect for a different reason: it sets no columns and updates the entity `addEntity()` returned, so its two `update()` calls bound one stream twice.

## How It Is Being Fixed

The invariant the template now holds is that every save gets its own `OutputBlob`, built on the spot from a `byte[]` the test keeps, and every assertion compares a row re-read from the database against that `byte[]` rather than one `Blob` against another. A `byte[]` can be wrapped in a fresh `ByteArrayInputStream` any number of times; a spent stream cannot.

`testCreateDraft` now mints its own blob for the draft instead of copying the head's reference, then flushes and clears the session, re-reads the draft row by primary key, and asserts that row's blob against the `byte[]`. `testUpdateWithExistingExternalReferenceCode` mints a fresh blob before each of its two updates. The fix sits at each save site rather than inside `addEntity()`, because that helper is shared by more than thirty tests and cannot know how many saves a caller will perform.

Regenerating touched 109 files, 108 of which changed only their trailing `LIFERAY-SERVICE-BUILDER-HASH` comment. `ERCVersionedEntry` is the only entity combining an external reference code, versioning, and a `Blob` column, so it carries the only real output change.

CI covered both legs across all seven database shards, per test method: Hibernate 5 on this branch and Hibernate 7 on the LPD-94036 branch. `testCreateDraft` and `testUpdateWithExistingExternalReferenceCode` pass 7/7 on each, which is the first real coverage this assertion has had. Those runs were on `15cd3bb`, whose tree is identical to the head below — only the commit message changed since.

## PR Check

**pr-check: PASS** — tested on `d8b16346750aa49caaee1dbd26ce3ede111b7d3b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Integration Test Compile matched 42 modules and ran 1: `:util:portal-tools-service-builder-test-test`, the only module with a real generated change. The other 41 changed only their `LIFERAY-SERVICE-BUILDER-HASH` comment line.

<!-- pr-check {"result": "success", "sha": "d8b16346750aa49caaee1dbd26ce3ede111b7d3b"} -->
