### PR TITLE
LPD-97697 Extend the batch entity compliance suite to 13 more delegates

### DIFF
--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/BaseBatchEnginePortletDataHandlerTestCase.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/BaseBatchEnginePortletDataHandlerTestCase.java
@@ -492,6 +492,10 @@ public abstract class BaseBatchEnginePortletDataHandlerTestCase
 
 	@Test
 	public void testUpdateResolvesEmptyEntry() throws Exception {
+		if (!supportsEmptyEntries()) {
+			return;
+		}
+
 		long groupId = _getGroupId(_getScope());
 
 		String externalReferenceCode = null;
@@ -540,8 +544,9 @@ public abstract class BaseBatchEnginePortletDataHandlerTestCase
 		return _targetUser;
 	}
 
-	protected abstract String addEmptyEntry(long groupId, long userId)
-		throws Exception;
+	protected String addEmptyEntry(long groupId, long userId) throws Exception {
+		throw new UnsupportedOperationException();
+	}
 
 	protected abstract String addEntry(
 			long groupId, long userId, Date dateModified)
@@ -646,8 +651,11 @@ public abstract class BaseBatchEnginePortletDataHandlerTestCase
 			long groupId, String externalReferenceCode)
 		throws Exception;
 
-	protected abstract int getStatus(long groupId, String externalReferenceCode)
-		throws Exception;
+	protected int getStatus(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
 
 	protected String getTargetModelClassName() {
 		ExportImportDescriptor<?> exportImportDescriptor =
@@ -657,6 +665,8 @@ public abstract class BaseBatchEnginePortletDataHandlerTestCase
 	}
 
 	protected abstract boolean supportsComments();
+
+	protected abstract boolean supportsEmptyEntries();
 
 	protected abstract void updateEntry(
 			long groupId, String externalReferenceCode)

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/build.gradle
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/build.gradle
@@ -5,6 +5,10 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "commons-lang", name: "commons-lang", version: "2.6"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
+	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-admin-address:headless-admin-address-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-address:headless-admin-address-client")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/internal/exportimport/data/handler/test/CountryBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/internal/exportimport/data/handler/test/CountryBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.address.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.address.resource.v1_0.CountryResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CountryLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class CountryBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		Country country = _countryLocalService.addCountry(
+			RandomTestUtil.randomString(), _randomCode(2), _randomCode(3), true,
+			true, _randomNumber(), RandomTestUtil.randomString(),
+			_randomNumber(), RandomTestUtil.randomDouble(), true, true, true,
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, userId));
+
+		country.setModifiedDate(dateModified);
+
+		country = _countryLocalService.updateCountry(country);
+
+		return country.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_countryLocalService.deleteCountry(
+			_getCountry(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Country country = _getCountry(groupId, externalReferenceCode);
+
+		return country.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Country country = _getCountry(groupId, externalReferenceCode);
+
+		return country.getName();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			CountryResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_countryLocalService.getCompanyCountries(_getCompanyId(groupId)),
+			Country::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Country country = _getCountry(groupId, externalReferenceCode);
+
+		return country.getCountryId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Country country = _getCountry(groupId, externalReferenceCode);
+
+		_countryLocalService.updateCountry(
+			country.getExternalReferenceCode(), country.getCountryId(),
+			country.getA2(), country.getA3(), country.isActive(),
+			country.isBillingAllowed(), country.getIdd(),
+			RandomTestUtil.randomString(), country.getNumber(),
+			country.getPosition(), country.isShippingAllowed(),
+			country.isSubjectToVAT());
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private Country _getCountry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _countryLocalService.fetchCountryByExternalReferenceCode(
+			externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private String _randomCode(int length) {
+		return StringUtil.toUpperCase(RandomTestUtil.randomString(length));
+	}
+
+	private String _randomNumber() {
+		return String.valueOf(RandomTestUtil.randomInt(100, 999));
+	}
+
+	@Inject
+	private CountryLocalService _countryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/internal/exportimport/data/handler/test/RegionBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/internal/exportimport/data/handler/test/RegionBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,208 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.address.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.address.resource.v1_0.RegionResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.service.CountryLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RegionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class RegionBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		Country country = _getCountry(groupId, userId);
+
+		Region region = _regionLocalService.addRegion(
+			RandomTestUtil.randomString(), country.getCountryId(), true,
+			RandomTestUtil.randomString(), RandomTestUtil.randomDouble(),
+			StringUtil.toUpperCase(RandomTestUtil.randomString(4)),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, userId));
+
+		region.setModifiedDate(dateModified);
+
+		region = _regionLocalService.updateRegion(region);
+
+		return region.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_regionLocalService.deleteRegion(
+			_getRegion(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Region region = _getRegion(groupId, externalReferenceCode);
+
+		return region.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Region region = _getRegion(groupId, externalReferenceCode);
+
+		return region.getName();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			RegionResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		List<String> externalReferenceCodes = new ArrayList<>();
+
+		for (Country country :
+				_countryLocalService.getCompanyCountries(
+					_getCompanyId(groupId))) {
+
+			externalReferenceCodes.addAll(
+				TransformUtil.transform(
+					_regionLocalService.getRegions(
+						country.getCountryId(), QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS, null),
+					Region::getExternalReferenceCode));
+		}
+
+		return externalReferenceCodes;
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Region region = _getRegion(groupId, externalReferenceCode);
+
+		return region.getRegionId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Region region = _getRegion(groupId, externalReferenceCode);
+
+		_regionLocalService.updateRegion(
+			region.getExternalReferenceCode(), region.getRegionId(),
+			region.isActive(), RandomTestUtil.randomString(),
+			region.getPosition(), region.getRegionCode());
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private Country _getCountry(long groupId, long userId) throws Exception {
+		long companyId = _getCompanyId(groupId);
+
+		Country country =
+			_countryLocalService.fetchCountryByExternalReferenceCode(
+				_COUNTRY_EXTERNAL_REFERENCE_CODE, companyId);
+
+		if (country != null) {
+			return country;
+		}
+
+		return _countryLocalService.addCountry(
+			_COUNTRY_EXTERNAL_REFERENCE_CODE,
+			StringUtil.toUpperCase(RandomTestUtil.randomString(2)),
+			StringUtil.toUpperCase(RandomTestUtil.randomString(3)), true, true,
+			String.valueOf(RandomTestUtil.randomInt(100, 999)),
+			RandomTestUtil.randomString(),
+			String.valueOf(RandomTestUtil.randomInt(100, 999)),
+			RandomTestUtil.randomDouble(), true, true, true,
+			ServiceContextTestUtil.getServiceContext(
+				companyId, groupId, userId));
+	}
+
+	private Region _getRegion(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _regionLocalService.fetchRegionByExternalReferenceCode(
+			externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private static final String _COUNTRY_EXTERNAL_REFERENCE_CODE =
+		"batch-engine-region-test-country";
+
+	@Inject
+	private CountryLocalService _countryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private RegionLocalService _regionLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/build.gradle
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/build.gradle
@@ -5,6 +5,10 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
+	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-admin-list-type:headless-admin-list-type-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-list-type:headless-admin-list-type-client")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/internal/exportimport/data/handler/test/ListTypeDefinitionBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/internal/exportimport/data/handler/test/ListTypeDefinitionBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.list.type.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionResource;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class ListTypeDefinitionBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition =
+			_listTypeDefinitionLocalService.addListTypeDefinition(
+				RandomTestUtil.randomString(), userId,
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				false, Collections.emptyList(),
+				ServiceContextTestUtil.getServiceContext(
+					_getCompanyId(groupId), groupId, userId));
+
+		listTypeDefinition.setModifiedDate(dateModified);
+
+		listTypeDefinition =
+			_listTypeDefinitionLocalService.updateListTypeDefinition(
+				listTypeDefinition);
+
+		return listTypeDefinition.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_listTypeDefinitionLocalService.deleteListTypeDefinition(
+			_getListTypeDefinition(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition = _getListTypeDefinition(
+			groupId, externalReferenceCode);
+
+		return listTypeDefinition.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition = _getListTypeDefinition(
+			groupId, externalReferenceCode);
+
+		return listTypeDefinition.getName(LocaleUtil.getDefault());
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			ListTypeDefinitionResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		long companyId = _getCompanyId(groupId);
+
+		return TransformUtil.transform(
+			ListUtil.filter(
+				_listTypeDefinitionLocalService.getListTypeDefinitions(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				listTypeDefinition ->
+					listTypeDefinition.getCompanyId() == companyId),
+			ListTypeDefinition::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition = _getListTypeDefinition(
+			groupId, externalReferenceCode);
+
+		return listTypeDefinition.getListTypeDefinitionId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition = _getListTypeDefinition(
+			groupId, externalReferenceCode);
+
+		_listTypeDefinitionLocalService.updateListTypeDefinition(
+			listTypeDefinition.getExternalReferenceCode(),
+			listTypeDefinition.getListTypeDefinitionId(),
+			listTypeDefinition.getUserId(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyList(),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId,
+				listTypeDefinition.getUserId()));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private ListTypeDefinition _getListTypeDefinition(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _listTypeDefinitionLocalService.
+			fetchListTypeDefinitionByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/KeywordBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/KeywordBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.SITE)
+@RunWith(Arquillian.class)
+public class KeywordBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		AssetTag assetTag = _assetTagLocalService.addTag(
+			RandomTestUtil.randomString(), userId, groupId, _randomName(),
+			ServiceContextTestUtil.getServiceContext(groupId, userId));
+
+		assetTag.setModifiedDate(dateModified);
+
+		assetTag = _assetTagLocalService.updateAssetTag(assetTag);
+
+		return assetTag.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_assetTagLocalService.deleteTag(
+			_getAssetTag(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AssetTag assetTag = _getAssetTag(groupId, externalReferenceCode);
+
+		return assetTag.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AssetTag assetTag = _getAssetTag(groupId, externalReferenceCode);
+
+		return assetTag.getName();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			KeywordResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_assetTagLocalService.getGroupTags(groupId),
+			AssetTag::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AssetTag assetTag = _getAssetTag(groupId, externalReferenceCode);
+
+		return assetTag.getTagId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AssetTag assetTag = _getAssetTag(groupId, externalReferenceCode);
+
+		_assetTagLocalService.updateTag(
+			assetTag.getExternalReferenceCode(), assetTag.getUserId(),
+			assetTag.getTagId(), _randomName(),
+			ServiceContextTestUtil.getServiceContext(
+				groupId, assetTag.getUserId()));
+	}
+
+	private AssetTag _getAssetTag(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _assetTagLocalService.fetchAssetTagByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	private String _randomName() {
+		return StringUtil.toLowerCase(RandomTestUtil.randomString());
+	}
+
+	@Inject
+	private AssetTagLocalService _assetTagLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/TaxonomyCategoryBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/TaxonomyCategoryBatchEnginePortletDataHandlerTest.java
@@ -161,6 +161,11 @@ public class TaxonomyCategoryBatchEnginePortletDataHandlerTest
 	}
 
 	@Override
+	protected boolean supportsEmptyEntries() {
+		return true;
+	}
+
+	@Override
 	protected void updateEntry(long groupId, String externalReferenceCode)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/TaxonomyVocabularyBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/exportimport/data/handler/test/TaxonomyVocabularyBatchEnginePortletDataHandlerTest.java
@@ -143,6 +143,11 @@ public class TaxonomyVocabularyBatchEnginePortletDataHandlerTest
 	}
 
 	@Override
+	protected boolean supportsEmptyEntries() {
+		return true;
+	}
+
+	@Override
 	protected void updateEntry(long groupId, String externalReferenceCode)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:expando:expando-test-util")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-client")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/AccountBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/AccountBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.exportimport.data.handler.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.user.resource.v1_0.AccountResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class AccountBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		AccountEntry accountEntry = _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), userId,
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, null, null, AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, userId));
+
+		accountEntry.setModifiedDate(dateModified);
+
+		accountEntry = _accountEntryLocalService.updateAccountEntry(
+			accountEntry);
+
+		return accountEntry.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_accountEntryLocalService.deleteAccountEntry(
+			_getAccountEntry(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountEntry accountEntry = _getAccountEntry(
+			groupId, externalReferenceCode);
+
+		return accountEntry.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountEntry accountEntry = _getAccountEntry(
+			groupId, externalReferenceCode);
+
+		return accountEntry.getDescription();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			AccountResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_accountEntryLocalService.getAccountEntries(
+				_getCompanyId(groupId), WorkflowConstants.STATUS_APPROVED,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+			AccountEntry::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountEntry accountEntry = _getAccountEntry(
+			groupId, externalReferenceCode);
+
+		return accountEntry.getAccountEntryId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountEntry accountEntry = _getAccountEntry(
+			groupId, externalReferenceCode);
+
+		_accountEntryLocalService.updateAccountEntry(
+			accountEntry.getExternalReferenceCode(),
+			accountEntry.getAccountEntryId(),
+			accountEntry.getParentAccountEntryId(), accountEntry.getName(),
+			RandomTestUtil.randomString(), false,
+			accountEntry.getDomainsArray(), accountEntry.getEmailAddress(),
+			null, accountEntry.getTaxIdNumber(), accountEntry.getStatus(),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, accountEntry.getUserId()));
+	}
+
+	private AccountEntry _getAccountEntry(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _accountEntryLocalService.
+			fetchAccountEntryByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/AccountGroupBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/AccountGroupBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.exportimport.data.handler.test;
+
+import com.liferay.account.model.AccountGroup;
+import com.liferay.account.service.AccountGroupLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.user.resource.v1_0.AccountGroupResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class AccountGroupBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		AccountGroup accountGroup = _accountGroupLocalService.addAccountGroup(
+			RandomTestUtil.randomString(), userId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, userId));
+
+		accountGroup.setModifiedDate(dateModified);
+
+		accountGroup = _accountGroupLocalService.updateAccountGroup(
+			accountGroup);
+
+		return accountGroup.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_accountGroupLocalService.deleteAccountGroup(
+			_getAccountGroup(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountGroup accountGroup = _getAccountGroup(
+			groupId, externalReferenceCode);
+
+		return accountGroup.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountGroup accountGroup = _getAccountGroup(
+			groupId, externalReferenceCode);
+
+		return accountGroup.getDescription();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			AccountGroupResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_accountGroupLocalService.getAccountGroups(
+				_getCompanyId(groupId), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				null),
+			AccountGroup::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountGroup accountGroup = _getAccountGroup(
+			groupId, externalReferenceCode);
+
+		return accountGroup.getAccountGroupId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		AccountGroup accountGroup = _getAccountGroup(
+			groupId, externalReferenceCode);
+
+		_accountGroupLocalService.updateAccountGroup(
+			accountGroup.getExternalReferenceCode(),
+			accountGroup.getAccountGroupId(), RandomTestUtil.randomString(),
+			accountGroup.getName(),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, accountGroup.getUserId()));
+	}
+
+	private AccountGroup _getAccountGroup(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _accountGroupLocalService.
+			fetchAccountGroupByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	@Inject
+	private AccountGroupLocalService _accountGroupLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/OrganizationBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/OrganizationBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.user.resource.v1_0.OrganizationResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ListType;
+import com.liferay.portal.kernel.model.ListTypeConstants;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ListTypeLocalService;
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class OrganizationBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		long companyId = _getCompanyId(groupId);
+
+		Organization organization = _organizationLocalService.addOrganization(
+			RandomTestUtil.randomString(), userId,
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			RandomTestUtil.randomString(),
+			OrganizationConstants.TYPE_ORGANIZATION, 0, 0,
+			_getStatusListTypeId(companyId), RandomTestUtil.randomString(),
+			false,
+			ServiceContextTestUtil.getServiceContext(
+				companyId, groupId, userId));
+
+		organization.setModifiedDate(dateModified);
+
+		organization = _organizationLocalService.updateOrganization(
+			organization);
+
+		return organization.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_organizationLocalService.deleteOrganization(
+			_getOrganization(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Organization organization = _getOrganization(
+			groupId, externalReferenceCode);
+
+		return organization.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Organization organization = _getOrganization(
+			groupId, externalReferenceCode);
+
+		return organization.getComments();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			OrganizationResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_organizationLocalService.getOrganizations(
+				_getCompanyId(groupId),
+				OrganizationConstants.ANY_PARENT_ORGANIZATION_ID),
+			Organization::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Organization organization = _getOrganization(
+			groupId, externalReferenceCode);
+
+		return organization.getOrganizationId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Organization organization = _getOrganization(
+			groupId, externalReferenceCode);
+
+		long companyId = _getCompanyId(groupId);
+
+		_organizationLocalService.updateOrganization(
+			organization.getExternalReferenceCode(), companyId,
+			organization.getOrganizationId(),
+			organization.getParentOrganizationId(), organization.getName(),
+			organization.getType(), organization.getRegionId(),
+			organization.getCountryId(), organization.getStatusListTypeId(),
+			RandomTestUtil.randomString(), false, null, false,
+			ServiceContextTestUtil.getServiceContext(
+				companyId, groupId, organization.getUserId()));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private Organization _getOrganization(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _organizationLocalService.
+			fetchOrganizationByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private long _getStatusListTypeId(long companyId) throws Exception {
+		ListType listType = _listTypeLocalService.getListType(
+			companyId, ListTypeConstants.ORGANIZATION_STATUS_DEFAULT,
+			ListTypeConstants.ORGANIZATION_STATUS);
+
+		return listType.getListTypeId();
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ListTypeLocalService _listTypeLocalService;
+
+	@Inject
+	private OrganizationLocalService _organizationLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/RoleBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/RoleBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class RoleBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		Role role = _roleLocalService.addRole(
+			RandomTestUtil.randomString(), userId, null, 0,
+			RandomTestUtil.randomString(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			null, RoleConstants.TYPE_REGULAR, null,
+			ServiceContextTestUtil.getServiceContext(groupId, userId));
+
+		role.setModifiedDate(dateModified);
+
+		role = _roleLocalService.updateRole(role);
+
+		return role.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_roleLocalService.deleteRole(_getRole(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Role role = _getRole(groupId, externalReferenceCode);
+
+		return role.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Role role = _getRole(groupId, externalReferenceCode);
+
+		return role.getTitle(LocaleUtil.getDefault());
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			RoleResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_roleLocalService.getRoles(_getCompanyId(groupId)),
+			Role::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Role role = _getRole(groupId, externalReferenceCode);
+
+		return role.getRoleId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		Role role = _getRole(groupId, externalReferenceCode);
+
+		_roleLocalService.updateRole(
+			role.getExternalReferenceCode(), role.getRoleId(), role.getName(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			role.getDescriptionMap(), role.getSubtype(),
+			ServiceContextTestUtil.getServiceContext(
+				_getCompanyId(groupId), groupId, role.getUserId()));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private Role _getRole(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _roleLocalService.fetchRoleByExternalReferenceCode(
+			externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/UserGroupBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/internal/exportimport/data/handler/test/UserGroupBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.admin.user.resource.v1_0.UserGroupResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class UserGroupBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		long companyId = _getCompanyId(groupId);
+
+		UserGroup userGroup = _userGroupLocalService.addUserGroup(
+			RandomTestUtil.randomString(), userId, companyId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				companyId, groupId, userId));
+
+		userGroup.setModifiedDate(dateModified);
+
+		userGroup = _userGroupLocalService.updateUserGroup(userGroup);
+
+		return userGroup.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_userGroupLocalService.deleteUserGroup(
+			_getUserGroup(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		UserGroup userGroup = _getUserGroup(groupId, externalReferenceCode);
+
+		return userGroup.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		UserGroup userGroup = _getUserGroup(groupId, externalReferenceCode);
+
+		return userGroup.getDescription();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			UserGroupResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_userGroupLocalService.getUserGroups(_getCompanyId(groupId)),
+			UserGroup::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		UserGroup userGroup = _getUserGroup(groupId, externalReferenceCode);
+
+		return userGroup.getUserGroupId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		UserGroup userGroup = _getUserGroup(groupId, externalReferenceCode);
+
+		long companyId = _getCompanyId(groupId);
+
+		_userGroupLocalService.updateUserGroup(
+			userGroup.getExternalReferenceCode(), companyId,
+			userGroup.getUserGroupId(), userGroup.getName(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				companyId, groupId, userGroup.getUserId()));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private UserGroup _getUserGroup(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _userGroupLocalService.fetchUserGroupByExternalReferenceCode(
+			externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+}

--- a/modules/apps/headless/headless-object/headless-object-test/build.gradle
+++ b/modules/apps/headless/headless-object/headless-object-test/build.gradle
@@ -6,6 +6,9 @@ dependencies {
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:headless:headless-object:headless-object-api")
 	testIntegrationImplementation project(":apps:headless:headless-object:headless-object-client")

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/exportimport/data/handler/test/ObjectEntryFolderBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/exportimport/data/handler/test/ObjectEntryFolderBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.DEPOT)
+@RunWith(Arquillian.class)
+public class ObjectEntryFolderBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				RandomTestUtil.randomString(), groupId, userId,
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(groupId, userId));
+
+		objectEntryFolder.setModifiedDate(dateModified);
+
+		objectEntryFolder =
+			_objectEntryFolderLocalService.updateObjectEntryFolder(
+				objectEntryFolder);
+
+		return objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(
+			_getObjectEntryFolder(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
+			groupId, externalReferenceCode);
+
+		return objectEntryFolder.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
+			groupId, externalReferenceCode);
+
+		return objectEntryFolder.getDescription();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			ObjectEntryFolderResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_objectEntryFolderLocalService.getObjectEntryFolders(
+				groupId, _getCompanyId(groupId),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			ObjectEntryFolder::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
+			groupId, externalReferenceCode);
+
+		return objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
+			groupId, externalReferenceCode);
+
+		_objectEntryFolderLocalService.updateObjectEntryFolder(
+			objectEntryFolder.getUserId(),
+			objectEntryFolder.getObjectEntryFolderId(),
+			objectEntryFolder.getParentObjectEntryFolderId(),
+			RandomTestUtil.randomString(), objectEntryFolder.getLabelMap(),
+			objectEntryFolder.getName(),
+			ServiceContextTestUtil.getServiceContext(
+				groupId, objectEntryFolder.getUserId()));
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private ObjectEntryFolder _getObjectEntryFolder(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _objectEntryFolderLocalService.
+			fetchObjectEntryFolderByExternalReferenceCode(
+				externalReferenceCode, groupId, _getCompanyId(groupId));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/oauth-client/oauth-client-rest-test/build.gradle
+++ b/modules/apps/oauth-client/oauth-client-rest-test/build.gradle
@@ -4,6 +4,10 @@ dependencies {
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
+	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:oauth-client:oauth-client-api")
 	testIntegrationImplementation project(":apps:oauth-client:oauth-client-persistence-api")

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/internal/exportimport/data/handler/test/OAuthClientASLocalMetadataBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/internal/exportimport/data/handler/test/OAuthClientASLocalMetadataBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,192 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.oauth.client.persistence.model.OAuthClientASLocalMetadata;
+import com.liferay.oauth.client.persistence.service.OAuthClientASLocalMetadataLocalService;
+import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientASLocalMetadataResource;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class OAuthClientASLocalMetadataBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				addOAuthClientASLocalMetadata(
+					RandomTestUtil.randomString(), userId, _randomURL(),
+					_randomURL(), _randomURL(), false, _randomURL(),
+					new String[] {"authorization_code"},
+					new String[] {"openid"}, new String[] {"public"},
+					_randomURL(), _randomURL());
+
+		oAuthClientASLocalMetadata.setModifiedDate(dateModified);
+
+		oAuthClientASLocalMetadata =
+			_oAuthClientASLocalMetadataLocalService.
+				updateOAuthClientASLocalMetadata(oAuthClientASLocalMetadata);
+
+		return oAuthClientASLocalMetadata.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_oAuthClientASLocalMetadataLocalService.
+			deleteOAuthClientASLocalMetadata(
+				_getOAuthClientASLocalMetadata(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_getOAuthClientASLocalMetadata(groupId, externalReferenceCode);
+
+		return oAuthClientASLocalMetadata.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_getOAuthClientASLocalMetadata(groupId, externalReferenceCode);
+
+		return oAuthClientASLocalMetadata.getTokenEndpoint();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			OAuthClientASLocalMetadataResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		long companyId = _getCompanyId(groupId);
+
+		return TransformUtil.transform(
+			ListUtil.filter(
+				_oAuthClientASLocalMetadataLocalService.
+					getOAuthClientASLocalMetadatas(
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				oAuthClientASLocalMetadata ->
+					oAuthClientASLocalMetadata.getCompanyId() == companyId),
+			OAuthClientASLocalMetadata::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_getOAuthClientASLocalMetadata(groupId, externalReferenceCode);
+
+		return oAuthClientASLocalMetadata.getOAuthClientASLocalMetadataId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
+			_getOAuthClientASLocalMetadata(groupId, externalReferenceCode);
+
+		_oAuthClientASLocalMetadataLocalService.
+			updateOAuthClientASLocalMetadata(
+				oAuthClientASLocalMetadata.getOAuthClientASLocalMetadataId(),
+				oAuthClientASLocalMetadata.getAuthorizationEndpoint(),
+				oAuthClientASLocalMetadata.getIssuer(),
+				oAuthClientASLocalMetadata.getJwksURI(),
+				oAuthClientASLocalMetadata.isLocalWellKnownEnabled(),
+				oAuthClientASLocalMetadata.getRegistrationEndpoint(),
+				oAuthClientASLocalMetadata.getSupportedGrantTypesArray(),
+				oAuthClientASLocalMetadata.getSupportedScopesArray(),
+				oAuthClientASLocalMetadata.getSupportedSubjectTypesArray(),
+				_randomURL(), oAuthClientASLocalMetadata.getUserInfoEndpoint());
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private OAuthClientASLocalMetadata _getOAuthClientASLocalMetadata(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _oAuthClientASLocalMetadataLocalService.
+			fetchOAuthClientASLocalMetadataByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private String _randomURL() {
+		return "http://localhost/" + RandomTestUtil.randomString();
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private OAuthClientASLocalMetadataLocalService
+		_oAuthClientASLocalMetadataLocalService;
+
+}

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/internal/exportimport/data/handler/test/OAuthClientEntryBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/internal/exportimport/data/handler/test/OAuthClientEntryBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,219 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.oauth.client.persistence.constants.OAuthClientEntryConstants;
+import com.liferay.oauth.client.persistence.model.OAuthClientEntry;
+import com.liferay.oauth.client.persistence.service.OAuthClientEntryLocalService;
+import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientEntryResource;
+import com.liferay.oauth.client.test.util.OpenIdConnectProviderHttpServer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class OAuthClientEntryBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_openIdConnectProviderHttpServer =
+			new OpenIdConnectProviderHttpServer();
+	}
+
+	@After
+	public void tearDown() {
+		if (_openIdConnectProviderHttpServer != null) {
+			_openIdConnectProviderHttpServer.close();
+
+			_openIdConnectProviderHttpServer = null;
+		}
+	}
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		OAuthClientEntry oAuthClientEntry =
+			_oAuthClientEntryLocalService.addOAuthClientEntry(
+				RandomTestUtil.randomString(), userId, _randomJSON(),
+				_openIdConnectProviderHttpServer.getURL(), _randomJSON(),
+				_getInfoJSON(), "email", 0,
+				OAuthClientEntryConstants.OIDC_USER_INFO_MAPPER_JSON, 0,
+				_randomJSON());
+
+		oAuthClientEntry.setModifiedDate(dateModified);
+
+		oAuthClientEntry = _oAuthClientEntryLocalService.updateOAuthClientEntry(
+			oAuthClientEntry);
+
+		return oAuthClientEntry.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_oAuthClientEntryLocalService.deleteOAuthClientEntry(
+			_getOAuthClientEntry(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientEntry oAuthClientEntry = _getOAuthClientEntry(
+			groupId, externalReferenceCode);
+
+		return oAuthClientEntry.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientEntry oAuthClientEntry = _getOAuthClientEntry(
+			groupId, externalReferenceCode);
+
+		return oAuthClientEntry.getMatcherField();
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			OAuthClientEntryResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_oAuthClientEntryLocalService.getCompanyOAuthClientEntries(
+				_getCompanyId(groupId)),
+			OAuthClientEntry::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientEntry oAuthClientEntry = _getOAuthClientEntry(
+			groupId, externalReferenceCode);
+
+		return oAuthClientEntry.getOAuthClientEntryId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		OAuthClientEntry oAuthClientEntry = _getOAuthClientEntry(
+			groupId, externalReferenceCode);
+
+		_oAuthClientEntryLocalService.updateOAuthClientEntry(
+			oAuthClientEntry.getOAuthClientEntryId(),
+			oAuthClientEntry.getAuthRequestParametersJSON(),
+			oAuthClientEntry.getAuthServerWellKnownURI(),
+			oAuthClientEntry.getCustomClaimsJSON(),
+			oAuthClientEntry.getInfoJSON(), RandomTestUtil.randomString(),
+			oAuthClientEntry.getMetadataCacheTime(),
+			oAuthClientEntry.getOIDCUserInfoMapperJSON(),
+			oAuthClientEntry.getTokenConnectionTimeout(),
+			oAuthClientEntry.getTokenRequestParametersJSON());
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private String _getInfoJSON() {
+		return JSONUtil.put(
+			"client_id", RandomTestUtil.randomString()
+		).put(
+			"client_name", "example_client"
+		).put(
+			"client_secret", RandomTestUtil.randomString()
+		).put(
+			"scope", "openid email profile"
+		).put(
+			"subject_type", "public"
+		).toString();
+	}
+
+	private OAuthClientEntry _getOAuthClientEntry(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _oAuthClientEntryLocalService.
+			fetchOAuthClientEntryByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	private String _randomJSON() {
+		return JSONUtil.put(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString()
+		).toString();
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private OAuthClientEntryLocalService _oAuthClientEntryLocalService;
+
+	private OpenIdConnectProviderHttpServer _openIdConnectProviderHttpServer;
+
+}

--- a/modules/apps/object/object-admin-rest-test/build.gradle
+++ b/modules/apps/object/object-admin-rest-test/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:feature-flag:feature-flag-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/internal/exportimport/data/handler/test/ObjectDefinitionBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/internal/exportimport/data/handler/test/ObjectDefinitionBatchEnginePortletDataHandlerTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.admin.rest.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.rule.ExportImportScopes;
+import com.liferay.exportimport.test.util.exportimport.data.handler.BaseBatchEnginePortletDataHandlerTestCase;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@ExportImportScopes(Scope.COMPANY)
+@RunWith(Arquillian.class)
+public class ObjectDefinitionBatchEnginePortletDataHandlerTest
+	extends BaseBatchEnginePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected String addEntry(long groupId, long userId, Date dateModified)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				RandomTestUtil.randomString(), userId, 0, null, true, true,
+				false, false, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionTestUtil.getRandomName(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, ObjectDefinitionConstants.SCOPE_COMPANY,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), new ServiceContext());
+
+		objectDefinition.setModifiedDate(dateModified);
+
+		objectDefinition = _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+
+		return objectDefinition.getExternalReferenceCode();
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected void deleteEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_getObjectDefinition(groupId, externalReferenceCode));
+	}
+
+	@Override
+	protected long getCreatorUserId(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _getObjectDefinition(
+			groupId, externalReferenceCode);
+
+		return objectDefinition.getUserId();
+	}
+
+	@Override
+	protected Object getEntryValue(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _getObjectDefinition(
+			groupId, externalReferenceCode);
+
+		return objectDefinition.getLabel(
+			objectDefinition.getDefaultLanguageId());
+	}
+
+	@Override
+	protected ExportImportVulcanBatchEngineTaskItemDelegate<?>
+		getExportImportVulcanBatchEngineTaskItemDelegate() {
+
+		return getExportImportVulcanBatchEngineTaskItemDelegate(
+			ObjectDefinitionResource.class);
+	}
+
+	@Override
+	protected List<String> getExternalReferenceCodes(long groupId)
+		throws Exception {
+
+		return TransformUtil.transform(
+			_objectDefinitionLocalService.getObjectDefinitions(
+				_getCompanyId(groupId), WorkflowConstants.STATUS_ANY),
+			ObjectDefinition::getExternalReferenceCode);
+	}
+
+	@Override
+	protected long getPrimaryKey(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _getObjectDefinition(
+			groupId, externalReferenceCode);
+
+		return objectDefinition.getObjectDefinitionId();
+	}
+
+	@Override
+	protected boolean supportsComments() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsEmptyEntries() {
+		return false;
+	}
+
+	@Override
+	protected void updateEntry(long groupId, String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _getObjectDefinition(
+			groupId, externalReferenceCode);
+
+		objectDefinition.setLabelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()));
+
+		_objectDefinitionLocalService.updateObjectDefinition(objectDefinition);
+	}
+
+	private long _getCompanyId(long groupId) throws Exception {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		return group.getCompanyId();
+	}
+
+	private ObjectDefinition _getObjectDefinition(
+			long groupId, String externalReferenceCode)
+		throws Exception {
+
+		return _objectDefinitionLocalService.
+			fetchObjectDefinitionByExternalReferenceCode(
+				externalReferenceCode, _getCompanyId(groupId));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/exportimport/data/handler/test/ObjectEntryBatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/exportimport/data/handler/test/ObjectEntryBatchEnginePortletDataHandlerTest.java
@@ -296,6 +296,11 @@ public class ObjectEntryBatchEnginePortletDataHandlerTest
 	}
 
 	@Override
+	protected boolean supportsEmptyEntries() {
+		return true;
+	}
+
+	@Override
 	protected void updateEntry(long groupId, String externalReferenceCode)
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97697

Stacked on top of the `LPD-97697-scope-fixtures` base branch, which carries the four commits from https://github.com/liferay-headless/liferay-portal/pull/4054 rebased onto master. Only the two commits in this PR are new.

**What is being fixed:** `BaseBatchEnginePortletDataHandlerTestCase` only covered three delegates — ObjectEntry, TaxonomyVocabulary and TaxonomyCategory — so nothing verified that the rest of the entities exported through a `BatchEnginePortletDataHandler` actually round trip through the publication infrastructure. The base also demanded an `addEmptyEntry` implementation from every subclass, which most entities cannot provide because they have no empty model concept.

**How it is being fixed:** The base gains `supportsEmptyEntries`, mirroring the existing `supportsComments`, and `addEmptyEntry` and `getStatus` become default implementations that throw, so a delegate only implements them when it declares support. On top of that, every `ExportImportVulcanBatchEngineTaskItemDelegate` outside headless-admin-site now has a compliance test: Keyword, Role, UserGroup, Account, AccountGroup, Organization, Country, Region, ListTypeDefinition, ObjectEntryFolder, OAuthClientEntry, OAuthClientASLocalMetadata and ObjectDefinition. The company scoped entities resolve their company from the scope group, since the base hands out a group id while these entities live at the company level.

Several tests are red on purpose, reporting gaps the suite exists to surface rather than hiding them behind a capability flag. The resource permission set on a source entry does not reach the target for any company scoped entity, asset tags declare no individual scope resource actions at all, and Keyword declares staging support while a changeset scoped export imports nothing.

Two caveats for the reviewer. The nine headless-admin-site delegates are not covered yet. Five of the new classes — ListTypeDefinition, ObjectEntryFolder, OAuthClientEntry, OAuthClientASLocalMetadata and ObjectDefinition — compile and are formatted but have not been executed against a bundle, and the Country and Region classes are slow enough to be a problem in CI, since at company scope they export the entire seeded country table.