### PR TITLE
LPD-100526 Fix the portlet export and import of Control Panel portlets

### DIFF
--- a/modules/apps/export-import/export-import-rest-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import REST API
 Bundle-SymbolicName: com.liferay.exportimport.rest.api
-Bundle-Version: 5.1.1
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.exportimport.rest.dto.v1_0,\
 	com.liferay.exportimport.rest.resource.v1_0

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportPreviewResource.java
@@ -43,29 +43,17 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface ExportPreviewResource {
 
 	public ExportPreview getAssetLibraryExportPreview(
-			String assetLibraryExternalReferenceCode, Date endDate,
-			Date startDate)
+			String assetLibraryExternalReferenceCode, Date endDate, Long plid,
+			String portletId, Date startDate)
 		throws Exception;
 
-	public ExportPreview getAssetLibraryPortletExportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Date endDate, Long plid, Date startDate)
-		throws Exception;
-
-	public ExportPreview getExportPreview(Date endDate, Date startDate)
-		throws Exception;
-
-	public ExportPreview getPortletExportPreview(
-			String portletId, Date endDate, Long plid, Date startDate)
+	public ExportPreview getExportPreview(
+			Date endDate, Long plid, String portletId, Date startDate)
 		throws Exception;
 
 	public ExportPreview getSiteExportPreview(
-			String siteExternalReferenceCode, Date endDate, Date startDate)
-		throws Exception;
-
-	public ExportPreview getSitePortletExportPreview(
-			String siteExternalReferenceCode, String portletId, Date endDate,
-			Long plid, Date startDate)
+			String siteExternalReferenceCode, Date endDate, Long plid,
+			String portletId, Date startDate)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -156,4 +144,4 @@ public interface ExportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-877717860
+// LIFERAY-REST-BUILDER-HASH:1891978607

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportPreviewResource.java
@@ -55,6 +55,10 @@ public interface ExportPreviewResource {
 	public ExportPreview getExportPreview(Date endDate, Date startDate)
 		throws Exception;
 
+	public ExportPreview getPortletExportPreview(
+			String portletId, Date endDate, Long plid, Date startDate)
+		throws Exception;
+
 	public ExportPreview getSiteExportPreview(
 			String siteExternalReferenceCode, Date endDate, Date startDate)
 		throws Exception;
@@ -152,4 +156,4 @@ public interface ExportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:244394098
+// LIFERAY-REST-BUILDER-HASH:-877717860

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportProcessResource.java
@@ -81,6 +81,12 @@ public interface ExportProcessResource {
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
+	public Page<ExportProcess> getPortletExportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	public Page<ExportProcess> getSiteExportProcessesPage(
 			String siteExternalReferenceCode, Long creatorId, String search,
 			Integer status, Pagination pagination,
@@ -132,6 +138,11 @@ public interface ExportProcessResource {
 			Long creatorId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
+		throws Exception;
+
+	public ExportProcess postPortletExportProcess(
+			String portletId, Long plid,
+			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public ExportProcess postSiteExportProcess(
@@ -252,4 +263,4 @@ public interface ExportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1845212112
+// LIFERAY-REST-BUILDER-HASH:1474850743

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ExportProcessResource.java
@@ -55,13 +55,7 @@ public interface ExportProcessResource {
 
 	public Page<ExportProcess> getAssetLibraryExportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ExportProcess> getAssetLibraryPortletExportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
+			String portletId, String search, Integer status,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
@@ -76,57 +70,42 @@ public interface ExportProcessResource {
 		throws Exception;
 
 	public Page<ExportProcess> getExportProcessesPage(
-			Long creatorId, String search, Integer status,
-			Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ExportProcess> getPortletExportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
 	public Page<ExportProcess> getSiteExportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ExportProcess> getSitePortletExportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
 	public ExportProcess postAssetLibraryExportProcess(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public Response postAssetLibraryExportProcessBatch(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest, String callbackURL,
-			Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest,
+			String callbackURL, Object object)
 		throws Exception;
 
 	public Response postAssetLibraryExportProcessesPageExportBatch(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status,
+			String portletId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
 		throws Exception;
 
-	public ExportProcess postAssetLibraryPortletExportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
 	public ExportProcess postExportProcess(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public Response postExportProcessBatch(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
@@ -135,36 +114,27 @@ public interface ExportProcessResource {
 		throws Exception;
 
 	public Response postExportProcessesPageExportBatch(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
 		throws Exception;
 
-	public ExportProcess postPortletExportProcess(
-			String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
 	public ExportProcess postSiteExportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public Response postSiteExportProcessBatch(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public Response postSiteExportProcessesPageExportBatch(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, com.liferay.portal.kernel.search.Sort[] sorts,
-			String callbackURL, String contentType, String fieldNames)
-		throws Exception;
-
-	public ExportProcess postSitePortletExportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -263,4 +233,4 @@ public interface ExportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1474850743
+// LIFERAY-REST-BUILDER-HASH:-396753810

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportPreviewResource.java
@@ -67,6 +67,10 @@ public interface ImportPreviewResource {
 			MultipartBody multipartBody, String callbackURL, Object object)
 		throws Exception;
 
+	public ImportPreview postPortletImportPreview(
+			String portletId, Long plid, MultipartBody multipartBody)
+		throws Exception;
+
 	public ImportPreview postSiteImportPreview(
 			String siteExternalReferenceCode, MultipartBody multipartBody)
 		throws Exception;
@@ -177,4 +181,4 @@ public interface ImportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-224406554
+// LIFERAY-REST-BUILDER-HASH:2043114669

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportPreviewResource.java
@@ -46,43 +46,33 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface ImportPreviewResource {
 
 	public ImportPreview postAssetLibraryImportPreview(
-			String assetLibraryExternalReferenceCode,
-			MultipartBody multipartBody)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, MultipartBody multipartBody)
 		throws Exception;
 
 	public Response postAssetLibraryImportPreviewBatch(
-			String assetLibraryExternalReferenceCode,
-			MultipartBody multipartBody, String callbackURL, Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, MultipartBody multipartBody, String callbackURL,
+			Object object)
 		throws Exception;
 
-	public ImportPreview postAssetLibraryPortletImportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, MultipartBody multipartBody)
-		throws Exception;
-
-	public ImportPreview postImportPreview(MultipartBody multipartBody)
+	public ImportPreview postImportPreview(
+			Long plid, String portletId, MultipartBody multipartBody)
 		throws Exception;
 
 	public Response postImportPreviewBatch(
-			MultipartBody multipartBody, String callbackURL, Object object)
-		throws Exception;
-
-	public ImportPreview postPortletImportPreview(
-			String portletId, Long plid, MultipartBody multipartBody)
-		throws Exception;
-
-	public ImportPreview postSiteImportPreview(
-			String siteExternalReferenceCode, MultipartBody multipartBody)
-		throws Exception;
-
-	public Response postSiteImportPreviewBatch(
-			String siteExternalReferenceCode, MultipartBody multipartBody,
+			Long plid, String portletId, MultipartBody multipartBody,
 			String callbackURL, Object object)
 		throws Exception;
 
-	public ImportPreview postSitePortletImportPreview(
-			String siteExternalReferenceCode, String portletId, Long plid,
+	public ImportPreview postSiteImportPreview(
+			String siteExternalReferenceCode, Long plid, String portletId,
 			MultipartBody multipartBody)
+		throws Exception;
+
+	public Response postSiteImportPreviewBatch(
+			String siteExternalReferenceCode, Long plid, String portletId,
+			MultipartBody multipartBody, String callbackURL, Object object)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -181,4 +171,4 @@ public interface ImportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2043114669
+// LIFERAY-REST-BUILDER-HASH:2105655360

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
@@ -55,13 +55,7 @@ public interface ImportProcessResource {
 
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ImportProcess> getAssetLibraryPortletImportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
+			String portletId, String search, Integer status,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
@@ -73,92 +67,68 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Page<ImportProcess> getImportProcessesPage(
-			Long creatorId, String search, Integer status,
-			Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ImportProcess> getPortletImportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws Exception;
-
-	public Page<ImportProcess> getSitePortletImportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
 	public ImportProcess postAssetLibraryImportProcess(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public Response postAssetLibraryImportProcessBatch(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest, String callbackURL,
-			Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest,
+			String callbackURL, Object object)
 		throws Exception;
 
 	public Response postAssetLibraryImportProcessesPageExportBatch(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status,
+			String portletId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
 		throws Exception;
 
-	public ImportProcess postAssetLibraryPortletImportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ImportProcessRequest importProcessRequest)
-		throws Exception;
-
 	public ImportProcess postImportProcess(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public Response postImportProcessBatch(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public Response postImportProcessesPageExportBatch(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
 		throws Exception;
 
-	public ImportProcess postPortletImportProcess(
-			String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception;
-
 	public ImportProcess postSiteImportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public Response postSiteImportProcessBatch(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public Response postSiteImportProcessesPageExportBatch(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, com.liferay.portal.kernel.search.Sort[] sorts,
-			String callbackURL, String contentType, String fieldNames)
-		throws Exception;
-
-	public ImportProcess postSitePortletImportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -257,4 +227,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:419484224
+// LIFERAY-REST-BUILDER-HASH:1354619723

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
@@ -78,6 +78,12 @@ public interface ImportProcessResource {
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
+	public Page<ImportProcess> getPortletImportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	public Page<ImportProcess> getSiteImportProcessesPage(
 			String siteExternalReferenceCode, Long creatorId, String search,
 			Integer status, Pagination pagination,
@@ -126,6 +132,11 @@ public interface ImportProcessResource {
 			Long creatorId, String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
+		throws Exception;
+
+	public ImportProcess postPortletImportProcess(
+			String portletId, Long plid,
+			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public ImportProcess postSiteImportProcess(
@@ -246,4 +257,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1370542329
+// LIFERAY-REST-BUILDER-HASH:419484224

--- a/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/resource/v1_0/packageinfo
+++ b/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportPreviewResource.java
@@ -64,6 +64,16 @@ public interface ExportPreviewResource {
 			java.util.Date endDate, java.util.Date startDate)
 		throws Exception;
 
+	public ExportPreview getPortletExportPreview(
+			String portletId, java.util.Date endDate, Long plid,
+			java.util.Date startDate)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPortletExportPreviewHttpResponse(
+			String portletId, java.util.Date endDate, Long plid,
+			java.util.Date startDate)
+		throws Exception;
+
 	public ExportPreview getSiteExportPreview(
 			String siteExternalReferenceCode, java.util.Date endDate,
 			java.util.Date startDate)
@@ -566,6 +576,132 @@ public interface ExportPreviewResource {
 			return httpInvoker.invoke();
 		}
 
+		public ExportPreview getPortletExportPreview(
+				String portletId, java.util.Date endDate, Long plid,
+				java.util.Date startDate)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPortletExportPreviewHttpResponse(
+					portletId, endDate, plid, startDate);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ExportPreviewSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getPortletExportPreviewHttpResponse(
+				String portletId, java.util.Date endDate, Long plid,
+				java.util.Date startDate)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+				"yyyy-MM-dd'T'HH:mm:ssXX");
+
+			if (endDate != null) {
+				httpInvoker.parameter(
+					"endDate", liferayToJSONDateFormat.format(endDate));
+			}
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (startDate != null) {
+				httpInvoker.parameter(
+					"startDate", liferayToJSONDateFormat.format(startDate));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/export-preview");
+
+			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public ExportPreview getSiteExportPreview(
 				String siteExternalReferenceCode, java.util.Date endDate,
 				java.util.Date startDate)
@@ -830,4 +966,4 @@ public interface ExportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:823374822
+// LIFERAY-REST-BUILDER-HASH:-2119587010

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportPreviewResource.java
@@ -37,61 +37,32 @@ public interface ExportPreviewResource {
 
 	public ExportPreview getAssetLibraryExportPreview(
 			String assetLibraryExternalReferenceCode, java.util.Date endDate,
-			java.util.Date startDate)
+			Long plid, String portletId, java.util.Date startDate)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getAssetLibraryExportPreviewHttpResponse(
 			String assetLibraryExternalReferenceCode, java.util.Date endDate,
-			java.util.Date startDate)
-		throws Exception;
-
-	public ExportPreview getAssetLibraryPortletExportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			java.util.Date endDate, Long plid, java.util.Date startDate)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			getAssetLibraryPortletExportPreviewHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				java.util.Date endDate, Long plid, java.util.Date startDate)
+			Long plid, String portletId, java.util.Date startDate)
 		throws Exception;
 
 	public ExportPreview getExportPreview(
-			java.util.Date endDate, java.util.Date startDate)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getExportPreviewHttpResponse(
-			java.util.Date endDate, java.util.Date startDate)
-		throws Exception;
-
-	public ExportPreview getPortletExportPreview(
-			String portletId, java.util.Date endDate, Long plid,
+			java.util.Date endDate, Long plid, String portletId,
 			java.util.Date startDate)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getPortletExportPreviewHttpResponse(
-			String portletId, java.util.Date endDate, Long plid,
+	public HttpInvoker.HttpResponse getExportPreviewHttpResponse(
+			java.util.Date endDate, Long plid, String portletId,
 			java.util.Date startDate)
 		throws Exception;
 
 	public ExportPreview getSiteExportPreview(
-			String siteExternalReferenceCode, java.util.Date endDate,
-			java.util.Date startDate)
+			String siteExternalReferenceCode, java.util.Date endDate, Long plid,
+			String portletId, java.util.Date startDate)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSiteExportPreviewHttpResponse(
-			String siteExternalReferenceCode, java.util.Date endDate,
-			java.util.Date startDate)
-		throws Exception;
-
-	public ExportPreview getSitePortletExportPreview(
-			String siteExternalReferenceCode, String portletId,
-			java.util.Date endDate, Long plid, java.util.Date startDate)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getSitePortletExportPreviewHttpResponse(
-			String siteExternalReferenceCode, String portletId,
-			java.util.Date endDate, Long plid, java.util.Date startDate)
+			String siteExternalReferenceCode, java.util.Date endDate, Long plid,
+			String portletId, java.util.Date startDate)
 		throws Exception;
 
 	public static class Builder {
@@ -205,12 +176,14 @@ public interface ExportPreviewResource {
 
 		public ExportPreview getAssetLibraryExportPreview(
 				String assetLibraryExternalReferenceCode,
-				java.util.Date endDate, java.util.Date startDate)
+				java.util.Date endDate, Long plid, String portletId,
+				java.util.Date startDate)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getAssetLibraryExportPreviewHttpResponse(
-					assetLibraryExternalReferenceCode, endDate, startDate);
+					assetLibraryExternalReferenceCode, endDate, plid, portletId,
+					startDate);
 
 			String content = httpResponse.getContent();
 
@@ -274,133 +247,8 @@ public interface ExportPreviewResource {
 		public HttpInvoker.HttpResponse
 				getAssetLibraryExportPreviewHttpResponse(
 					String assetLibraryExternalReferenceCode,
-					java.util.Date endDate, java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ssXX");
-
-			if (endDate != null) {
-				httpInvoker.parameter(
-					"endDate", liferayToJSONDateFormat.format(endDate));
-			}
-
-			if (startDate != null) {
-				httpInvoker.parameter(
-					"startDate", liferayToJSONDateFormat.format(startDate));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-preview");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ExportPreview getAssetLibraryPortletExportPreview(
-				String assetLibraryExternalReferenceCode, String portletId,
-				java.util.Date endDate, Long plid, java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getAssetLibraryPortletExportPreviewHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, endDate, plid,
-					startDate);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				getAssetLibraryPortletExportPreviewHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					java.util.Date endDate, Long plid, java.util.Date startDate)
+					java.util.Date endDate, Long plid, String portletId,
+					java.util.Date startDate)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -436,6 +284,10 @@ public interface ExportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (startDate != null) {
 				httpInvoker.parameter(
 					"startDate", liferayToJSONDateFormat.format(startDate));
@@ -444,12 +296,11 @@ public interface ExportPreviewResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-preview");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-preview");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -460,11 +311,13 @@ public interface ExportPreviewResource {
 		}
 
 		public ExportPreview getExportPreview(
-				java.util.Date endDate, java.util.Date startDate)
+				java.util.Date endDate, Long plid, String portletId,
+				java.util.Date startDate)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getExportPreviewHttpResponse(endDate, startDate);
+				getExportPreviewHttpResponse(
+					endDate, plid, portletId, startDate);
 
 			String content = httpResponse.getContent();
 
@@ -526,126 +379,7 @@ public interface ExportPreviewResource {
 		}
 
 		public HttpInvoker.HttpResponse getExportPreviewHttpResponse(
-				java.util.Date endDate, java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ssXX");
-
-			if (endDate != null) {
-				httpInvoker.parameter(
-					"endDate", liferayToJSONDateFormat.format(endDate));
-			}
-
-			if (startDate != null) {
-				httpInvoker.parameter(
-					"startDate", liferayToJSONDateFormat.format(startDate));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/export-preview");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ExportPreview getPortletExportPreview(
-				String portletId, java.util.Date endDate, Long plid,
-				java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getPortletExportPreviewHttpResponse(
-					portletId, endDate, plid, startDate);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getPortletExportPreviewHttpResponse(
-				String portletId, java.util.Date endDate, Long plid,
+				java.util.Date endDate, Long plid, String portletId,
 				java.util.Date startDate)
 			throws Exception {
 
@@ -682,6 +416,10 @@ public interface ExportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (startDate != null) {
 				httpInvoker.parameter(
 					"startDate", liferayToJSONDateFormat.format(startDate));
@@ -690,9 +428,7 @@ public interface ExportPreviewResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/export-preview");
-
-			httpInvoker.path("portletId", portletId);
+						"/o/export-import/v1.0/export-preview");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -704,12 +440,13 @@ public interface ExportPreviewResource {
 
 		public ExportPreview getSiteExportPreview(
 				String siteExternalReferenceCode, java.util.Date endDate,
-				java.util.Date startDate)
+				Long plid, String portletId, java.util.Date startDate)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getSiteExportPreviewHttpResponse(
-					siteExternalReferenceCode, endDate, startDate);
+					siteExternalReferenceCode, endDate, plid, portletId,
+					startDate);
 
 			String content = httpResponse.getContent();
 
@@ -772,131 +509,7 @@ public interface ExportPreviewResource {
 
 		public HttpInvoker.HttpResponse getSiteExportPreviewHttpResponse(
 				String siteExternalReferenceCode, java.util.Date endDate,
-				java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ssXX");
-
-			if (endDate != null) {
-				httpInvoker.parameter(
-					"endDate", liferayToJSONDateFormat.format(endDate));
-			}
-
-			if (startDate != null) {
-				httpInvoker.parameter(
-					"startDate", liferayToJSONDateFormat.format(startDate));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-preview");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ExportPreview getSitePortletExportPreview(
-				String siteExternalReferenceCode, String portletId,
-				java.util.Date endDate, Long plid, java.util.Date startDate)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getSitePortletExportPreviewHttpResponse(
-					siteExternalReferenceCode, portletId, endDate, plid,
-					startDate);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getSitePortletExportPreviewHttpResponse(
-				String siteExternalReferenceCode, String portletId,
-				java.util.Date endDate, Long plid, java.util.Date startDate)
+				Long plid, String portletId, java.util.Date startDate)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -932,6 +545,10 @@ public interface ExportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (startDate != null) {
 				httpInvoker.parameter(
 					"startDate", liferayToJSONDateFormat.format(startDate));
@@ -940,11 +557,10 @@ public interface ExportPreviewResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-preview");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-preview");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -966,4 +582,4 @@ public interface ExportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2119587010
+// LIFERAY-REST-BUILDER-HASH:811751926

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportProcessResource.java
@@ -52,27 +52,14 @@ public interface ExportProcessResource {
 
 	public Page<ExportProcess> getAssetLibraryExportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination,
-			String sortString)
+			String portletId, String search, Integer status,
+			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			getAssetLibraryExportProcessesPageHttpResponse(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, Pagination pagination,
-				String sortString)
-		throws Exception;
-
-	public Page<ExportProcess> getAssetLibraryPortletExportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			getAssetLibraryPortletExportProcessesPageHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
+				String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 		throws Exception;
 
@@ -97,109 +84,82 @@ public interface ExportProcessResource {
 		throws Exception;
 
 	public Page<ExportProcess> getExportProcessesPage(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getExportProcessesPageHttpResponse(
-			Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public Page<ExportProcess> getPortletExportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getPortletExportProcessesPageHttpResponse(
-			String portletId, Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public Page<ExportProcess> getSiteExportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getSiteExportProcessesPageHttpResponse(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, String sortString)
-		throws Exception;
-
-	public Page<ExportProcess> getSitePortletExportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination,
 			String sortString)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse
-			getSitePortletExportProcessesPageHttpResponse(
-				String siteExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
+	public HttpInvoker.HttpResponse getSiteExportProcessesPageHttpResponse(
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public ExportProcess postAssetLibraryExportProcess(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postAssetLibraryExportProcessHttpResponse(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public void postAssetLibraryExportProcessBatch(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest, String callbackURL,
-			Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest,
+			String callbackURL, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryExportProcessBatchHttpResponse(
-				String assetLibraryExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest, String callbackURL,
-				Object object)
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ExportProcessRequest exportProcessRequest,
+				String callbackURL, Object object)
 		throws Exception;
 
 	public void postAssetLibraryExportProcessesPageExportBatch(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, String sortString,
+			String portletId, String search, Integer status, String sortString,
 			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryExportProcessesPageExportBatchHttpResponse(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, String sortString,
-				String callbackURL, String contentType, String fieldNames)
-		throws Exception;
-
-	public ExportProcess postAssetLibraryPortletExportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			postAssetLibraryPortletExportProcessHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ExportProcessRequest exportProcessRequest)
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
 		throws Exception;
 
 	public ExportProcess postExportProcess(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postExportProcessHttpResponse(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public void postExportProcessBatch(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postExportProcessBatchHttpResponse(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
@@ -212,70 +172,52 @@ public interface ExportProcessResource {
 		throws Exception;
 
 	public void postExportProcessesPageExportBatch(
-			Long creatorId, String search, Integer status, String sortString,
-			String callbackURL, String contentType, String fieldNames)
+			Long creatorId, String portletId, String search, Integer status,
+			String sortString, String callbackURL, String contentType,
+			String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postExportProcessesPageExportBatchHttpResponse(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 		throws Exception;
 
-	public ExportProcess postPortletExportProcess(
-			String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postPortletExportProcessHttpResponse(
-			String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
 	public ExportProcess postSiteExportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSiteExportProcessHttpResponse(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public void postSiteExportProcessBatch(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSiteExportProcessBatchHttpResponse(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public void postSiteExportProcessesPageExportBatch(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, String sortString, String callbackURL,
-			String contentType, String fieldNames)
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status, String sortString,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postSiteExportProcessesPageExportBatchHttpResponse(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
-		throws Exception;
-
-	public ExportProcess postSitePortletExportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postSitePortletExportProcessHttpResponse(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
 		throws Exception;
 
 	public static class Builder {
@@ -591,14 +533,14 @@ public interface ExportProcessResource {
 
 		public Page<ExportProcess> getAssetLibraryExportProcessesPage(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, Pagination pagination,
-				String sortString)
+				String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getAssetLibraryExportProcessesPageHttpResponse(
-					assetLibraryExternalReferenceCode, creatorId, search,
-					status, pagination, sortString);
+					assetLibraryExternalReferenceCode, creatorId, portletId,
+					search, status, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -662,8 +604,8 @@ public interface ExportProcessResource {
 		public HttpInvoker.HttpResponse
 				getAssetLibraryExportProcessesPageHttpResponse(
 					String assetLibraryExternalReferenceCode, Long creatorId,
-					String search, Integer status, Pagination pagination,
-					String sortString)
+					String portletId, String search, Integer status,
+					Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -689,6 +631,10 @@ public interface ExportProcessResource {
 
 			if (creatorId != null) {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
 			}
 
 			if (search != null) {
@@ -718,145 +664,6 @@ public interface ExportProcessResource {
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ExportProcess> getAssetLibraryPortletExportProcessesPage(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getAssetLibraryPortletExportProcessesPageHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, creatorId,
-					search, status, pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ExportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				getAssetLibraryPortletExportProcessesPageHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					Long creatorId, String search, Integer status,
-					Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1171,143 +978,13 @@ public interface ExportProcessResource {
 		}
 
 		public Page<ExportProcess> getExportProcessesPage(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getExportProcessesPageHttpResponse(
-					creatorId, search, status, pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ExportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getExportProcessesPageHttpResponse(
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/export-processes");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ExportProcess> getPortletExportProcessesPage(
-				String portletId, Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getPortletExportProcessesPageHttpResponse(
-					portletId, creatorId, search, status, pagination,
+					creatorId, portletId, search, status, pagination,
 					sortString);
 
 			String content = httpResponse.getContent();
@@ -1369,10 +1046,9 @@ public interface ExportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getPortletExportProcessesPageHttpResponse(
-					String portletId, Long creatorId, String search,
-					Integer status, Pagination pagination, String sortString)
+		public HttpInvoker.HttpResponse getExportProcessesPageHttpResponse(
+				Long creatorId, String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1400,6 +1076,10 @@ public interface ExportProcessResource {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
@@ -1422,9 +1102,7 @@ public interface ExportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/export-processes");
-
-			httpInvoker.path("portletId", portletId);
+						"/o/export-import/v1.0/export-processes");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1435,148 +1113,14 @@ public interface ExportProcessResource {
 		}
 
 		public Page<ExportProcess> getSiteExportProcessesPage(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getSiteExportProcessesPageHttpResponse(
-					siteExternalReferenceCode, creatorId, search, status,
-					pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ExportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getSiteExportProcessesPageHttpResponse(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ExportProcess> getSitePortletExportProcessesPage(
-				String siteExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSitePortletExportProcessesPageHttpResponse(
-					siteExternalReferenceCode, portletId, creatorId, search,
+				getSiteExportProcessesPageHttpResponse(
+					siteExternalReferenceCode, creatorId, portletId, search,
 					status, pagination, sortString);
 
 			String content = httpResponse.getContent();
@@ -1638,11 +1182,10 @@ public interface ExportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getSitePortletExportProcessesPageHttpResponse(
-					String siteExternalReferenceCode, String portletId,
-					Long creatorId, String search, Integer status,
-					Pagination pagination, String sortString)
+		public HttpInvoker.HttpResponse getSiteExportProcessesPageHttpResponse(
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1670,6 +1213,10 @@ public interface ExportProcessResource {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
@@ -1692,11 +1239,10 @@ public interface ExportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1707,375 +1253,13 @@ public interface ExportProcessResource {
 		}
 
 		public ExportProcess postAssetLibraryExportProcess(
-				String assetLibraryExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest)
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAssetLibraryExportProcessHttpResponse(
-					assetLibraryExternalReferenceCode, exportProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryExportProcessHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				exportProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postAssetLibraryExportProcessBatch(
-				String assetLibraryExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryExportProcessBatchHttpResponse(
-					assetLibraryExternalReferenceCode, exportProcessRequest,
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryExportProcessBatchHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ExportProcessRequest exportProcessRequest,
-					String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/batch");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postAssetLibraryExportProcessesPageExportBatch(
-				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, String sortString,
-				String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryExportProcessesPageExportBatchHttpResponse(
-					assetLibraryExternalReferenceCode, creatorId, search,
-					status, sortString, callbackURL, contentType, fieldNames);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryExportProcessesPageExportBatchHttpResponse(
-					String assetLibraryExternalReferenceCode, Long creatorId,
-					String search, Integer status, String sortString,
-					String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body("[]", "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			if (contentType != null) {
-				httpInvoker.parameter(
-					"contentType", String.valueOf(contentType));
-			}
-
-			if (fieldNames != null) {
-				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/export-batch");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ExportProcess postAssetLibraryPortletExportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryPortletExportProcessHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, plid,
+					assetLibraryExternalReferenceCode, plid, portletId,
 					exportProcessRequest);
 
 			String content = httpResponse.getContent();
@@ -2138,9 +1322,9 @@ public interface ExportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAssetLibraryPortletExportProcessHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					Long plid, ExportProcessRequest exportProcessRequest)
+				postAssetLibraryExportProcessHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -2171,15 +1355,280 @@ public interface ExportProcessResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryExportProcessBatch(
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ExportProcessRequest exportProcessRequest,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryExportProcessBatchHttpResponse(
+					assetLibraryExternalReferenceCode, plid, portletId,
+					exportProcessRequest, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryExportProcessBatchHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ExportProcessRequest exportProcessRequest,
+					String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/batch");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryExportProcessesPageExportBatch(
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryExportProcessesPageExportBatchHttpResponse(
+					assetLibraryExternalReferenceCode, creatorId, portletId,
+					search, status, sortString, callbackURL, contentType,
+					fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryExportProcessesPageExportBatchHttpResponse(
+					String assetLibraryExternalReferenceCode, Long creatorId,
+					String portletId, String search, Integer status,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/export-batch");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -2190,11 +1639,13 @@ public interface ExportProcessResource {
 		}
 
 		public ExportProcess postExportProcess(
+				Long plid, String portletId,
 				ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postExportProcessHttpResponse(exportProcessRequest);
+				postExportProcessHttpResponse(
+					plid, portletId, exportProcessRequest);
 
 			String content = httpResponse.getContent();
 
@@ -2256,6 +1707,7 @@ public interface ExportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse postExportProcessHttpResponse(
+				Long plid, String portletId,
 				ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
@@ -2283,6 +1735,14 @@ public interface ExportProcessResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
@@ -2297,13 +1757,14 @@ public interface ExportProcessResource {
 		}
 
 		public void postExportProcessBatch(
+				Long plid, String portletId,
 				ExportProcessRequest exportProcessRequest, String callbackURL,
 				Object object)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postExportProcessBatchHttpResponse(
-					exportProcessRequest, callbackURL, object);
+					plid, portletId, exportProcessRequest, callbackURL, object);
 
 			String content = httpResponse.getContent();
 
@@ -2354,6 +1815,7 @@ public interface ExportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse postExportProcessBatchHttpResponse(
+				Long plid, String portletId,
 				ExportProcessRequest exportProcessRequest, String callbackURL,
 				Object object)
 			throws Exception {
@@ -2380,6 +1842,14 @@ public interface ExportProcessResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
 
 			if (callbackURL != null) {
 				httpInvoker.parameter(
@@ -2507,15 +1977,15 @@ public interface ExportProcessResource {
 		}
 
 		public void postExportProcessesPageExportBatch(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postExportProcessesPageExportBatchHttpResponse(
-					creatorId, search, status, sortString, callbackURL,
-					contentType, fieldNames);
+					creatorId, portletId, search, status, sortString,
+					callbackURL, contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -2567,9 +2037,9 @@ public interface ExportProcessResource {
 
 		public HttpInvoker.HttpResponse
 				postExportProcessesPageExportBatchHttpResponse(
-					Long creatorId, String search, Integer status,
-					String sortString, String callbackURL, String contentType,
-					String fieldNames)
+					Long creatorId, String portletId, String search,
+					Integer status, String sortString, String callbackURL,
+					String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -2597,6 +2067,10 @@ public interface ExportProcessResource {
 
 			if (creatorId != null) {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
 			}
 
 			if (search != null) {
@@ -2638,487 +2112,14 @@ public interface ExportProcessResource {
 			return httpInvoker.invoke();
 		}
 
-		public ExportProcess postPortletExportProcess(
-				String portletId, Long plid,
-				ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postPortletExportProcessHttpResponse(
-					portletId, plid, exportProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postPortletExportProcessHttpResponse(
-				String portletId, Long plid,
-				ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				exportProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (plid != null) {
-				httpInvoker.parameter("plid", String.valueOf(plid));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/export-processes");
-
-			httpInvoker.path("portletId", portletId);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
 		public ExportProcess postSiteExportProcess(
-				String siteExternalReferenceCode,
+				String siteExternalReferenceCode, Long plid, String portletId,
 				ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSiteExportProcessHttpResponse(
-					siteExternalReferenceCode, exportProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ExportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteExportProcessHttpResponse(
-				String siteExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				exportProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postSiteExportProcessBatch(
-				String siteExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteExportProcessBatchHttpResponse(
-					siteExternalReferenceCode, exportProcessRequest,
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteExportProcessBatchHttpResponse(
-				String siteExternalReferenceCode,
-				ExportProcessRequest exportProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/batch");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postSiteExportProcessesPageExportBatch(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteExportProcessesPageExportBatchHttpResponse(
-					siteExternalReferenceCode, creatorId, search, status,
-					sortString, callbackURL, contentType, fieldNames);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postSiteExportProcessesPageExportBatchHttpResponse(
-					String siteExternalReferenceCode, Long creatorId,
-					String search, Integer status, String sortString,
-					String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body("[]", "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			if (contentType != null) {
-				httpInvoker.parameter(
-					"contentType", String.valueOf(contentType));
-			}
-
-			if (fieldNames != null) {
-				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/export-batch");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ExportProcess postSitePortletExportProcess(
-				String siteExternalReferenceCode, String portletId, Long plid,
-				ExportProcessRequest exportProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSitePortletExportProcessHttpResponse(
-					siteExternalReferenceCode, portletId, plid,
+					siteExternalReferenceCode, plid, portletId,
 					exportProcessRequest);
 
 			String content = httpResponse.getContent();
@@ -3180,10 +2181,9 @@ public interface ExportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				postSitePortletExportProcessHttpResponse(
-					String siteExternalReferenceCode, String portletId,
-					Long plid, ExportProcessRequest exportProcessRequest)
+		public HttpInvoker.HttpResponse postSiteExportProcessHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ExportProcessRequest exportProcessRequest)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -3214,14 +2214,275 @@ public interface ExportProcessResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteExportProcessBatch(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ExportProcessRequest exportProcessRequest, String callbackURL,
+				Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteExportProcessBatchHttpResponse(
+					siteExternalReferenceCode, plid, portletId,
+					exportProcessRequest, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteExportProcessBatchHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ExportProcessRequest exportProcessRequest, String callbackURL,
+				Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteExportProcessesPageExportBatch(
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteExportProcessesPageExportBatchHttpResponse(
+					siteExternalReferenceCode, creatorId, portletId, search,
+					status, sortString, callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postSiteExportProcessesPageExportBatchHttpResponse(
+					String siteExternalReferenceCode, Long creatorId,
+					String portletId, String search, Integer status,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/export-batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -3243,4 +2504,4 @@ public interface ExportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1650066463
+// LIFERAY-REST-BUILDER-HASH:-519095865

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ExportProcessResource.java
@@ -106,6 +106,16 @@ public interface ExportProcessResource {
 			Pagination pagination, String sortString)
 		throws Exception;
 
+	public Page<ExportProcess> getPortletExportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPortletExportProcessesPageHttpResponse(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, String sortString)
+		throws Exception;
+
 	public Page<ExportProcess> getSiteExportProcessesPage(
 			String siteExternalReferenceCode, Long creatorId, String search,
 			Integer status, Pagination pagination, String sortString)
@@ -211,6 +221,16 @@ public interface ExportProcessResource {
 				Long creatorId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
+		throws Exception;
+
+	public ExportProcess postPortletExportProcess(
+			String portletId, Long plid,
+			ExportProcessRequest exportProcessRequest)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortletExportProcessHttpResponse(
+			String portletId, Long plid,
+			ExportProcessRequest exportProcessRequest)
 		throws Exception;
 
 	public ExportProcess postSiteExportProcess(
@@ -1271,6 +1291,140 @@ public interface ExportProcessResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/export-import/v1.0/export-processes");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<ExportProcess> getPortletExportProcessesPage(
+				String portletId, Long creatorId, String search, Integer status,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPortletExportProcessesPageHttpResponse(
+					portletId, creatorId, search, status, pagination,
+					sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, ExportProcessSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getPortletExportProcessesPageHttpResponse(
+					String portletId, Long creatorId, String search,
+					Integer status, Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/export-processes");
+
+			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -2484,6 +2638,122 @@ public interface ExportProcessResource {
 			return httpInvoker.invoke();
 		}
 
+		public ExportProcess postPortletExportProcess(
+				String portletId, Long plid,
+				ExportProcessRequest exportProcessRequest)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortletExportProcessHttpResponse(
+					portletId, plid, exportProcessRequest);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ExportProcessSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortletExportProcessHttpResponse(
+				String portletId, Long plid,
+				ExportProcessRequest exportProcessRequest)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				exportProcessRequest.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/export-processes");
+
+			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public ExportProcess postSiteExportProcess(
 				String siteExternalReferenceCode,
 				ExportProcessRequest exportProcessRequest)
@@ -2973,4 +3243,4 @@ public interface ExportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1699794415
+// LIFERAY-REST-BUILDER-HASH:1650066463

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportPreviewResource.java
@@ -88,6 +88,16 @@ public interface ImportPreviewResource {
 			String callbackURL, Object object)
 		throws Exception;
 
+	public ImportPreview postPortletImportPreview(
+			String portletId, Long plid, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortletImportPreviewHttpResponse(
+			String portletId, Long plid, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
+		throws Exception;
+
 	public ImportPreview postSiteImportPreview(
 			String siteExternalReferenceCode, ImportPreview importPreview,
 			Map<String, File> multipartFiles)
@@ -807,6 +817,128 @@ public interface ImportPreviewResource {
 			return httpInvoker.invoke();
 		}
 
+		public ImportPreview postPortletImportPreview(
+				String portletId, Long plid, ImportPreview importPreview,
+				Map<String, File> multipartFiles)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortletImportPreviewHttpResponse(
+					portletId, plid, importPreview, multipartFiles);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ImportPreviewSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortletImportPreviewHttpResponse(
+				String portletId, Long plid, ImportPreview importPreview,
+				Map<String, File> multipartFiles)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.multipart();
+
+			httpInvoker.part(
+				"importPreview", ImportPreviewSerDes.toJSON(importPreview));
+
+			for (Map.Entry<String, File> entry : multipartFiles.entrySet()) {
+				httpInvoker.part(entry.getKey(), entry.getValue());
+			}
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/import-preview");
+
+			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public ImportPreview postSiteImportPreview(
 				String siteExternalReferenceCode, ImportPreview importPreview,
 				Map<String, File> multipartFiles)
@@ -1174,4 +1306,4 @@ public interface ImportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2057983589
+// LIFERAY-REST-BUILDER-HASH:-1636292396

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportPreviewResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportPreviewResource.java
@@ -35,97 +35,71 @@ public interface ImportPreviewResource {
 	}
 
 	public ImportPreview postAssetLibraryImportPreview(
-			String assetLibraryExternalReferenceCode,
-			ImportPreview importPreview, Map<String, File> multipartFiles)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postAssetLibraryImportPreviewHttpResponse(
-			String assetLibraryExternalReferenceCode,
-			ImportPreview importPreview, Map<String, File> multipartFiles)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public void postAssetLibraryImportPreviewBatch(
-			String assetLibraryExternalReferenceCode,
-			ImportPreview importPreview, Map<String, File> multipartFiles,
-			String callbackURL, Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles, String callbackURL, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryImportPreviewBatchHttpResponse(
-				String assetLibraryExternalReferenceCode,
-				ImportPreview importPreview, Map<String, File> multipartFiles,
-				String callbackURL, Object object)
-		throws Exception;
-
-	public ImportPreview postAssetLibraryPortletImportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ImportPreview importPreview,
-			Map<String, File> multipartFiles)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			postAssetLibraryPortletImportPreviewHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ImportPreview importPreview,
-				Map<String, File> multipartFiles)
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles, String callbackURL,
+				Object object)
 		throws Exception;
 
 	public ImportPreview postImportPreview(
-			ImportPreview importPreview, Map<String, File> multipartFiles)
+			Long plid, String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postImportPreviewHttpResponse(
-			ImportPreview importPreview, Map<String, File> multipartFiles)
+			Long plid, String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles)
 		throws Exception;
 
 	public void postImportPreviewBatch(
-			ImportPreview importPreview, Map<String, File> multipartFiles,
-			String callbackURL, Object object)
+			Long plid, String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles, String callbackURL, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postImportPreviewBatchHttpResponse(
+			Long plid, String portletId, ImportPreview importPreview,
+			Map<String, File> multipartFiles, String callbackURL, Object object)
+		throws Exception;
+
+	public ImportPreview postSiteImportPreview(
+			String siteExternalReferenceCode, Long plid, String portletId,
+			ImportPreview importPreview, Map<String, File> multipartFiles)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postSiteImportPreviewHttpResponse(
+			String siteExternalReferenceCode, Long plid, String portletId,
+			ImportPreview importPreview, Map<String, File> multipartFiles)
+		throws Exception;
+
+	public void postSiteImportPreviewBatch(
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportPreview importPreview, Map<String, File> multipartFiles,
 			String callbackURL, Object object)
 		throws Exception;
 
-	public ImportPreview postPortletImportPreview(
-			String portletId, Long plid, ImportPreview importPreview,
-			Map<String, File> multipartFiles)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postPortletImportPreviewHttpResponse(
-			String portletId, Long plid, ImportPreview importPreview,
-			Map<String, File> multipartFiles)
-		throws Exception;
-
-	public ImportPreview postSiteImportPreview(
-			String siteExternalReferenceCode, ImportPreview importPreview,
-			Map<String, File> multipartFiles)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postSiteImportPreviewHttpResponse(
-			String siteExternalReferenceCode, ImportPreview importPreview,
-			Map<String, File> multipartFiles)
-		throws Exception;
-
-	public void postSiteImportPreviewBatch(
-			String siteExternalReferenceCode, ImportPreview importPreview,
-			Map<String, File> multipartFiles, String callbackURL, Object object)
-		throws Exception;
-
 	public HttpInvoker.HttpResponse postSiteImportPreviewBatchHttpResponse(
-			String siteExternalReferenceCode, ImportPreview importPreview,
-			Map<String, File> multipartFiles, String callbackURL, Object object)
-		throws Exception;
-
-	public ImportPreview postSitePortletImportPreview(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportPreview importPreview, Map<String, File> multipartFiles)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postSitePortletImportPreviewHttpResponse(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportPreview importPreview, Map<String, File> multipartFiles)
+			String siteExternalReferenceCode, Long plid, String portletId,
+			ImportPreview importPreview, Map<String, File> multipartFiles,
+			String callbackURL, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -238,249 +212,14 @@ public interface ImportPreviewResource {
 		implements ImportPreviewResource {
 
 		public ImportPreview postAssetLibraryImportPreview(
-				String assetLibraryExternalReferenceCode,
-				ImportPreview importPreview, Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryImportPreviewHttpResponse(
-					assetLibraryExternalReferenceCode, importPreview,
-					multipartFiles);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryImportPreviewHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ImportPreview importPreview,
-					Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.multipart();
-
-			httpInvoker.part(
-				"importPreview", ImportPreviewSerDes.toJSON(importPreview));
-
-			for (Map.Entry<String, File> entry : multipartFiles.entrySet()) {
-				httpInvoker.part(entry.getKey(), entry.getValue());
-			}
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-preview");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postAssetLibraryImportPreviewBatch(
-				String assetLibraryExternalReferenceCode,
-				ImportPreview importPreview, Map<String, File> multipartFiles,
-				String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryImportPreviewBatchHttpResponse(
-					assetLibraryExternalReferenceCode, importPreview,
-					multipartFiles, callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryImportPreviewBatchHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ImportPreview importPreview,
-					Map<String, File> multipartFiles, String callbackURL,
-					Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-preview/batch");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ImportPreview postAssetLibraryPortletImportPreview(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ImportPreview importPreview,
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportPreview importPreview,
 				Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryPortletImportPreviewHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, plid,
+				postAssetLibraryImportPreviewHttpResponse(
+					assetLibraryExternalReferenceCode, plid, portletId,
 					importPreview, multipartFiles);
 
 			String content = httpResponse.getContent();
@@ -543,9 +282,9 @@ public interface ImportPreviewResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAssetLibraryPortletImportPreviewHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					Long plid, ImportPreview importPreview,
+				postAssetLibraryImportPreviewHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ImportPreview importPreview,
 					Map<String, File> multipartFiles)
 			throws Exception {
 
@@ -583,15 +322,139 @@ public interface ImportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-preview");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-preview");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryImportPreviewBatch(
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles, String callbackURL,
+				Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryImportPreviewBatchHttpResponse(
+					assetLibraryExternalReferenceCode, plid, portletId,
+					importPreview, multipartFiles, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryImportPreviewBatchHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ImportPreview importPreview,
+					Map<String, File> multipartFiles, String callbackURL,
+					Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-preview/batch");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -602,11 +465,13 @@ public interface ImportPreviewResource {
 		}
 
 		public ImportPreview postImportPreview(
-				ImportPreview importPreview, Map<String, File> multipartFiles)
+				Long plid, String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postImportPreviewHttpResponse(importPreview, multipartFiles);
+				postImportPreviewHttpResponse(
+					plid, portletId, importPreview, multipartFiles);
 
 			String content = httpResponse.getContent();
 
@@ -668,7 +533,8 @@ public interface ImportPreviewResource {
 		}
 
 		public HttpInvoker.HttpResponse postImportPreviewHttpResponse(
-				ImportPreview importPreview, Map<String, File> multipartFiles)
+				Long plid, String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -701,6 +567,14 @@ public interface ImportPreviewResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
@@ -715,13 +589,15 @@ public interface ImportPreviewResource {
 		}
 
 		public void postImportPreviewBatch(
-				ImportPreview importPreview, Map<String, File> multipartFiles,
-				String callbackURL, Object object)
+				Long plid, String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles, String callbackURL,
+				Object object)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postImportPreviewBatchHttpResponse(
-					importPreview, multipartFiles, callbackURL, object);
+					plid, portletId, importPreview, multipartFiles, callbackURL,
+					object);
 
 			String content = httpResponse.getContent();
 
@@ -772,134 +648,14 @@ public interface ImportPreviewResource {
 		}
 
 		public HttpInvoker.HttpResponse postImportPreviewBatchHttpResponse(
-				ImportPreview importPreview, Map<String, File> multipartFiles,
-				String callbackURL, Object object)
+				Long plid, String portletId, ImportPreview importPreview,
+				Map<String, File> multipartFiles, String callbackURL,
+				Object object)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
 			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/import-preview/batch");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ImportPreview postPortletImportPreview(
-				String portletId, Long plid, ImportPreview importPreview,
-				Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postPortletImportPreviewHttpResponse(
-					portletId, plid, importPreview, multipartFiles);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postPortletImportPreviewHttpResponse(
-				String portletId, Long plid, ImportPreview importPreview,
-				Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.multipart();
-
-			httpInvoker.part(
-				"importPreview", ImportPreviewSerDes.toJSON(importPreview));
-
-			for (Map.Entry<String, File> entry : multipartFiles.entrySet()) {
-				httpInvoker.part(entry.getKey(), entry.getValue());
-			}
 
 			if (_builder._locale != null) {
 				httpInvoker.header(
@@ -924,12 +680,19 @@ public interface ImportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/import-preview");
-
-			httpInvoker.path("portletId", portletId);
+						"/o/export-import/v1.0/import-preview/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -940,241 +703,13 @@ public interface ImportPreviewResource {
 		}
 
 		public ImportPreview postSiteImportPreview(
-				String siteExternalReferenceCode, ImportPreview importPreview,
-				Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteImportPreviewHttpResponse(
-					siteExternalReferenceCode, importPreview, multipartFiles);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportPreviewSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteImportPreviewHttpResponse(
-				String siteExternalReferenceCode, ImportPreview importPreview,
-				Map<String, File> multipartFiles)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.multipart();
-
-			httpInvoker.part(
-				"importPreview", ImportPreviewSerDes.toJSON(importPreview));
-
-			for (Map.Entry<String, File> entry : multipartFiles.entrySet()) {
-				httpInvoker.part(entry.getKey(), entry.getValue());
-			}
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postSiteImportPreviewBatch(
-				String siteExternalReferenceCode, ImportPreview importPreview,
-				Map<String, File> multipartFiles, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteImportPreviewBatchHttpResponse(
-					siteExternalReferenceCode, importPreview, multipartFiles,
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteImportPreviewBatchHttpResponse(
-				String siteExternalReferenceCode, ImportPreview importPreview,
-				Map<String, File> multipartFiles, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview/batch");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ImportPreview postSitePortletImportPreview(
-				String siteExternalReferenceCode, String portletId, Long plid,
+				String siteExternalReferenceCode, Long plid, String portletId,
 				ImportPreview importPreview, Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postSitePortletImportPreviewHttpResponse(
-					siteExternalReferenceCode, portletId, plid, importPreview,
+				postSiteImportPreviewHttpResponse(
+					siteExternalReferenceCode, plid, portletId, importPreview,
 					multipartFiles);
 
 			String content = httpResponse.getContent();
@@ -1236,11 +771,9 @@ public interface ImportPreviewResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				postSitePortletImportPreviewHttpResponse(
-					String siteExternalReferenceCode, String portletId,
-					Long plid, ImportPreview importPreview,
-					Map<String, File> multipartFiles)
+		public HttpInvoker.HttpResponse postSiteImportPreviewHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportPreview importPreview, Map<String, File> multipartFiles)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1277,14 +810,134 @@ public interface ImportPreviewResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-preview");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteImportPreviewBatch(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportPreview importPreview, Map<String, File> multipartFiles,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteImportPreviewBatchHttpResponse(
+					siteExternalReferenceCode, plid, portletId, importPreview,
+					multipartFiles, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteImportPreviewBatchHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportPreview importPreview, Map<String, File> multipartFiles,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview/batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1306,4 +959,4 @@ public interface ImportPreviewResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1636292396
+// LIFERAY-REST-BUILDER-HASH:-1739599483

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
@@ -100,6 +100,16 @@ public interface ImportProcessResource {
 			Pagination pagination, String sortString)
 		throws Exception;
 
+	public Page<ImportProcess> getPortletImportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPortletImportProcessesPageHttpResponse(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, String sortString)
+		throws Exception;
+
 	public Page<ImportProcess> getSiteImportProcessesPage(
 			String siteExternalReferenceCode, Long creatorId, String search,
 			Integer status, Pagination pagination, String sortString)
@@ -198,6 +208,16 @@ public interface ImportProcessResource {
 				Long creatorId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
+		throws Exception;
+
+	public ImportProcess postPortletImportProcess(
+			String portletId, Long plid,
+			ImportProcessRequest importProcessRequest)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortletImportProcessHttpResponse(
+			String portletId, Long plid,
+			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public ImportProcess postSiteImportProcess(
@@ -1164,6 +1184,140 @@ public interface ImportProcessResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/export-import/v1.0/import-processes");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<ImportProcess> getPortletImportProcessesPage(
+				String portletId, Long creatorId, String search, Integer status,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPortletImportProcessesPageHttpResponse(
+					portletId, creatorId, search, status, pagination,
+					sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, ImportProcessSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getPortletImportProcessesPageHttpResponse(
+					String portletId, Long creatorId, String search,
+					Integer status, Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/import-processes");
+
+			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -2270,6 +2424,122 @@ public interface ImportProcessResource {
 			return httpInvoker.invoke();
 		}
 
+		public ImportProcess postPortletImportProcess(
+				String portletId, Long plid,
+				ImportProcessRequest importProcessRequest)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortletImportProcessHttpResponse(
+					portletId, plid, importProcessRequest);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ImportProcessSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortletImportProcessHttpResponse(
+				String portletId, Long plid,
+				ImportProcessRequest importProcessRequest)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				importProcessRequest.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/portlets/{portletId}/import-processes");
+
+			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public ImportProcess postSiteImportProcess(
 				String siteExternalReferenceCode,
 				ImportProcessRequest importProcessRequest)
@@ -2759,4 +3029,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1265065574
+// LIFERAY-REST-BUILDER-HASH:-1151998588

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
@@ -52,27 +52,14 @@ public interface ImportProcessResource {
 
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination,
-			String sortString)
+			String portletId, String search, Integer status,
+			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			getAssetLibraryImportProcessesPageHttpResponse(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, Pagination pagination,
-				String sortString)
-		throws Exception;
-
-	public Page<ImportProcess> getAssetLibraryPortletImportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			getAssetLibraryPortletImportProcessesPageHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
+				String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 		throws Exception;
 
@@ -91,178 +78,133 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Page<ImportProcess> getImportProcessesPage(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getImportProcessesPageHttpResponse(
-			Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public Page<ImportProcess> getPortletImportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getPortletImportProcessesPageHttpResponse(
-			String portletId, Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, String sortString)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, String sortString)
-		throws Exception;
-
-	public Page<ImportProcess> getSitePortletImportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination,
 			String sortString)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse
-			getSitePortletImportProcessesPageHttpResponse(
-				String siteExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
+	public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public ImportProcess postAssetLibraryImportProcess(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postAssetLibraryImportProcessHttpResponse(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public void postAssetLibraryImportProcessBatch(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest, String callbackURL,
-			Object object)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest,
+			String callbackURL, Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryImportProcessBatchHttpResponse(
-				String assetLibraryExternalReferenceCode,
-				ImportProcessRequest importProcessRequest, String callbackURL,
-				Object object)
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportProcessRequest importProcessRequest,
+				String callbackURL, Object object)
 		throws Exception;
 
 	public void postAssetLibraryImportProcessesPageExportBatch(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, String sortString,
+			String portletId, String search, Integer status, String sortString,
 			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryImportProcessesPageExportBatchHttpResponse(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, String sortString,
-				String callbackURL, String contentType, String fieldNames)
-		throws Exception;
-
-	public ImportProcess postAssetLibraryPortletImportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ImportProcessRequest importProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			postAssetLibraryPortletImportProcessHttpResponse(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ImportProcessRequest importProcessRequest)
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
 		throws Exception;
 
 	public ImportProcess postImportProcess(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postImportProcessHttpResponse(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public void postImportProcessBatch(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postImportProcessBatchHttpResponse(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public void postImportProcessesPageExportBatch(
-			Long creatorId, String search, Integer status, String sortString,
-			String callbackURL, String contentType, String fieldNames)
+			Long creatorId, String portletId, String search, Integer status,
+			String sortString, String callbackURL, String contentType,
+			String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postImportProcessesPageExportBatchHttpResponse(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 		throws Exception;
 
-	public ImportProcess postPortletImportProcess(
-			String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postPortletImportProcessHttpResponse(
-			String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception;
-
 	public ImportProcess postSiteImportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSiteImportProcessHttpResponse(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception;
 
 	public void postSiteImportProcessBatch(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSiteImportProcessBatchHttpResponse(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest, String callbackURL,
 			Object object)
 		throws Exception;
 
 	public void postSiteImportProcessesPageExportBatch(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, String sortString, String callbackURL,
-			String contentType, String fieldNames)
+			String siteExternalReferenceCode, Long creatorId, String portletId,
+			String search, Integer status, String sortString,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postSiteImportProcessesPageExportBatchHttpResponse(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
-		throws Exception;
-
-	public ImportProcess postSitePortletImportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postSitePortletImportProcessHttpResponse(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
 		throws Exception;
 
 	public static class Builder {
@@ -578,14 +520,14 @@ public interface ImportProcessResource {
 
 		public Page<ImportProcess> getAssetLibraryImportProcessesPage(
 				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, Pagination pagination,
-				String sortString)
+				String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getAssetLibraryImportProcessesPageHttpResponse(
-					assetLibraryExternalReferenceCode, creatorId, search,
-					status, pagination, sortString);
+					assetLibraryExternalReferenceCode, creatorId, portletId,
+					search, status, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -649,8 +591,8 @@ public interface ImportProcessResource {
 		public HttpInvoker.HttpResponse
 				getAssetLibraryImportProcessesPageHttpResponse(
 					String assetLibraryExternalReferenceCode, Long creatorId,
-					String search, Integer status, Pagination pagination,
-					String sortString)
+					String portletId, String search, Integer status,
+					Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -676,6 +618,10 @@ public interface ImportProcessResource {
 
 			if (creatorId != null) {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
 			}
 
 			if (search != null) {
@@ -705,145 +651,6 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ImportProcess> getAssetLibraryPortletImportProcessesPage(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getAssetLibraryPortletImportProcessesPageHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, creatorId,
-					search, status, pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ImportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				getAssetLibraryPortletImportProcessesPageHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					Long creatorId, String search, Integer status,
-					Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1064,143 +871,13 @@ public interface ImportProcessResource {
 		}
 
 		public Page<ImportProcess> getImportProcessesPage(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getImportProcessesPageHttpResponse(
-					creatorId, search, status, pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ImportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getImportProcessesPageHttpResponse(
-				Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/import-processes");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ImportProcess> getPortletImportProcessesPage(
-				String portletId, Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getPortletImportProcessesPageHttpResponse(
-					portletId, creatorId, search, status, pagination,
+					creatorId, portletId, search, status, pagination,
 					sortString);
 
 			String content = httpResponse.getContent();
@@ -1262,10 +939,9 @@ public interface ImportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getPortletImportProcessesPageHttpResponse(
-					String portletId, Long creatorId, String search,
-					Integer status, Pagination pagination, String sortString)
+		public HttpInvoker.HttpResponse getImportProcessesPageHttpResponse(
+				Long creatorId, String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1293,6 +969,10 @@ public interface ImportProcessResource {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
@@ -1315,9 +995,7 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/import-processes");
-
-			httpInvoker.path("portletId", portletId);
+						"/o/export-import/v1.0/import-processes");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1328,148 +1006,14 @@ public interface ImportProcessResource {
 		}
 
 		public Page<ImportProcess> getSiteImportProcessesPage(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				getSiteImportProcessesPageHttpResponse(
-					siteExternalReferenceCode, creatorId, search, status,
-					pagination, sortString);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return Page.of(content, ImportProcessSerDes::toDTO);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (pagination != null) {
-				httpInvoker.parameter(
-					"page", String.valueOf(pagination.getPage()));
-				httpInvoker.parameter(
-					"pageSize", String.valueOf(pagination.getPageSize()));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public Page<ImportProcess> getSitePortletImportProcessesPage(
-				String siteExternalReferenceCode, String portletId,
-				Long creatorId, String search, Integer status,
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
 				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSitePortletImportProcessesPageHttpResponse(
-					siteExternalReferenceCode, portletId, creatorId, search,
+				getSiteImportProcessesPageHttpResponse(
+					siteExternalReferenceCode, creatorId, portletId, search,
 					status, pagination, sortString);
 
 			String content = httpResponse.getContent();
@@ -1531,11 +1075,10 @@ public interface ImportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getSitePortletImportProcessesPageHttpResponse(
-					String siteExternalReferenceCode, String portletId,
-					Long creatorId, String search, Integer status,
-					Pagination pagination, String sortString)
+		public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1563,6 +1106,10 @@ public interface ImportProcessResource {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
@@ -1585,11 +1132,10 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1600,375 +1146,13 @@ public interface ImportProcessResource {
 		}
 
 		public ImportProcess postAssetLibraryImportProcess(
-				String assetLibraryExternalReferenceCode,
-				ImportProcessRequest importProcessRequest)
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportProcessRequest importProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAssetLibraryImportProcessHttpResponse(
-					assetLibraryExternalReferenceCode, importProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryImportProcessHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				importProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postAssetLibraryImportProcessBatch(
-				String assetLibraryExternalReferenceCode,
-				ImportProcessRequest importProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryImportProcessBatchHttpResponse(
-					assetLibraryExternalReferenceCode, importProcessRequest,
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryImportProcessBatchHttpResponse(
-					String assetLibraryExternalReferenceCode,
-					ImportProcessRequest importProcessRequest,
-					String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/batch");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postAssetLibraryImportProcessesPageExportBatch(
-				String assetLibraryExternalReferenceCode, Long creatorId,
-				String search, Integer status, String sortString,
-				String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
-					assetLibraryExternalReferenceCode, creatorId, search,
-					status, sortString, callbackURL, contentType, fieldNames);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
-					String assetLibraryExternalReferenceCode, Long creatorId,
-					String search, Integer status, String sortString,
-					String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body("[]", "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			if (contentType != null) {
-				httpInvoker.parameter(
-					"contentType", String.valueOf(contentType));
-			}
-
-			if (fieldNames != null) {
-				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/export-batch");
-
-			httpInvoker.path(
-				"assetLibraryExternalReferenceCode",
-				assetLibraryExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ImportProcess postAssetLibraryPortletImportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				Long plid, ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postAssetLibraryPortletImportProcessHttpResponse(
-					assetLibraryExternalReferenceCode, portletId, plid,
+					assetLibraryExternalReferenceCode, plid, portletId,
 					importProcessRequest);
 
 			String content = httpResponse.getContent();
@@ -2031,9 +1215,9 @@ public interface ImportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAssetLibraryPortletImportProcessHttpResponse(
-					String assetLibraryExternalReferenceCode, String portletId,
-					Long plid, ImportProcessRequest importProcessRequest)
+				postAssetLibraryImportProcessHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ImportProcessRequest importProcessRequest)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -2064,15 +1248,280 @@ public interface ImportProcessResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
 				assetLibraryExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryImportProcessBatch(
+				String assetLibraryExternalReferenceCode, Long plid,
+				String portletId, ImportProcessRequest importProcessRequest,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryImportProcessBatchHttpResponse(
+					assetLibraryExternalReferenceCode, plid, portletId,
+					importProcessRequest, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryImportProcessBatchHttpResponse(
+					String assetLibraryExternalReferenceCode, Long plid,
+					String portletId, ImportProcessRequest importProcessRequest,
+					String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/batch");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryImportProcessesPageExportBatch(
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
+					assetLibraryExternalReferenceCode, creatorId, portletId,
+					search, status, sortString, callbackURL, contentType,
+					fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
+					String assetLibraryExternalReferenceCode, Long creatorId,
+					String portletId, String search, Integer status,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/export-batch");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -2083,11 +1532,13 @@ public interface ImportProcessResource {
 		}
 
 		public ImportProcess postImportProcess(
+				Long plid, String portletId,
 				ImportProcessRequest importProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postImportProcessHttpResponse(importProcessRequest);
+				postImportProcessHttpResponse(
+					plid, portletId, importProcessRequest);
 
 			String content = httpResponse.getContent();
 
@@ -2149,6 +1600,7 @@ public interface ImportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse postImportProcessHttpResponse(
+				Long plid, String portletId,
 				ImportProcessRequest importProcessRequest)
 			throws Exception {
 
@@ -2176,6 +1628,14 @@ public interface ImportProcessResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
@@ -2190,13 +1650,14 @@ public interface ImportProcessResource {
 		}
 
 		public void postImportProcessBatch(
+				Long plid, String portletId,
 				ImportProcessRequest importProcessRequest, String callbackURL,
 				Object object)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postImportProcessBatchHttpResponse(
-					importProcessRequest, callbackURL, object);
+					plid, portletId, importProcessRequest, callbackURL, object);
 
 			String content = httpResponse.getContent();
 
@@ -2247,6 +1708,7 @@ public interface ImportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse postImportProcessBatchHttpResponse(
+				Long plid, String portletId,
 				ImportProcessRequest importProcessRequest, String callbackURL,
 				Object object)
 			throws Exception {
@@ -2274,6 +1736,14 @@ public interface ImportProcessResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			if (callbackURL != null) {
 				httpInvoker.parameter(
 					"callbackURL", String.valueOf(callbackURL));
@@ -2293,15 +1763,15 @@ public interface ImportProcessResource {
 		}
 
 		public void postImportProcessesPageExportBatch(
-				Long creatorId, String search, Integer status,
+				Long creatorId, String portletId, String search, Integer status,
 				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postImportProcessesPageExportBatchHttpResponse(
-					creatorId, search, status, sortString, callbackURL,
-					contentType, fieldNames);
+					creatorId, portletId, search, status, sortString,
+					callbackURL, contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -2353,9 +1823,9 @@ public interface ImportProcessResource {
 
 		public HttpInvoker.HttpResponse
 				postImportProcessesPageExportBatchHttpResponse(
-					Long creatorId, String search, Integer status,
-					String sortString, String callbackURL, String contentType,
-					String fieldNames)
+					Long creatorId, String portletId, String search,
+					Integer status, String sortString, String callbackURL,
+					String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -2383,6 +1853,10 @@ public interface ImportProcessResource {
 
 			if (creatorId != null) {
 				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
 			}
 
 			if (search != null) {
@@ -2424,487 +1898,14 @@ public interface ImportProcessResource {
 			return httpInvoker.invoke();
 		}
 
-		public ImportProcess postPortletImportProcess(
-				String portletId, Long plid,
-				ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postPortletImportProcessHttpResponse(
-					portletId, plid, importProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postPortletImportProcessHttpResponse(
-				String portletId, Long plid,
-				ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				importProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (plid != null) {
-				httpInvoker.parameter("plid", String.valueOf(plid));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/portlets/{portletId}/import-processes");
-
-			httpInvoker.path("portletId", portletId);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
 		public ImportProcess postSiteImportProcess(
-				String siteExternalReferenceCode,
+				String siteExternalReferenceCode, Long plid, String portletId,
 				ImportProcessRequest importProcessRequest)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSiteImportProcessHttpResponse(
-					siteExternalReferenceCode, importProcessRequest);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return ImportProcessSerDes.toDTO(content);
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteImportProcessHttpResponse(
-				String siteExternalReferenceCode,
-				ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(
-				importProcessRequest.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postSiteImportProcessBatch(
-				String siteExternalReferenceCode,
-				ImportProcessRequest importProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteImportProcessBatchHttpResponse(
-					siteExternalReferenceCode, importProcessRequest,
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse postSiteImportProcessBatchHttpResponse(
-				String siteExternalReferenceCode,
-				ImportProcessRequest importProcessRequest, String callbackURL,
-				Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/batch");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void postSiteImportProcessesPageExportBatch(
-				String siteExternalReferenceCode, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSiteImportProcessesPageExportBatchHttpResponse(
-					siteExternalReferenceCode, creatorId, search, status,
-					sortString, callbackURL, contentType, fieldNames);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				postSiteImportProcessesPageExportBatchHttpResponse(
-					String siteExternalReferenceCode, Long creatorId,
-					String search, Integer status, String sortString,
-					String callbackURL, String contentType, String fieldNames)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body("[]", "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-
-			if (creatorId != null) {
-				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
-			}
-
-			if (search != null) {
-				httpInvoker.parameter("search", String.valueOf(search));
-			}
-
-			if (status != null) {
-				httpInvoker.parameter("status", String.valueOf(status));
-			}
-
-			if (sortString != null) {
-				httpInvoker.parameter("sort", sortString);
-			}
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			if (contentType != null) {
-				httpInvoker.parameter(
-					"contentType", String.valueOf(contentType));
-			}
-
-			if (fieldNames != null) {
-				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/export-batch");
-
-			httpInvoker.path(
-				"siteExternalReferenceCode", siteExternalReferenceCode);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public ImportProcess postSitePortletImportProcess(
-				String siteExternalReferenceCode, String portletId, Long plid,
-				ImportProcessRequest importProcessRequest)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				postSitePortletImportProcessHttpResponse(
-					siteExternalReferenceCode, portletId, plid,
+					siteExternalReferenceCode, plid, portletId,
 					importProcessRequest);
 
 			String content = httpResponse.getContent();
@@ -2966,10 +1967,9 @@ public interface ImportProcessResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				postSitePortletImportProcessHttpResponse(
-					String siteExternalReferenceCode, String portletId,
-					Long plid, ImportProcessRequest importProcessRequest)
+		public HttpInvoker.HttpResponse postSiteImportProcessHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportProcessRequest importProcessRequest)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -3000,14 +2000,275 @@ public interface ImportProcessResource {
 				httpInvoker.parameter("plid", String.valueOf(plid));
 			}
 
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
-			httpInvoker.path("portletId", portletId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteImportProcessBatch(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportProcessRequest importProcessRequest, String callbackURL,
+				Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteImportProcessBatchHttpResponse(
+					siteExternalReferenceCode, plid, portletId,
+					importProcessRequest, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteImportProcessBatchHttpResponse(
+				String siteExternalReferenceCode, Long plid, String portletId,
+				ImportProcessRequest importProcessRequest, String callbackURL,
+				Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (plid != null) {
+				httpInvoker.parameter("plid", String.valueOf(plid));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteImportProcessesPageExportBatch(
+				String siteExternalReferenceCode, Long creatorId,
+				String portletId, String search, Integer status,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteImportProcessesPageExportBatchHttpResponse(
+					siteExternalReferenceCode, creatorId, portletId, search,
+					status, sortString, callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postSiteImportProcessesPageExportBatchHttpResponse(
+					String siteExternalReferenceCode, Long creatorId,
+					String portletId, String search, Integer status,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (creatorId != null) {
+				httpInvoker.parameter("creatorId", String.valueOf(creatorId));
+			}
+
+			if (portletId != null) {
+				httpInvoker.parameter("portletId", String.valueOf(portletId));
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (status != null) {
+				httpInvoker.parameter("status", String.valueOf(status));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/export-batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -3029,4 +2290,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1151998588
+// LIFERAY-REST-BUILDER-HASH:384493994

--- a/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
@@ -1455,6 +1455,255 @@ paths:
                                     $ref: "#/components/schemas/ReportEntry"
                                 type: array
             tags: ["ReportEntry"]
+    "/portlets/{portletId}/export-preview":
+        get:
+            operationId: getPortletExportPreview
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: endDate
+                    schema:
+                        format: date-time
+                        type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: startDate
+                    schema:
+                        format: date-time
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ExportPreview"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ExportPreview"
+            tags: ["ExportPreview"]
+    "/portlets/{portletId}/export-processes":
+        get:
+            operationId: getPortletExportProcessesPage
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: creatorId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+                -   in: query
+                    name: status
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ExportProcess"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ExportProcess"
+                                type: array
+            tags: ["ExportProcess"]
+        post:
+            operationId: postPortletExportProcess
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ExportProcessRequest"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ExportProcessRequest"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ExportProcess"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ExportProcess"
+            tags: ["ExportProcess"]
+    "/portlets/{portletId}/import-preview":
+        post:
+            operationId: postPortletImportPreview
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    multipart/form-data:
+                        schema:
+                            properties:
+                                file:
+                                    format: binary
+                                    type: string
+                            type: object
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImportPreview"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ImportPreview"
+            tags: ["ImportPreview"]
+    "/portlets/{portletId}/import-processes":
+        get:
+            operationId: getPortletImportProcessesPage
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: creatorId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+                -   in: query
+                    name: status
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ImportProcess"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ImportProcess"
+                                type: array
+            tags: ["ImportProcess"]
+        post:
+            operationId: postPortletImportProcess
+            parameters:
+                -   in: path
+                    name: portletId
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
+            tags: ["ImportProcess"]
     "/report-entry/{reportEntryId}":
         get:
             description:

--- a/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
@@ -512,6 +512,15 @@ paths:
                         format: date-time
                         type: string
                 -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
+                -   in: query
                     name: startDate
                     schema:
                         format: date-time
@@ -529,7 +538,7 @@ paths:
     "/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes":
         get:
             description:
-                Retrieves the layout export process entries for the specified asset library.
+                Retrieves the layout export process entries of the specified asset library, or the export process entries of one of its portlets when a portlet ID is given.
             operationId: getAssetLibraryExportProcessesPage
             parameters:
                 -   in: path
@@ -558,6 +567,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -596,6 +609,15 @@ paths:
                     required: true
                     schema:
                         type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     application/json:
@@ -623,6 +645,15 @@ paths:
                     required: true
                     schema:
                         type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     multipart/form-data:
@@ -645,7 +676,7 @@ paths:
     "/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes":
         get:
             description:
-                Retrieves the layout import process entries for the specified asset library.
+                Retrieves the layout import process entries of the specified asset library, or the import process entries of one of its portlets when a portlet ID is given.
             operationId: getAssetLibraryImportProcessesPage
             parameters:
                 -   in: path
@@ -674,6 +705,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -712,285 +747,15 @@ paths:
                     required: true
                     schema:
                         type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-            tags: ["ImportProcess"]
-    "/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-preview":
-        get:
-            operationId: getAssetLibraryPortletExportPreview
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: endDate
-                    schema:
-                        format: date-time
-                        type: string
                 -   in: query
                     name: plid
                     schema:
                         format: int64
                         type: integer
                 -   in: query
-                    name: startDate
-                    schema:
-                        format: date-time
-                        type: string
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-            tags: ["ExportPreview"]
-    "/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes":
-        get:
-            operationId: getAssetLibraryPortletExportProcessesPage
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
                     name: portletId
-                    required: true
                     schema:
                         type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-            tags: ["ExportProcess"]
-        post:
-            operationId: postAssetLibraryPortletExportProcess
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-            tags: ["ExportProcess"]
-    "/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-preview":
-        post:
-            operationId: postAssetLibraryPortletImportPreview
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    multipart/form-data:
-                        schema:
-                            properties:
-                                file:
-                                    format: binary
-                                    type: string
-                            type: object
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-            tags: ["ImportPreview"]
-    "/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes":
-        get:
-            operationId: getAssetLibraryPortletImportProcessesPage
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-            tags: ["ImportProcess"]
-        post:
-            operationId: postAssetLibraryPortletImportProcess
-            parameters:
-                -   in: path
-                    name: assetLibraryExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
             requestBody:
                 content:
                     application/json:
@@ -1019,6 +784,15 @@ paths:
                         format: date-time
                         type: string
                 -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
+                -   in: query
                     name: startDate
                     schema:
                         format: date-time
@@ -1036,7 +810,7 @@ paths:
     "/export-processes":
         get:
             description:
-                Retrieves all the layout export process entries.
+                Retrieves the layout export process entries of the instance, or the export process entries of one of its portlets when a portlet ID is given.
             operationId: getExportProcessesPage
             parameters:
                 -   in: query
@@ -1060,6 +834,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -1092,6 +870,16 @@ paths:
             tags: ["ExportProcess"]
         post:
             operationId: postExportProcess
+            parameters:
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     application/json:
@@ -1228,6 +1016,16 @@ paths:
     "/import-preview":
         post:
             operationId: postImportPreview
+            parameters:
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     multipart/form-data:
@@ -1250,7 +1048,7 @@ paths:
     "/import-processes":
         get:
             description:
-                Retrieves all the layout import process entries.
+                Retrieves the layout import process entries of the instance, or the import process entries of one of its portlets when a portlet ID is given.
             operationId: getImportProcessesPage
             parameters:
                 -   in: query
@@ -1274,6 +1072,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -1306,6 +1108,16 @@ paths:
             tags: ["ImportProcess"]
         post:
             operationId: postImportProcess
+            parameters:
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     application/json:
@@ -1455,255 +1267,6 @@ paths:
                                     $ref: "#/components/schemas/ReportEntry"
                                 type: array
             tags: ["ReportEntry"]
-    "/portlets/{portletId}/export-preview":
-        get:
-            operationId: getPortletExportPreview
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: endDate
-                    schema:
-                        format: date-time
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: startDate
-                    schema:
-                        format: date-time
-                        type: string
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-            tags: ["ExportPreview"]
-    "/portlets/{portletId}/export-processes":
-        get:
-            operationId: getPortletExportProcessesPage
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-            tags: ["ExportProcess"]
-        post:
-            operationId: postPortletExportProcess
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-            tags: ["ExportProcess"]
-    "/portlets/{portletId}/import-preview":
-        post:
-            operationId: postPortletImportPreview
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    multipart/form-data:
-                        schema:
-                            properties:
-                                file:
-                                    format: binary
-                                    type: string
-                            type: object
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-            tags: ["ImportPreview"]
-    "/portlets/{portletId}/import-processes":
-        get:
-            operationId: getPortletImportProcessesPage
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-            tags: ["ImportProcess"]
-        post:
-            operationId: postPortletImportProcess
-            parameters:
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-            tags: ["ImportProcess"]
     "/report-entry/{reportEntryId}":
         get:
             description:
@@ -1753,6 +1316,15 @@ paths:
                         format: date-time
                         type: string
                 -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
+                -   in: query
                     name: startDate
                     schema:
                         format: date-time
@@ -1770,7 +1342,7 @@ paths:
     "/sites/{siteExternalReferenceCode}/export-processes":
         get:
             description:
-                Retrieves the layout export process entries for the specified site.
+                Retrieves the layout export process entries of the specified site, or the export process entries of one of its portlets when a portlet ID is given.
             operationId: getSiteExportProcessesPage
             parameters:
                 -   in: path
@@ -1799,6 +1371,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -1837,6 +1413,15 @@ paths:
                     required: true
                     schema:
                         type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     application/json:
@@ -1864,6 +1449,15 @@ paths:
                     required: true
                     schema:
                         type: string
+                -   in: query
+                    name: plid
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
             requestBody:
                 content:
                     multipart/form-data:
@@ -1886,7 +1480,7 @@ paths:
     "/sites/{siteExternalReferenceCode}/import-processes":
         get:
             description:
-                Retrieves the layout import process entries for the specified site.
+                Retrieves the layout import process entries of the specified site, or the import process entries of one of its portlets when a portlet ID is given.
             operationId: getSiteImportProcessesPage
             parameters:
                 -   in: path
@@ -1915,6 +1509,10 @@ paths:
                     name: pageSize
                     schema:
                         type: integer
+                -   in: query
+                    name: portletId
+                    schema:
+                        type: string
                 -   in: query
                     name: restrictFields
                     schema:
@@ -1953,285 +1551,15 @@ paths:
                     required: true
                     schema:
                         type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-            tags: ["ImportProcess"]
-    "/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-preview":
-        get:
-            operationId: getSitePortletExportPreview
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: endDate
-                    schema:
-                        format: date-time
-                        type: string
                 -   in: query
                     name: plid
                     schema:
                         format: int64
                         type: integer
                 -   in: query
-                    name: startDate
-                    schema:
-                        format: date-time
-                        type: string
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportPreview"
-            tags: ["ExportPreview"]
-    "/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes":
-        get:
-            operationId: getSitePortletExportProcessesPage
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
                     name: portletId
-                    required: true
                     schema:
                         type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ExportProcess"
-                                type: array
-            tags: ["ExportProcess"]
-        post:
-            operationId: postSitePortletExportProcess
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ExportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ExportProcess"
-            tags: ["ExportProcess"]
-    "/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-preview":
-        post:
-            operationId: postSitePortletImportPreview
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
-            requestBody:
-                content:
-                    multipart/form-data:
-                        schema:
-                            properties:
-                                file:
-                                    format: binary
-                                    type: string
-                            type: object
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportPreview"
-            tags: ["ImportPreview"]
-    "/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes":
-        get:
-            operationId: getSitePortletImportProcessesPage
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: creatorId
-                    schema:
-                        format: int64
-                        type: integer
-                -   in: query
-                    name: fields
-                    schema:
-                        type: string
-                -   in: query
-                    name: nestedFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: page
-                    schema:
-                        type: integer
-                -   in: query
-                    name: pageSize
-                    schema:
-                        type: integer
-                -   in: query
-                    name: restrictFields
-                    schema:
-                        type: string
-                -   in: query
-                    name: search
-                    schema:
-                        type: string
-                -   in: query
-                    name: sort
-                    schema:
-                        type: string
-                -   in: query
-                    name: status
-                    schema:
-                        type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/ImportProcess"
-                                type: array
-            tags: ["ImportProcess"]
-        post:
-            operationId: postSitePortletImportProcess
-            parameters:
-                -   in: path
-                    name: siteExternalReferenceCode
-                    required: true
-                    schema:
-                        type: string
-                -   in: path
-                    name: portletId
-                    required: true
-                    schema:
-                        type: string
-                -   in: query
-                    name: plid
-                    schema:
-                        format: int64
-                        type: integer
             requestBody:
                 content:
                     application/json:

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportPreviewResourceImpl.java
@@ -60,6 +60,14 @@ public abstract class BaseExportPreviewResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "startDate"
 			)
 		}
@@ -84,68 +92,11 @@ public abstract class BaseExportPreviewResourceImpl
 			@jakarta.ws.rs.QueryParam("endDate")
 			Date endDate,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("startDate")
-			Date startDate)
-		throws Exception {
-
-		return new ExportPreview();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "endDate"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "startDate"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportPreview")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-preview"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportPreview getAssetLibraryPortletExportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("endDate")
-			Date endDate,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("plid")
 			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("startDate")
 			Date startDate)
@@ -167,6 +118,14 @@ public abstract class BaseExportPreviewResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "startDate"
 			)
 		}
@@ -185,58 +144,11 @@ public abstract class BaseExportPreviewResourceImpl
 			@jakarta.ws.rs.QueryParam("endDate")
 			Date endDate,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("startDate")
-			Date startDate)
-		throws Exception {
-
-		return new ExportPreview();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "endDate"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "startDate"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportPreview")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path("/portlets/{portletId}/export-preview")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportPreview getPortletExportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("endDate")
-			Date endDate,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("plid")
 			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("startDate")
 			Date startDate)
@@ -262,6 +174,14 @@ public abstract class BaseExportPreviewResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "startDate"
 			)
 		}
@@ -284,68 +204,11 @@ public abstract class BaseExportPreviewResourceImpl
 			@jakarta.ws.rs.QueryParam("endDate")
 			Date endDate,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("startDate")
-			Date startDate)
-		throws Exception {
-
-		return new ExportPreview();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "endDate"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "startDate"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportPreview")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-preview"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportPreview getSitePortletExportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("endDate")
-			Date endDate,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("plid")
 			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("startDate")
 			Date startDate)
@@ -799,4 +662,4 @@ public abstract class BaseExportPreviewResourceImpl
 		LogFactoryUtil.getLog(BaseExportPreviewResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1589543413
+// LIFERAY-REST-BUILDER-HASH:-1472463750

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportPreviewResourceImpl.java
@@ -195,6 +195,59 @@ public abstract class BaseExportPreviewResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-preview'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "endDate"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "startDate"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportPreview")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/portlets/{portletId}/export-preview")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ExportPreview getPortletExportPreview(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("endDate")
+			Date endDate,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("startDate")
+			Date startDate)
+		throws Exception {
+
+		return new ExportPreview();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-preview'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -746,4 +799,4 @@ public abstract class BaseExportPreviewResourceImpl
 		LogFactoryUtil.getLog(BaseExportPreviewResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1067755155
+// LIFERAY-REST-BUILDER-HASH:-1589543413

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
@@ -524,6 +524,86 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-processes'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "status"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/portlets/{portletId}/export-processes")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ExportProcess> getPortletExportProcessesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("creatorId")
+			Long creatorId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("status")
+			Integer status,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -1130,6 +1210,47 @@ public abstract class BaseExportProcessResourceImpl
 				ExportProcess.class.getName(), callbackURL, contentType,
 				fieldNames)
 		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/portlets/{portletId}/export-processes")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ExportProcess postPortletExportProcess(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			ExportProcessRequest exportProcessRequest)
+		throws Exception {
+
+		return new ExportProcess();
 	}
 
 	/**
@@ -2138,4 +2259,4 @@ public abstract class BaseExportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseExportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1915466767
+// LIFERAY-REST-BUILDER-HASH:-1485327852

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
@@ -158,7 +158,7 @@ public abstract class BaseExportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves the layout export process entries for the specified asset library."
+		description = "Retrieves the layout export process entries of the specified asset library, or the export process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -185,6 +185,10 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -224,95 +228,8 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ExportProcess> getAssetLibraryPortletExportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -452,7 +369,7 @@ public abstract class BaseExportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/export-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves all the layout export process entries."
+		description = "Retrieves the layout export process entries of the instance, or the export process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -475,6 +392,10 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -508,85 +429,8 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path("/portlets/{portletId}/export-processes")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ExportProcess> getPortletExportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -607,7 +451,7 @@ public abstract class BaseExportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves the layout export process entries for the specified site."
+		description = "Retrieves the layout export process entries of the specified site, or the export process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -634,6 +478,10 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -671,95 +519,8 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ExportProcess> getSitePortletExportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -784,6 +545,14 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -804,6 +573,12 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
@@ -820,6 +595,14 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -844,6 +627,12 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -881,6 +670,10 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -929,6 +722,9 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -970,59 +766,20 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
+				name = "portletId"
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/export-processes"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportProcess postAssetLibraryPortletExportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return new ExportProcess();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
 			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
@@ -1034,6 +791,12 @@ public abstract class BaseExportProcessResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public ExportProcess postExportProcess(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
@@ -1047,6 +810,14 @@ public abstract class BaseExportProcessResourceImpl
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "callbackURL"
@@ -1064,6 +835,12 @@ public abstract class BaseExportProcessResourceImpl
 	@jakarta.ws.rs.Produces("application/json")
 	@Override
 	public Response postExportProcessBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -1135,6 +912,10 @@ public abstract class BaseExportProcessResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "search"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -1173,6 +954,9 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -1215,47 +999,6 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path("/portlets/{portletId}/export-processes")
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportProcess postPortletExportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return new ExportProcess();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -1263,6 +1006,14 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -1281,6 +1032,12 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
@@ -1297,6 +1054,14 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1321,6 +1086,12 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ExportProcessRequest exportProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -1358,6 +1129,10 @@ public abstract class BaseExportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1406,6 +1181,9 @@ public abstract class BaseExportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -1444,57 +1222,6 @@ public abstract class BaseExportProcessResourceImpl
 		).build();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ExportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/export-processes"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ExportProcess postSitePortletExportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return new ExportProcess();
-	}
-
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
@@ -1514,6 +1241,8 @@ public abstract class BaseExportProcessResourceImpl
 					exportProcess -> postAssetLibraryExportProcess(
 						(String)parameters.get(
 							"assetLibraryExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ExportProcessRequest)parameters.get(
 							"exportProcessRequest"));
 			}
@@ -1521,12 +1250,16 @@ public abstract class BaseExportProcessResourceImpl
 				exportProcessUnsafeFunction =
 					exportProcess -> postSiteExportProcess(
 						(String)parameters.get("siteExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ExportProcessRequest)parameters.get(
 							"exportProcessRequest"));
 			}
 			else {
 				exportProcessUnsafeFunction =
 					exportProcess -> postExportProcess(
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ExportProcessRequest)parameters.get(
 							"exportProcessRequest"));
 			}
@@ -1616,20 +1349,23 @@ public abstract class BaseExportProcessResourceImpl
 		if (parameters.containsKey("assetLibraryExternalReferenceCode")) {
 			return getAssetLibraryExportProcessesPage(
 				(String)parameters.get("assetLibraryExternalReferenceCode"),
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
 		else if (parameters.containsKey("siteExternalReferenceCode")) {
 			return getSiteExportProcessesPage(
 				(String)parameters.get("siteExternalReferenceCode"),
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
 		else {
 			return getExportProcessesPage(
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
@@ -2259,4 +1995,4 @@ public abstract class BaseExportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseExportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1485327852
+// LIFERAY-REST-BUILDER-HASH:-1070892510

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportPreviewResourceImpl.java
@@ -294,6 +294,50 @@ public abstract class BaseImportPreviewResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-preview'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostPortletImportPreviewRequestBody.class)))
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportPreview")
+		}
+	)
+	@jakarta.ws.rs.Consumes("multipart/form-data")
+	@jakarta.ws.rs.Path("/portlets/{portletId}/import-preview")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ImportPreview postPortletImportPreview(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			MultipartBody multipartBody)
+		throws Exception {
+
+		return new ImportPreview();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -1168,6 +1212,15 @@ public abstract class BaseImportPreviewResourceImpl
 
 	}
 
+	private class PostPortletImportPreviewRequestBody {
+
+		@io.swagger.v3.oas.annotations.media.Schema(
+			description = "File", format = "binary", type = "string"
+		)
+		public String file;
+
+	}
+
 	private class PostSiteImportPreviewRequestBody {
 
 		@io.swagger.v3.oas.annotations.media.Schema(
@@ -1187,4 +1240,4 @@ public abstract class BaseImportPreviewResourceImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1366032335
+// LIFERAY-REST-BUILDER-HASH:-1385005064

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportPreviewResourceImpl.java
@@ -83,6 +83,14 @@ public abstract class BaseImportPreviewResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -103,6 +111,12 @@ public abstract class BaseImportPreviewResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			MultipartBody multipartBody)
 		throws Exception {
 
@@ -119,6 +133,14 @@ public abstract class BaseImportPreviewResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -143,6 +165,12 @@ public abstract class BaseImportPreviewResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			MultipartBody multipartBody,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -169,64 +197,22 @@ public abstract class BaseImportPreviewResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostAssetLibraryPortletImportPreviewRequestBody.class)))
-	)
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportPreview")
-		}
-	)
-	@jakarta.ws.rs.Consumes("multipart/form-data")
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-preview"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportPreview postAssetLibraryPortletImportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			MultipartBody multipartBody)
-		throws Exception {
-
-		return new ImportPreview();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-preview'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostImportPreviewRequestBody.class)))
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			)
+		}
 	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -238,7 +224,14 @@ public abstract class BaseImportPreviewResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ImportPreview postImportPreview(MultipartBody multipartBody)
+	public ImportPreview postImportPreview(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			MultipartBody multipartBody)
 		throws Exception {
 
 		return new ImportPreview();
@@ -251,6 +244,14 @@ public abstract class BaseImportPreviewResourceImpl
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "callbackURL"
@@ -268,6 +269,12 @@ public abstract class BaseImportPreviewResourceImpl
 	@jakarta.ws.rs.Produces("application/json")
 	@Override
 	public Response postImportPreviewBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			MultipartBody multipartBody,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -294,50 +301,6 @@ public abstract class BaseImportPreviewResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostPortletImportPreviewRequestBody.class)))
-	)
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportPreview")
-		}
-	)
-	@jakarta.ws.rs.Consumes("multipart/form-data")
-	@jakarta.ws.rs.Path("/portlets/{portletId}/import-preview")
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportPreview postPortletImportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			MultipartBody multipartBody)
-		throws Exception {
-
-		return new ImportPreview();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-preview'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -348,6 +311,14 @@ public abstract class BaseImportPreviewResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -366,6 +337,12 @@ public abstract class BaseImportPreviewResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			MultipartBody multipartBody)
 		throws Exception {
 
@@ -382,6 +359,14 @@ public abstract class BaseImportPreviewResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -406,6 +391,12 @@ public abstract class BaseImportPreviewResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			MultipartBody multipartBody,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -429,60 +420,6 @@ public abstract class BaseImportPreviewResourceImpl
 		).build();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-preview'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostSitePortletImportPreviewRequestBody.class)))
-	)
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportPreview")
-		}
-	)
-	@jakarta.ws.rs.Consumes("multipart/form-data")
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-preview"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportPreview postSitePortletImportPreview(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			MultipartBody multipartBody)
-		throws Exception {
-
-		return new ImportPreview();
-	}
-
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
@@ -502,17 +439,24 @@ public abstract class BaseImportPreviewResourceImpl
 					importPreview -> postAssetLibraryImportPreview(
 						(String)parameters.get(
 							"assetLibraryExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(MultipartBody)null);
 			}
 			else if (parameters.containsKey("siteExternalReferenceCode")) {
 				importPreviewUnsafeFunction =
 					importPreview -> postSiteImportPreview(
 						(String)parameters.get("siteExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(MultipartBody)null);
 			}
 			else {
 				importPreviewUnsafeFunction =
-					importPreview -> postImportPreview((MultipartBody)null);
+					importPreview -> postImportPreview(
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
+						(MultipartBody)null);
 			}
 		}
 
@@ -622,6 +566,14 @@ public abstract class BaseImportPreviewResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	@Override
@@ -1194,25 +1146,7 @@ public abstract class BaseImportPreviewResourceImpl
 
 	}
 
-	private class PostAssetLibraryPortletImportPreviewRequestBody {
-
-		@io.swagger.v3.oas.annotations.media.Schema(
-			description = "File", format = "binary", type = "string"
-		)
-		public String file;
-
-	}
-
 	private class PostImportPreviewRequestBody {
-
-		@io.swagger.v3.oas.annotations.media.Schema(
-			description = "File", format = "binary", type = "string"
-		)
-		public String file;
-
-	}
-
-	private class PostPortletImportPreviewRequestBody {
 
 		@io.swagger.v3.oas.annotations.media.Schema(
 			description = "File", format = "binary", type = "string"
@@ -1230,14 +1164,5 @@ public abstract class BaseImportPreviewResourceImpl
 
 	}
 
-	private class PostSitePortletImportPreviewRequestBody {
-
-		@io.swagger.v3.oas.annotations.media.Schema(
-			description = "File", format = "binary", type = "string"
-		)
-		public String file;
-
-	}
-
 }
-// LIFERAY-REST-BUILDER-HASH:-1385005064
+// LIFERAY-REST-BUILDER-HASH:752676789

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
@@ -487,6 +487,86 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-processes'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "status"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/portlets/{portletId}/import-processes")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ImportProcess> getPortletImportProcessesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("creatorId")
+			Long creatorId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("status")
+			Integer status,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -1058,6 +1138,47 @@ public abstract class BaseImportProcessResourceImpl
 				ImportProcess.class.getName(), callbackURL, contentType,
 				fieldNames)
 		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portletId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/portlets/{portletId}/import-processes")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ImportProcess postPortletImportProcess(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			ImportProcessRequest importProcessRequest)
+		throws Exception {
+
+		return new ImportProcess();
 	}
 
 	/**
@@ -2066,4 +2187,4 @@ public abstract class BaseImportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseImportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1628700479
+// LIFERAY-REST-BUILDER-HASH:-1945185848

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
@@ -158,7 +158,7 @@ public abstract class BaseImportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves the layout import process entries for the specified asset library."
+		description = "Retrieves the layout import process entries of the specified asset library, or the import process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -185,6 +185,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -224,95 +228,8 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ImportProcess> getAssetLibraryPortletImportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -415,7 +332,7 @@ public abstract class BaseImportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/import-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves all the layout import process entries."
+		description = "Retrieves the layout import process entries of the instance, or the import process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -438,6 +355,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -471,85 +392,8 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path("/portlets/{portletId}/import-processes")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ImportProcess> getPortletImportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -570,7 +414,7 @@ public abstract class BaseImportProcessResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Retrieves the layout import process entries for the specified site."
+		description = "Retrieves the layout import process entries of the specified site, or the import process entries of one of its portlets when a portlet ID is given."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -597,6 +441,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -634,95 +482,8 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("search")
-			String search,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("status")
-			Integer status,
-			@jakarta.ws.rs.core.Context Pagination pagination,
-			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
-				sorts)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "creatorId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "fields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "nestedFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "page"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "pageSize"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictFields"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "search"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "sort"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "status"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes"
-	)
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public Page<ImportProcess> getSitePortletImportProcessesPage(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
+			@jakarta.ws.rs.QueryParam("portletId")
 			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("creatorId")
-			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -747,6 +508,14 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -767,6 +536,12 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
@@ -783,6 +558,14 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -807,6 +590,12 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
 			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -844,6 +633,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -892,6 +685,9 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -933,59 +729,20 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
+				name = "portletId"
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryExternalReferenceCode}/portlets/{portletId}/import-processes"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportProcess postAssetLibraryPortletImportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return new ImportProcess();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
 			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
@@ -997,6 +754,12 @@ public abstract class BaseImportProcessResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public ImportProcess postImportProcess(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
@@ -1010,6 +773,14 @@ public abstract class BaseImportProcessResourceImpl
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
+			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "callbackURL"
@@ -1027,6 +798,12 @@ public abstract class BaseImportProcessResourceImpl
 	@jakarta.ws.rs.Produces("application/json")
 	@Override
 	public Response postImportProcessBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -1060,6 +837,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1102,6 +883,9 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -1143,47 +927,6 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/portlets/{portletId}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path("/portlets/{portletId}/import-processes")
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportProcess postPortletImportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return new ImportProcess();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -1191,6 +934,14 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			)
 		}
 	)
@@ -1209,6 +960,12 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
@@ -1225,6 +982,14 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "plid"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1249,6 +1014,12 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("plid")
+			Long plid,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
 			ImportProcessRequest importProcessRequest,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
@@ -1286,6 +1057,10 @@ public abstract class BaseImportProcessResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "creatorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "portletId"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1334,6 +1109,9 @@ public abstract class BaseImportProcessResourceImpl
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("portletId")
+			String portletId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
@@ -1372,57 +1150,6 @@ public abstract class BaseImportProcessResourceImpl
 		).build();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteExternalReferenceCode"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "portletId"
-			),
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "plid"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(name = "ImportProcess")
-		}
-	)
-	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
-	@jakarta.ws.rs.Path(
-		"/sites/{siteExternalReferenceCode}/portlets/{portletId}/import-processes"
-	)
-	@jakarta.ws.rs.POST
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public ImportProcess postSitePortletImportProcess(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("portletId")
-			String portletId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("plid")
-			Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return new ImportProcess();
-	}
-
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
@@ -1442,6 +1169,8 @@ public abstract class BaseImportProcessResourceImpl
 					importProcess -> postAssetLibraryImportProcess(
 						(String)parameters.get(
 							"assetLibraryExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ImportProcessRequest)parameters.get(
 							"importProcessRequest"));
 			}
@@ -1449,12 +1178,16 @@ public abstract class BaseImportProcessResourceImpl
 				importProcessUnsafeFunction =
 					importProcess -> postSiteImportProcess(
 						(String)parameters.get("siteExternalReferenceCode"),
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ImportProcessRequest)parameters.get(
 							"importProcessRequest"));
 			}
 			else {
 				importProcessUnsafeFunction =
 					importProcess -> postImportProcess(
+						_parseLong((String)parameters.get("plid")),
+						(String)parameters.get("portletId"),
 						(ImportProcessRequest)parameters.get(
 							"importProcessRequest"));
 			}
@@ -1544,20 +1277,23 @@ public abstract class BaseImportProcessResourceImpl
 		if (parameters.containsKey("assetLibraryExternalReferenceCode")) {
 			return getAssetLibraryImportProcessesPage(
 				(String)parameters.get("assetLibraryExternalReferenceCode"),
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
 		else if (parameters.containsKey("siteExternalReferenceCode")) {
 			return getSiteImportProcessesPage(
 				(String)parameters.get("siteExternalReferenceCode"),
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
 		else {
 			return getImportProcessesPage(
-				_parseLong((String)parameters.get("creatorId")), search,
+				_parseLong((String)parameters.get("creatorId")),
+				(String)parameters.get("portletId"), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
@@ -2187,4 +1923,4 @@ public abstract class BaseImportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseImportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1945185848
+// LIFERAY-REST-BUILDER-HASH:411290483

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.exportimport.portlet.data.handler.provider.PortletDataHandler
 import com.liferay.exportimport.rest.dto.v1_0.ExportPreview;
 import com.liferay.exportimport.rest.dto.v1_0.PreviewPortletDataHandler;
 import com.liferay.exportimport.rest.internal.util.DateRangeUtil;
+import com.liferay.exportimport.rest.internal.util.GroupUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
 import com.liferay.exportimport.rest.internal.util.PreviewPortletDataHandlerUtil;
 import com.liferay.exportimport.rest.resource.v1_0.ExportPreviewResource;
@@ -27,9 +28,6 @@ import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.staging.StagingGroupHelper;
-
-import jakarta.ws.rs.NotFoundException;
 
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -57,7 +55,10 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		throws Exception {
 
 		return _getExportPreview(
-			endDate, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			endDate,
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId, startDate);
 	}
 
@@ -67,8 +68,8 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		throws Exception {
 
 		return _getExportPreview(
-			endDate, _getCompanyGroup(), GetterUtil.getLong(plid), portletId,
-			startDate);
+			endDate, GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			GetterUtil.getLong(plid), portletId, startDate);
 	}
 
 	@Override
@@ -78,30 +79,10 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		throws Exception {
 
 		return _getExportPreview(
-			endDate, _getSiteGroup(siteExternalReferenceCode),
+			endDate,
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId, startDate);
-	}
-
-	private Group _getAssetLibraryGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || !group.isDepot()) {
-			throw new NotFoundException();
-		}
-
-		return group;
-	}
-
-	private Group _getCompanyGroup() {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private ExportPreview _getExportPreview(
@@ -243,17 +224,6 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		};
 	}
 
-	private Group _getSiteGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || (!group.isCMS() && !group.isSite())) {
-			throw new NotFoundException();
-		}
-
-		return group;
-	}
-
 	@Reference
 	private DeletionSystemEventExporter _deletionSystemEventExporter;
 
@@ -268,8 +238,5 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 	@Reference
 	private PortletLocalService _portletLocalService;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
@@ -52,38 +52,18 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 	@Override
 	public ExportPreview getAssetLibraryExportPreview(
-			String assetLibraryExternalReferenceCode, Date endDate,
-			Date startDate)
-		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
-		return _getExportPreview(endDate, group, 0, null, startDate);
-	}
-
-	@Override
-	public ExportPreview getAssetLibraryPortletExportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Date endDate, Long plid, Date startDate)
-		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
-		return _getExportPreview(
-			endDate, group, GetterUtil.getLong(plid), portletId, startDate);
-	}
-
-	@Override
-	public ExportPreview getExportPreview(Date endDate, Date startDate)
+			String assetLibraryExternalReferenceCode, Date endDate, Long plid,
+			String portletId, Date startDate)
 		throws Exception {
 
 		return _getExportPreview(
-			endDate, _getCompanyGroup(), 0, null, startDate);
+			endDate, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			GetterUtil.getLong(plid), portletId, startDate);
 	}
 
 	@Override
-	public ExportPreview getPortletExportPreview(
-			String portletId, Date endDate, Long plid, Date startDate)
+	public ExportPreview getExportPreview(
+			Date endDate, Long plid, String portletId, Date startDate)
 		throws Exception {
 
 		return _getExportPreview(
@@ -93,24 +73,13 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 	@Override
 	public ExportPreview getSiteExportPreview(
-			String siteExternalReferenceCode, Date endDate, Date startDate)
+			String siteExternalReferenceCode, Date endDate, Long plid,
+			String portletId, Date startDate)
 		throws Exception {
-
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
-		return _getExportPreview(endDate, group, 0, null, startDate);
-	}
-
-	@Override
-	public ExportPreview getSitePortletExportPreview(
-			String siteExternalReferenceCode, String portletId, Date endDate,
-			Long plid, Date startDate)
-		throws Exception {
-
-		Group group = _getSiteGroup(siteExternalReferenceCode);
 
 		return _getExportPreview(
-			endDate, group, GetterUtil.getLong(plid), portletId, startDate);
+			endDate, _getSiteGroup(siteExternalReferenceCode),
+			GetterUtil.getLong(plid), portletId, startDate);
 	}
 
 	private Group _getAssetLibraryGroup(String externalReferenceCode) {

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
@@ -77,14 +77,18 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 	public ExportPreview getExportPreview(Date endDate, Date startDate)
 		throws Exception {
 
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
+		return _getExportPreview(
+			endDate, _getCompanyGroup(), 0, null, startDate);
+	}
 
-		if (group == null) {
-			throw new NotFoundException();
-		}
+	@Override
+	public ExportPreview getPortletExportPreview(
+			String portletId, Date endDate, Long plid, Date startDate)
+		throws Exception {
 
-		return _getExportPreview(endDate, group, 0, null, startDate);
+		return _getExportPreview(
+			endDate, _getCompanyGroup(), GetterUtil.getLong(plid), portletId,
+			startDate);
 	}
 
 	@Override
@@ -114,6 +118,17 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 			externalReferenceCode, contextCompany.getCompanyId());
 
 		if ((group == null) || !group.isDepot()) {
+			throw new NotFoundException();
+		}
+
+		return group;
+	}
+
+	private Group _getCompanyGroup() {
+		Group group = _stagingGroupHelper.fetchCompanyGroup(
+			contextCompany.getCompanyId());
+
+		if (group == null) {
 			throw new NotFoundException();
 		}
 

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.exportimport.rest.dto.v1_0.ProcessProgress;
 import com.liferay.exportimport.rest.dto.v1_0.Status;
 import com.liferay.exportimport.rest.internal.util.BackgroundTaskUtil;
 import com.liferay.exportimport.rest.internal.util.DateRangeUtil;
+import com.liferay.exportimport.rest.internal.util.GroupUtil;
 import com.liferay.exportimport.rest.internal.util.ParameterMapUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
 import com.liferay.exportimport.rest.internal.util.PreviewPortletDataHandlerUtil;
@@ -49,7 +50,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
@@ -94,7 +94,10 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		throws Exception {
 
 		return _getExportProcessesPage(
-			creatorId, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			creatorId,
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			pagination, portletId, search, sorts, status);
 	}
 
@@ -149,8 +152,8 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		throws Exception {
 
 		return _getExportProcessesPage(
-			creatorId, _getCompanyGroup(), pagination, portletId, search, sorts,
-			status);
+			creatorId, GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -181,8 +184,10 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		throws Exception {
 
 		return _getExportProcessesPage(
-			creatorId, _getSiteGroup(siteExternalReferenceCode), pagination,
-			portletId, search, sorts, status);
+			creatorId,
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -193,7 +198,9 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 
 		return _postExportProcess(
 			exportProcessRequest,
-			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId);
 	}
 
@@ -204,8 +211,9 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		throws Exception {
 
 		return _postExportProcess(
-			exportProcessRequest, _getCompanyGroup(), GetterUtil.getLong(plid),
-			portletId);
+			exportProcessRequest,
+			GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			GetterUtil.getLong(plid), portletId);
 	}
 
 	@Override
@@ -256,19 +264,10 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		throws Exception {
 
 		return _postExportProcess(
-			exportProcessRequest, _getSiteGroup(siteExternalReferenceCode),
+			exportProcessRequest,
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId);
-	}
-
-	private Group _getAssetLibraryGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || !group.isDepot()) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private List<BackgroundTask> _getBackgroundTasks(
@@ -287,17 +286,6 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		return _backgroundTaskLocalService.dynamicQuery(
 			dynamicQuery, pagination.getStartPosition(),
 			pagination.getEndPosition());
-	}
-
-	private Group _getCompanyGroup() {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private DynamicQuery _getDynamicQuery(
@@ -361,17 +349,6 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 			_backgroundTaskLocalService.dynamicQueryCount(
 				_getDynamicQuery(
 					creatorId, groupId, portletId, search, status)));
-	}
-
-	private Group _getSiteGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || (!group.isCMS() && !group.isSite())) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private ExportProcess _postExportProcess(
@@ -651,9 +628,6 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 
 	@Reference
 	private PortletLocalService _portletLocalService;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
@@ -163,8 +163,10 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
+		Group group = _getCompanyGroup();
+
 		return _getExportProcessesPage(
-			creatorId, _getCompanyGroupId(), pagination, null, search, sorts,
+			creatorId, group.getGroupId(), pagination, null, search, sorts,
 			status);
 	}
 
@@ -187,6 +189,19 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 						backgroundTask.getBackgroundTaskId()));
 			}
 		};
+	}
+
+	@Override
+	public Page<ExportProcess> getPortletExportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		Group group = _getCompanyGroup();
+
+		return _getExportProcessesPage(
+			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
+			status);
 	}
 
 	@Override
@@ -243,14 +258,8 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
-
-		return _postLayoutExportProcess(exportProcessRequest, group);
+		return _postLayoutExportProcess(
+			exportProcessRequest, _getCompanyGroup());
 	}
 
 	@Override
@@ -292,6 +301,17 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 
 		return _toExportProcess(
 			_backgroundTaskLocalService.getBackgroundTask(backgroundTaskId));
+	}
+
+	@Override
+	public ExportProcess postPortletExportProcess(
+			String portletId, Long plid,
+			ExportProcessRequest exportProcessRequest)
+		throws Exception {
+
+		return _postPortletExportProcess(
+			exportProcessRequest, _getCompanyGroup(), GetterUtil.getLong(plid),
+			portletId);
 	}
 
 	@Override
@@ -344,15 +364,15 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 			pagination.getEndPosition());
 	}
 
-	private long _getCompanyGroupId() {
+	private Group _getCompanyGroup() {
 		Group group = _stagingGroupHelper.fetchCompanyGroup(
 			contextCompany.getCompanyId());
 
 		if (group == null) {
-			return 0L;
+			throw new NotFoundException();
 		}
 
-		return group.getGroupId();
+		return group;
 	}
 
 	private DynamicQuery _getDynamicQuery(

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
@@ -89,28 +89,13 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 	@Override
 	public Page<ExportProcess> getAssetLibraryExportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
-		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
-			status);
-	}
-
-	@Override
-	public Page<ExportProcess> getAssetLibraryPortletExportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
+			String portletId, String search, Integer status,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
 		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
+			creatorId, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -159,14 +144,12 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 
 	@Override
 	public Page<ExportProcess> getExportProcessesPage(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getCompanyGroup();
-
 		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
+			creatorId, _getCompanyGroup(), pagination, portletId, search, sorts,
 			status);
 	}
 
@@ -192,62 +175,23 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 	}
 
 	@Override
-	public Page<ExportProcess> getPortletExportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
-			Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getCompanyGroup();
-
-		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
-	}
-
-	@Override
 	public Page<ExportProcess> getSiteExportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
-		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
-			status);
-	}
-
-	@Override
-	public Page<ExportProcess> getSitePortletExportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
 		return _getExportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
+			creatorId, _getSiteGroup(siteExternalReferenceCode), pagination,
+			portletId, search, sorts, status);
 	}
 
 	@Override
 	public ExportProcess postAssetLibraryExportProcess(
-			String assetLibraryExternalReferenceCode,
-			ExportProcessRequest exportProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
-		return _postLayoutExportProcess(
-			exportProcessRequest,
-			_getAssetLibraryGroup(assetLibraryExternalReferenceCode));
-	}
-
-	@Override
-	public ExportProcess postAssetLibraryPortletExportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return _postPortletExportProcess(
+		return _postExportProcess(
 			exportProcessRequest,
 			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId);
@@ -255,11 +199,13 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 
 	@Override
 	public ExportProcess postExportProcess(
+			Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
-		return _postLayoutExportProcess(
-			exportProcessRequest, _getCompanyGroup());
+		return _postExportProcess(
+			exportProcessRequest, _getCompanyGroup(), GetterUtil.getLong(plid),
+			portletId);
 	}
 
 	@Override
@@ -304,33 +250,12 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 	}
 
 	@Override
-	public ExportProcess postPortletExportProcess(
-			String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return _postPortletExportProcess(
-			exportProcessRequest, _getCompanyGroup(), GetterUtil.getLong(plid),
-			portletId);
-	}
-
-	@Override
 	public ExportProcess postSiteExportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ExportProcessRequest exportProcessRequest)
 		throws Exception {
 
-		return _postLayoutExportProcess(
-			exportProcessRequest, _getSiteGroup(siteExternalReferenceCode));
-	}
-
-	@Override
-	public ExportProcess postSitePortletExportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ExportProcessRequest exportProcessRequest)
-		throws Exception {
-
-		return _postPortletExportProcess(
+		return _postExportProcess(
 			exportProcessRequest, _getSiteGroup(siteExternalReferenceCode),
 			GetterUtil.getLong(plid), portletId);
 	}
@@ -420,9 +345,11 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 	}
 
 	private Page<ExportProcess> _getExportProcessesPage(
-			Long creatorId, long groupId, Pagination pagination,
+			Long creatorId, Group group, Pagination pagination,
 			String portletId, String search, Sort[] sorts, Integer status)
 		throws Exception {
+
+		long groupId = group.getGroupId();
 
 		return Page.of(
 			transform(
@@ -445,6 +372,24 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		}
 
 		return group;
+	}
+
+	private ExportProcess _postExportProcess(
+			ExportProcessRequest exportProcessRequest, Group group, long plid,
+			String portletId)
+		throws Exception {
+
+		if (Validator.isBlank(portletId)) {
+			return _postLayoutExportProcess(exportProcessRequest, group);
+		}
+
+		if (plid <= 0) {
+			throw new BadRequestException(
+				"Exporting the portlet " + portletId + " requires a plid");
+		}
+
+		return _postPortletExportProcess(
+			exportProcessRequest, group, plid, portletId);
 	}
 
 	private ExportProcess _postLayoutExportProcess(

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
@@ -84,14 +84,21 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 	public ImportPreview postImportPreview(MultipartBody multipartBody)
 		throws Exception {
 
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
+		Group group = _getCompanyGroup();
 
 		return _getImportPreview(group.getGroupId(), multipartBody, 0, null);
+	}
+
+	@Override
+	public ImportPreview postPortletImportPreview(
+			String portletId, Long plid, MultipartBody multipartBody)
+		throws Exception {
+
+		Group group = _getCompanyGroup();
+
+		return _getImportPreview(
+			group.getGroupId(), multipartBody, GetterUtil.getLong(plid),
+			portletId);
 	}
 
 	@Override
@@ -174,6 +181,17 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 			externalReferenceCode, contextCompany.getCompanyId());
 
 		if ((group == null) || !group.isDepot()) {
+			throw new NotFoundException();
+		}
+
+		return group;
+	}
+
+	private Group _getCompanyGroup() {
+		Group group = _stagingGroupHelper.fetchCompanyGroup(
+			contextCompany.getCompanyId());
+
+		if (group == null) {
 			throw new NotFoundException();
 		}
 

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
@@ -58,70 +58,34 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 
 	@Override
 	public ImportPreview postAssetLibraryImportPreview(
-			String assetLibraryExternalReferenceCode,
-			MultipartBody multipartBody)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, MultipartBody multipartBody)
 		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
-		return _getImportPreview(group.getGroupId(), multipartBody, 0, null);
-	}
-
-	@Override
-	public ImportPreview postAssetLibraryPortletImportPreview(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, MultipartBody multipartBody)
-		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
 
 		return _getImportPreview(
-			group.getGroupId(), multipartBody, GetterUtil.getLong(plid),
-			portletId);
+			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			multipartBody, GetterUtil.getLong(plid), portletId);
 	}
 
 	@Override
-	public ImportPreview postImportPreview(MultipartBody multipartBody)
+	public ImportPreview postImportPreview(
+			Long plid, String portletId, MultipartBody multipartBody)
 		throws Exception {
-
-		Group group = _getCompanyGroup();
-
-		return _getImportPreview(group.getGroupId(), multipartBody, 0, null);
-	}
-
-	@Override
-	public ImportPreview postPortletImportPreview(
-			String portletId, Long plid, MultipartBody multipartBody)
-		throws Exception {
-
-		Group group = _getCompanyGroup();
 
 		return _getImportPreview(
-			group.getGroupId(), multipartBody, GetterUtil.getLong(plid),
+			_getCompanyGroup(), multipartBody, GetterUtil.getLong(plid),
 			portletId);
 	}
 
 	@Override
 	public ImportPreview postSiteImportPreview(
-			String siteExternalReferenceCode, MultipartBody multipartBody)
-		throws Exception {
-
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
-		return _getImportPreview(group.getGroupId(), multipartBody, 0, null);
-	}
-
-	@Override
-	public ImportPreview postSitePortletImportPreview(
-			String siteExternalReferenceCode, String portletId, Long plid,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			MultipartBody multipartBody)
 		throws Exception {
 
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
 		return _getImportPreview(
-			group.getGroupId(), multipartBody, GetterUtil.getLong(plid),
-			portletId);
+			_getSiteGroup(siteExternalReferenceCode), multipartBody,
+			GetterUtil.getLong(plid), portletId);
 	}
 
 	private ExportImportConfiguration _addExportImportConfiguration(
@@ -199,9 +163,11 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 	}
 
 	private ImportPreview _getImportPreview(
-			long groupId, MultipartBody multipartBody, long plid,
+			Group group, MultipartBody multipartBody, long plid,
 			String portletId)
 		throws Exception {
+
+		long groupId = group.getGroupId();
 
 		PermissionUtil.checkImportPermission(
 			contextCompany.getCompanyId(), groupId);

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportPreviewResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.rest.dto.v1_0.ImportPreview;
 import com.liferay.exportimport.rest.dto.v1_0.PreviewPortletDataHandler;
+import com.liferay.exportimport.rest.internal.util.GroupUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
 import com.liferay.exportimport.rest.internal.util.PreviewPortletDataHandlerUtil;
 import com.liferay.exportimport.rest.resource.v1_0.ImportPreviewResource;
@@ -32,10 +33,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -63,7 +62,9 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 		throws Exception {
 
 		return _getImportPreview(
-			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			multipartBody, GetterUtil.getLong(plid), portletId);
 	}
 
@@ -73,8 +74,8 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 		throws Exception {
 
 		return _getImportPreview(
-			_getCompanyGroup(), multipartBody, GetterUtil.getLong(plid),
-			portletId);
+			GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			multipartBody, GetterUtil.getLong(plid), portletId);
 	}
 
 	@Override
@@ -84,8 +85,9 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 		throws Exception {
 
 		return _getImportPreview(
-			_getSiteGroup(siteExternalReferenceCode), multipartBody,
-			GetterUtil.getLong(plid), portletId);
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
+			multipartBody, GetterUtil.getLong(plid), portletId);
 	}
 
 	private ExportImportConfiguration _addExportImportConfiguration(
@@ -138,28 +140,6 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 		return _layoutService.addTempFileEntry(
 			groupId, folderName, binaryFile.getFileName(),
 			binaryFile.getInputStream(), binaryFile.getContentType());
-	}
-
-	private Group _getAssetLibraryGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || !group.isDepot()) {
-			throw new NotFoundException();
-		}
-
-		return group;
-	}
-
-	private Group _getCompanyGroup() {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private ImportPreview _getImportPreview(
@@ -240,17 +220,6 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 		};
 	}
 
-	private Group _getSiteGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || (!group.isCMS() && !group.isSite())) {
-			throw new NotFoundException();
-		}
-
-		return group;
-	}
-
 	private void _validateImportFile(
 			FileEntry fileEntry, long groupId, long plid, String portletId)
 		throws Exception {
@@ -303,8 +272,5 @@ public class ImportPreviewResourceImpl extends BaseImportPreviewResourceImpl {
 
 	@Reference
 	private Staging _staging;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
@@ -135,8 +135,10 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
+		Group group = _getCompanyGroup();
+
 		return _getImportProcessesPage(
-			creatorId, _getCompanyGroupId(), pagination, null, search, sorts,
+			creatorId, group.getGroupId(), pagination, null, search, sorts,
 			status);
 	}
 
@@ -159,6 +161,19 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 						backgroundTask.getBackgroundTaskId()));
 			}
 		};
+	}
+
+	@Override
+	public Page<ImportProcess> getPortletImportProcessesPage(
+			String portletId, Long creatorId, String search, Integer status,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		Group group = _getCompanyGroup();
+
+		return _getImportProcessesPage(
+			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
+			status);
 	}
 
 	@Override
@@ -214,14 +229,19 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
+		return _postLayoutImportProcess(
+			_getCompanyGroup(), importProcessRequest);
+	}
 
-		if (group == null) {
-			throw new NotFoundException();
-		}
+	@Override
+	public ImportProcess postPortletImportProcess(
+			String portletId, Long plid,
+			ImportProcessRequest importProcessRequest)
+		throws Exception {
 
-		return _postLayoutImportProcess(group, importProcessRequest);
+		return _postPortletImportProcess(
+			_getCompanyGroup(), importProcessRequest, GetterUtil.getLong(plid),
+			portletId);
 	}
 
 	@Override
@@ -274,15 +294,15 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 			pagination.getEndPosition());
 	}
 
-	private long _getCompanyGroupId() {
+	private Group _getCompanyGroup() {
 		Group group = _stagingGroupHelper.fetchCompanyGroup(
 			contextCompany.getCompanyId());
 
 		if (group == null) {
-			return 0L;
+			throw new NotFoundException();
 		}
 
-		return group.getGroupId();
+		return group;
 	}
 
 	private DynamicQuery _getDynamicQuery(

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.exportimport.rest.dto.v1_0.ImportProcessRequest;
 import com.liferay.exportimport.rest.dto.v1_0.ProcessProgress;
 import com.liferay.exportimport.rest.dto.v1_0.Status;
 import com.liferay.exportimport.rest.internal.util.BackgroundTaskUtil;
+import com.liferay.exportimport.rest.internal.util.GroupUtil;
 import com.liferay.exportimport.rest.internal.util.ParameterMapUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
 import com.liferay.exportimport.rest.resource.v1_0.ImportPreviewResource;
@@ -50,7 +51,6 @@ import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
@@ -96,7 +96,10 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _getImportProcessesPage(
-			creatorId, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			creatorId,
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			pagination, portletId, search, sorts, status);
 	}
 
@@ -122,8 +125,8 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _getImportProcessesPage(
-			creatorId, _getCompanyGroup(), pagination, portletId, search, sorts,
-			status);
+			creatorId, GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -154,8 +157,10 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _getImportProcessesPage(
-			creatorId, _getSiteGroup(siteExternalReferenceCode), pagination,
-			portletId, search, sorts, status);
+			creatorId,
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -165,7 +170,9 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _postImportProcess(
-			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			GroupUtil.getAssetLibraryGroup(
+				contextCompany.getCompanyId(),
+				assetLibraryExternalReferenceCode),
 			importProcessRequest, GetterUtil.getLong(plid), portletId);
 	}
 
@@ -176,8 +183,8 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _postImportProcess(
-			_getCompanyGroup(), importProcessRequest, GetterUtil.getLong(plid),
-			portletId);
+			GroupUtil.getCompanyGroup(contextCompany.getCompanyId()),
+			importProcessRequest, GetterUtil.getLong(plid), portletId);
 	}
 
 	@Override
@@ -187,19 +194,9 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		throws Exception {
 
 		return _postImportProcess(
-			_getSiteGroup(siteExternalReferenceCode), importProcessRequest,
-			GetterUtil.getLong(plid), portletId);
-	}
-
-	private Group _getAssetLibraryGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || !group.isDepot()) {
-			throw new NotFoundException();
-		}
-
-		return group;
+			GroupUtil.getSiteGroup(
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
+			importProcessRequest, GetterUtil.getLong(plid), portletId);
 	}
 
 	private List<BackgroundTask> _getBackgroundTasks(
@@ -218,17 +215,6 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		return _backgroundTaskLocalService.dynamicQuery(
 			dynamicQuery, pagination.getStartPosition(),
 			pagination.getEndPosition());
-	}
-
-	private Group _getCompanyGroup() {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			contextCompany.getCompanyId());
-
-		if (group == null) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private DynamicQuery _getDynamicQuery(
@@ -304,17 +290,6 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		}
 
 		return fileEntry;
-	}
-
-	private Group _getSiteGroup(String externalReferenceCode) {
-		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		if ((group == null) || (!group.isCMS() && !group.isSite())) {
-			throw new NotFoundException();
-		}
-
-		return group;
 	}
 
 	private boolean _isPrivateLayout(FileEntry fileEntry) throws Exception {
@@ -580,9 +555,6 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.staging.StagingGroupHelper;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 
 import java.io.InputStream;
@@ -90,28 +91,13 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 	@Override
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
 			String assetLibraryExternalReferenceCode, Long creatorId,
-			String search, Integer status, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
-		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
-			status);
-	}
-
-	@Override
-	public Page<ImportProcess> getAssetLibraryPortletImportProcessesPage(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long creatorId, String search, Integer status,
+			String portletId, String search, Integer status,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
-
 		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
+			creatorId, _getAssetLibraryGroup(assetLibraryExternalReferenceCode),
+			pagination, portletId, search, sorts, status);
 	}
 
 	@Override
@@ -131,14 +117,12 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 
 	@Override
 	public Page<ImportProcess> getImportProcessesPage(
-			Long creatorId, String search, Integer status,
+			Long creatorId, String portletId, String search, Integer status,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getCompanyGroup();
-
 		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
+			creatorId, _getCompanyGroup(), pagination, portletId, search, sorts,
 			status);
 	}
 
@@ -164,103 +148,45 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 	}
 
 	@Override
-	public Page<ImportProcess> getPortletImportProcessesPage(
-			String portletId, Long creatorId, String search, Integer status,
-			Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getCompanyGroup();
-
-		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
-	}
-
-	@Override
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			String siteExternalReferenceCode, Long creatorId, String search,
-			Integer status, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
-		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, null, search, sorts,
-			status);
-	}
-
-	@Override
-	public Page<ImportProcess> getSitePortletImportProcessesPage(
-			String siteExternalReferenceCode, String portletId, Long creatorId,
+			String siteExternalReferenceCode, Long creatorId, String portletId,
 			String search, Integer status, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		Group group = _getSiteGroup(siteExternalReferenceCode);
-
 		return _getImportProcessesPage(
-			creatorId, group.getGroupId(), pagination, portletId, search, sorts,
-			status);
+			creatorId, _getSiteGroup(siteExternalReferenceCode), pagination,
+			portletId, search, sorts, status);
 	}
 
 	@Override
 	public ImportProcess postAssetLibraryImportProcess(
-			String assetLibraryExternalReferenceCode,
-			ImportProcessRequest importProcessRequest)
+			String assetLibraryExternalReferenceCode, Long plid,
+			String portletId, ImportProcessRequest importProcessRequest)
 		throws Exception {
 
-		return _postLayoutImportProcess(
-			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
-			importProcessRequest);
-	}
-
-	@Override
-	public ImportProcess postAssetLibraryPortletImportProcess(
-			String assetLibraryExternalReferenceCode, String portletId,
-			Long plid, ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return _postPortletImportProcess(
+		return _postImportProcess(
 			_getAssetLibraryGroup(assetLibraryExternalReferenceCode),
 			importProcessRequest, GetterUtil.getLong(plid), portletId);
 	}
 
 	@Override
 	public ImportProcess postImportProcess(
+			Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
-		return _postLayoutImportProcess(
-			_getCompanyGroup(), importProcessRequest);
-	}
-
-	@Override
-	public ImportProcess postPortletImportProcess(
-			String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return _postPortletImportProcess(
+		return _postImportProcess(
 			_getCompanyGroup(), importProcessRequest, GetterUtil.getLong(plid),
 			portletId);
 	}
 
 	@Override
 	public ImportProcess postSiteImportProcess(
-			String siteExternalReferenceCode,
+			String siteExternalReferenceCode, Long plid, String portletId,
 			ImportProcessRequest importProcessRequest)
 		throws Exception {
 
-		return _postLayoutImportProcess(
-			_getSiteGroup(siteExternalReferenceCode), importProcessRequest);
-	}
-
-	@Override
-	public ImportProcess postSitePortletImportProcess(
-			String siteExternalReferenceCode, String portletId, Long plid,
-			ImportProcessRequest importProcessRequest)
-		throws Exception {
-
-		return _postPortletImportProcess(
+		return _postImportProcess(
 			_getSiteGroup(siteExternalReferenceCode), importProcessRequest,
 			GetterUtil.getLong(plid), portletId);
 	}
@@ -350,9 +276,11 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 	}
 
 	private Page<ImportProcess> _getImportProcessesPage(
-			Long creatorId, long groupId, Pagination pagination,
+			Long creatorId, Group group, Pagination pagination,
 			String portletId, String search, Sort[] sorts, Integer status)
 		throws Exception {
+
+		long groupId = group.getGroupId();
 
 		return Page.of(
 			transform(
@@ -408,6 +336,24 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 			return GetterUtil.getBoolean(
 				headerElement.attributeValue("private-layout"));
 		}
+	}
+
+	private ImportProcess _postImportProcess(
+			Group group, ImportProcessRequest importProcessRequest, long plid,
+			String portletId)
+		throws Exception {
+
+		if (Validator.isBlank(portletId)) {
+			return _postLayoutImportProcess(group, importProcessRequest);
+		}
+
+		if (plid <= 0) {
+			throw new BadRequestException(
+				"Importing the portlet " + portletId + " requires a plid");
+		}
+
+		return _postPortletImportProcess(
+			group, importProcessRequest, plid, portletId);
 	}
 
 	private ImportProcess _postLayoutImportProcess(

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/GroupUtil.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/GroupUtil.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.rest.internal.util;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
+
+import jakarta.ws.rs.NotFoundException;
+
+/**
+ * @author Daniel Raposo
+ */
+public class GroupUtil {
+
+	public static Group getAssetLibraryGroup(
+		long companyId, String externalReferenceCode) {
+
+		Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+
+		if ((group == null) || !group.isDepot()) {
+			throw new NotFoundException();
+		}
+
+		return group;
+	}
+
+	public static Group getCompanyGroup(long companyId) {
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		Group group = stagingGroupHelper.fetchCompanyGroup(companyId);
+
+		if (group == null) {
+			throw new NotFoundException();
+		}
+
+		return group;
+	}
+
+	public static Group getSiteGroup(
+		long companyId, String externalReferenceCode) {
+
+		Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+
+		if ((group == null) || (!group.isCMS() && !group.isSite())) {
+			throw new NotFoundException();
+		}
+
+		return group;
+	}
+
+}

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
@@ -225,6 +225,11 @@ public abstract class BaseExportPreviewResourceTestCase {
 	}
 
 	@Test
+	public void testGetPortletExportPreview() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testGetSiteExportPreview() throws Exception {
 		Assert.assertTrue(false);
 	}
@@ -894,4 +899,4 @@ public abstract class BaseExportPreviewResourceTestCase {
 		_exportPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1065176682
+// LIFERAY-REST-BUILDER-HASH:234483965

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
@@ -215,27 +215,12 @@ public abstract class BaseExportPreviewResourceTestCase {
 	}
 
 	@Test
-	public void testGetAssetLibraryPortletExportPreview() throws Exception {
-		Assert.assertTrue(false);
-	}
-
-	@Test
 	public void testGetExportPreview() throws Exception {
 		Assert.assertTrue(false);
 	}
 
 	@Test
-	public void testGetPortletExportPreview() throws Exception {
-		Assert.assertTrue(false);
-	}
-
-	@Test
 	public void testGetSiteExportPreview() throws Exception {
-		Assert.assertTrue(false);
-	}
-
-	@Test
-	public void testGetSitePortletExportPreview() throws Exception {
 		Assert.assertTrue(false);
 	}
 
@@ -899,4 +884,4 @@ public abstract class BaseExportPreviewResourceTestCase {
 		_exportPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:234483965
+// LIFERAY-REST-BUILDER-HASH:-660362624

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
@@ -335,8 +335,9 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> page =
 			exportProcessResource.getAssetLibraryExportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryExternalReferenceCode, null,
+				RandomTestUtil.randomString(), null, null, Pagination.of(1, 10),
+				null);
 
 		long totalCount = page.getTotalCount();
 
@@ -348,7 +349,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			page = exportProcessResource.getAssetLibraryExportProcessesPage(
 				irrelevantAssetLibraryExternalReferenceCode, null, null, null,
-				Pagination.of(1, (int)totalCount + 1), null);
+				null, Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -369,7 +370,7 @@ public abstract class BaseExportProcessResourceTestCase {
 				assetLibraryExternalReferenceCode, randomExportProcess());
 
 		page = exportProcessResource.getAssetLibraryExportProcessesPage(
-			assetLibraryExternalReferenceCode, null, null, null,
+			assetLibraryExternalReferenceCode, null, null, null, null,
 			Pagination.of(1, (int)totalCount + 2), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
@@ -417,7 +418,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> exportProcessesPage =
 			exportProcessResource.getAssetLibraryExportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null, null,
+				assetLibraryExternalReferenceCode, null, null, null, null, null,
 				null);
 
 		int totalCount = GetterUtil.getInteger(
@@ -442,7 +443,7 @@ public abstract class BaseExportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -455,7 +456,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -466,7 +467,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -478,7 +479,7 @@ public abstract class BaseExportProcessResourceTestCase {
 		else {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, totalCount + 2), null);
 
 			List<ExportProcess> exportProcesses1 =
@@ -490,7 +491,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
@@ -503,7 +504,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -643,13 +644,13 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> page =
 			exportProcessResource.getAssetLibraryExportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null, null,
+				assetLibraryExternalReferenceCode, null, null, null, null, null,
 				null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ExportProcess> ascPage =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -660,7 +661,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> descPage =
 				exportProcessResource.getAssetLibraryExportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -693,401 +694,6 @@ public abstract class BaseExportProcessResourceTestCase {
 		throws Exception {
 
 		return irrelevantDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPage()
-		throws Exception {
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletExportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String irrelevantAssetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletExportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletExportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetAssetLibraryPortletExportProcessesPage_getIrrelevantPortletId();
-
-		Page<ExportProcess> page =
-			exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if ((irrelevantAssetLibraryExternalReferenceCode != null) &&
-			(irrelevantPortletId != null)) {
-
-			ExportProcess irrelevantExportProcess =
-				testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId, randomIrrelevantExportProcess());
-
-			page =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantExportProcess, (List<ExportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetAssetLibraryPortletExportProcessesPage_getExpectedActions(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId));
-		}
-
-		ExportProcess exportProcess1 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomExportProcess());
-
-		page = exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-			assetLibraryExternalReferenceCode, portletId, null, null, null,
-			Pagination.of(1, (int)totalCount + 2), null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(exportProcess1, (List<ExportProcess>)page.getItems());
-		assertContains(exportProcess2, (List<ExportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetAssetLibraryPortletExportProcessesPage_getExpectedActions(
-				assetLibraryExternalReferenceCode, portletId));
-
-		exportProcessResource.deleteExportProcess(exportProcess1.getId());
-
-		exportProcessResource.deleteExportProcess(exportProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetAssetLibraryPortletExportProcessesPage_getExpectedActions(
-				String assetLibraryExternalReferenceCode, String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPageWithPagination()
-		throws Exception {
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletExportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletExportProcessesPage_getPortletId();
-
-		Page<ExportProcess> exportProcessesPage =
-			exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				null, null);
-
-		int totalCount = GetterUtil.getInteger(
-			exportProcessesPage.getTotalCount());
-
-		ExportProcess exportProcess1 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomExportProcess());
-
-		ExportProcess exportProcess3 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomExportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page1.getItems());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page2.getItems());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-		else {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, totalCount + 2), null);
-
-			List<ExportProcess> exportProcesses1 =
-				(List<ExportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				exportProcesses1.toString(), totalCount + 2,
-				exportProcesses1.size());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ExportProcess> exportProcesses2 =
-				(List<ExportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				exportProcesses2.toString(), 1, exportProcesses2.size());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetAssetLibraryPortletExportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetAssetLibraryPortletExportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetAssetLibraryPortletExportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletExportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetAssetLibraryPortletExportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, exportProcess1, exportProcess2) -> {
-				Class<?> clazz = exportProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetAssetLibraryPortletExportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ExportProcess, ExportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletExportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletExportProcessesPage_getPortletId();
-
-		ExportProcess exportProcess1 = randomExportProcess();
-		ExportProcess exportProcess2 = randomExportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, exportProcess1, exportProcess2);
-		}
-
-		exportProcess1 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId, exportProcess1);
-
-		exportProcess2 =
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				assetLibraryExternalReferenceCode, portletId, exportProcess2);
-
-		Page<ExportProcess> page =
-			exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				null, null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ExportProcess> ascPage =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)ascPage.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)ascPage.getItems());
-
-			Page<ExportProcess> descPage =
-				exportProcessResource.getAssetLibraryPortletExportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)descPage.getItems());
-			assertContains(
-				exportProcess1, (List<ExportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ExportProcess
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetAssetLibraryPortletExportProcessesPage_getAssetLibraryExternalReferenceCode()
-		throws Exception {
-
-		return testDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetAssetLibraryPortletExportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode()
-		throws Exception {
-
-		return irrelevantDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetAssetLibraryPortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetAssetLibraryPortletExportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
 	}
 
 	@Test
@@ -1314,7 +920,8 @@ public abstract class BaseExportProcessResourceTestCase {
 	@Test
 	public void testGetExportProcessesPage() throws Exception {
 		Page<ExportProcess> page = exportProcessResource.getExportProcessesPage(
-			null, null, null, Pagination.of(1, 10), null);
+			null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -1325,7 +932,8 @@ public abstract class BaseExportProcessResourceTestCase {
 			testGetExportProcessesPage_addExportProcess(randomExportProcess());
 
 		page = exportProcessResource.getExportProcessesPage(
-			null, null, null, Pagination.of(1, (int)totalCount + 2), null);
+			null, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -1351,7 +959,7 @@ public abstract class BaseExportProcessResourceTestCase {
 	public void testGetExportProcessesPageWithPagination() throws Exception {
 		Page<ExportProcess> exportProcessesPage =
 			exportProcessResource.getExportProcessesPage(
-				null, null, null, null, null);
+				null, null, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			exportProcessesPage.getTotalCount());
@@ -1372,7 +980,7 @@ public abstract class BaseExportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1385,7 +993,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1396,7 +1004,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1408,7 +1016,8 @@ public abstract class BaseExportProcessResourceTestCase {
 		else {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null, Pagination.of(1, totalCount + 2), null);
+					null, null, null, null, Pagination.of(1, totalCount + 2),
+					null);
 
 			List<ExportProcess> exportProcesses1 =
 				(List<ExportProcess>)page1.getItems();
@@ -1419,7 +1028,8 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null, Pagination.of(2, totalCount + 2), null);
+					null, null, null, null, Pagination.of(2, totalCount + 2),
+					null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -1431,8 +1041,8 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null, Pagination.of(1, (int)totalCount + 3),
-					null);
+					null, null, null, null,
+					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
 				exportProcess1, (List<ExportProcess>)page3.getItems());
@@ -1557,12 +1167,12 @@ public abstract class BaseExportProcessResourceTestCase {
 			exportProcess2);
 
 		Page<ExportProcess> page = exportProcessResource.getExportProcessesPage(
-			null, null, null, null, null);
+			null, null, null, null, null, null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ExportProcess> ascPage =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -1573,7 +1183,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> descPage =
 				exportProcessResource.getExportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -1593,350 +1203,6 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testGetPortletExportProcessesPage() throws Exception {
-		String portletId = testGetPortletExportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetPortletExportProcessesPage_getIrrelevantPortletId();
-
-		Page<ExportProcess> page =
-			exportProcessResource.getPortletExportProcessesPage(
-				portletId, null, null, null, Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if (irrelevantPortletId != null) {
-			ExportProcess irrelevantExportProcess =
-				testGetPortletExportProcessesPage_addExportProcess(
-					irrelevantPortletId, randomIrrelevantExportProcess());
-
-			page = exportProcessResource.getPortletExportProcessesPage(
-				irrelevantPortletId, null, null, null,
-				Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantExportProcess, (List<ExportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetPortletExportProcessesPage_getExpectedActions(
-					irrelevantPortletId));
-		}
-
-		ExportProcess exportProcess1 =
-			testGetPortletExportProcessesPage_addExportProcess(
-				portletId, randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetPortletExportProcessesPage_addExportProcess(
-				portletId, randomExportProcess());
-
-		page = exportProcessResource.getPortletExportProcessesPage(
-			portletId, null, null, null, Pagination.of(1, (int)totalCount + 2),
-			null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(exportProcess1, (List<ExportProcess>)page.getItems());
-		assertContains(exportProcess2, (List<ExportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetPortletExportProcessesPage_getExpectedActions(portletId));
-
-		exportProcessResource.deleteExportProcess(exportProcess1.getId());
-
-		exportProcessResource.deleteExportProcess(exportProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetPortletExportProcessesPage_getExpectedActions(
-				String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetPortletExportProcessesPageWithPagination()
-		throws Exception {
-
-		String portletId = testGetPortletExportProcessesPage_getPortletId();
-
-		Page<ExportProcess> exportProcessesPage =
-			exportProcessResource.getPortletExportProcessesPage(
-				portletId, null, null, null, null, null);
-
-		int totalCount = GetterUtil.getInteger(
-			exportProcessesPage.getTotalCount());
-
-		ExportProcess exportProcess1 =
-			testGetPortletExportProcessesPage_addExportProcess(
-				portletId, randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetPortletExportProcessesPage_addExportProcess(
-				portletId, randomExportProcess());
-
-		ExportProcess exportProcess3 =
-			testGetPortletExportProcessesPage_addExportProcess(
-				portletId, randomExportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page1.getItems());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page2.getItems());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-		else {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, totalCount + 2), null);
-
-			List<ExportProcess> exportProcesses1 =
-				(List<ExportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				exportProcesses1.toString(), totalCount + 2,
-				exportProcesses1.size());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ExportProcess> exportProcesses2 =
-				(List<ExportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				exportProcesses2.toString(), 1, exportProcesses2.size());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetPortletExportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetPortletExportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetPortletExportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetPortletExportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetPortletExportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetPortletExportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetPortletExportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetPortletExportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, exportProcess1, exportProcess2) -> {
-				Class<?> clazz = exportProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetPortletExportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ExportProcess, ExportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String portletId = testGetPortletExportProcessesPage_getPortletId();
-
-		ExportProcess exportProcess1 = randomExportProcess();
-		ExportProcess exportProcess2 = randomExportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, exportProcess1, exportProcess2);
-		}
-
-		exportProcess1 = testGetPortletExportProcessesPage_addExportProcess(
-			portletId, exportProcess1);
-
-		exportProcess2 = testGetPortletExportProcessesPage_addExportProcess(
-			portletId, exportProcess2);
-
-		Page<ExportProcess> page =
-			exportProcessResource.getPortletExportProcessesPage(
-				portletId, null, null, null, null, null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ExportProcess> ascPage =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)ascPage.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)ascPage.getItems());
-
-			Page<ExportProcess> descPage =
-				exportProcessResource.getPortletExportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)descPage.getItems());
-			assertContains(
-				exportProcess1, (List<ExportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ExportProcess testGetPortletExportProcessesPage_addExportProcess(
-			String portletId, ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String testGetPortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String testGetPortletExportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
-	}
-
-	@Test
 	public void testGetSiteExportProcessesPage() throws Exception {
 		String siteExternalReferenceCode =
 			testGetSiteExportProcessesPage_getSiteExternalReferenceCode();
@@ -1945,8 +1211,8 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> page =
 			exportProcessResource.getSiteExportProcessesPage(
-				siteExternalReferenceCode, null, null, null,
-				Pagination.of(1, 10), null);
+				siteExternalReferenceCode, null, RandomTestUtil.randomString(),
+				null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -1957,7 +1223,7 @@ public abstract class BaseExportProcessResourceTestCase {
 					randomIrrelevantExportProcess());
 
 			page = exportProcessResource.getSiteExportProcessesPage(
-				irrelevantSiteExternalReferenceCode, null, null, null,
+				irrelevantSiteExternalReferenceCode, null, null, null, null,
 				Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
@@ -1979,7 +1245,7 @@ public abstract class BaseExportProcessResourceTestCase {
 				siteExternalReferenceCode, randomExportProcess());
 
 		page = exportProcessResource.getSiteExportProcessesPage(
-			siteExternalReferenceCode, null, null, null,
+			siteExternalReferenceCode, null, null, null, null,
 			Pagination.of(1, (int)totalCount + 2), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
@@ -2027,7 +1293,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> exportProcessesPage =
 			exportProcessResource.getSiteExportProcessesPage(
-				siteExternalReferenceCode, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			exportProcessesPage.getTotalCount());
@@ -2051,7 +1317,7 @@ public abstract class BaseExportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2064,7 +1330,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2075,7 +1341,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2087,7 +1353,7 @@ public abstract class BaseExportProcessResourceTestCase {
 		else {
 			Page<ExportProcess> page1 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, totalCount + 2), null);
 
 			List<ExportProcess> exportProcesses1 =
@@ -2099,7 +1365,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page2 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
@@ -2112,7 +1378,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> page3 =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -2250,12 +1516,12 @@ public abstract class BaseExportProcessResourceTestCase {
 
 		Page<ExportProcess> page =
 			exportProcessResource.getSiteExportProcessesPage(
-				siteExternalReferenceCode, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null, null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ExportProcess> ascPage =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -2266,7 +1532,7 @@ public abstract class BaseExportProcessResourceTestCase {
 
 			Page<ExportProcess> descPage =
 				exportProcessResource.getSiteExportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -2300,382 +1566,6 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testGetSitePortletExportProcessesPage() throws Exception {
-		String siteExternalReferenceCode =
-			testGetSitePortletExportProcessesPage_getSiteExternalReferenceCode();
-		String irrelevantSiteExternalReferenceCode =
-			testGetSitePortletExportProcessesPage_getIrrelevantSiteExternalReferenceCode();
-		String portletId = testGetSitePortletExportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetSitePortletExportProcessesPage_getIrrelevantPortletId();
-
-		Page<ExportProcess> page =
-			exportProcessResource.getSitePortletExportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null,
-				Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if ((irrelevantSiteExternalReferenceCode != null) &&
-			(irrelevantPortletId != null)) {
-
-			ExportProcess irrelevantExportProcess =
-				testGetSitePortletExportProcessesPage_addExportProcess(
-					irrelevantSiteExternalReferenceCode, irrelevantPortletId,
-					randomIrrelevantExportProcess());
-
-			page = exportProcessResource.getSitePortletExportProcessesPage(
-				irrelevantSiteExternalReferenceCode, irrelevantPortletId, null,
-				null, null, Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantExportProcess, (List<ExportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetSitePortletExportProcessesPage_getExpectedActions(
-					irrelevantSiteExternalReferenceCode, irrelevantPortletId));
-		}
-
-		ExportProcess exportProcess1 =
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				siteExternalReferenceCode, portletId, randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				siteExternalReferenceCode, portletId, randomExportProcess());
-
-		page = exportProcessResource.getSitePortletExportProcessesPage(
-			siteExternalReferenceCode, portletId, null, null, null,
-			Pagination.of(1, (int)totalCount + 2), null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(exportProcess1, (List<ExportProcess>)page.getItems());
-		assertContains(exportProcess2, (List<ExportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetSitePortletExportProcessesPage_getExpectedActions(
-				siteExternalReferenceCode, portletId));
-
-		exportProcessResource.deleteExportProcess(exportProcess1.getId());
-
-		exportProcessResource.deleteExportProcess(exportProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetSitePortletExportProcessesPage_getExpectedActions(
-				String siteExternalReferenceCode, String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetSitePortletExportProcessesPageWithPagination()
-		throws Exception {
-
-		String siteExternalReferenceCode =
-			testGetSitePortletExportProcessesPage_getSiteExternalReferenceCode();
-		String portletId = testGetSitePortletExportProcessesPage_getPortletId();
-
-		Page<ExportProcess> exportProcessesPage =
-			exportProcessResource.getSitePortletExportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null, null,
-				null);
-
-		int totalCount = GetterUtil.getInteger(
-			exportProcessesPage.getTotalCount());
-
-		ExportProcess exportProcess1 =
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				siteExternalReferenceCode, portletId, randomExportProcess());
-
-		ExportProcess exportProcess2 =
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				siteExternalReferenceCode, portletId, randomExportProcess());
-
-		ExportProcess exportProcess3 =
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				siteExternalReferenceCode, portletId, randomExportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page1.getItems());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page2.getItems());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-		else {
-			Page<ExportProcess> page1 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, totalCount + 2), null);
-
-			List<ExportProcess> exportProcesses1 =
-				(List<ExportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				exportProcesses1.toString(), totalCount + 2,
-				exportProcesses1.size());
-
-			Page<ExportProcess> page2 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ExportProcess> exportProcesses2 =
-				(List<ExportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				exportProcesses2.toString(), 1, exportProcesses2.size());
-
-			Page<ExportProcess> page3 =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)page3.getItems());
-			assertContains(
-				exportProcess3, (List<ExportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetSitePortletExportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetSitePortletExportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetSitePortletExportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetSitePortletExportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetSitePortletExportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetSitePortletExportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, exportProcess1, exportProcess2) -> {
-				BeanTestUtil.setProperty(
-					exportProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					exportProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetSitePortletExportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetSitePortletExportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, exportProcess1, exportProcess2) -> {
-				Class<?> clazz = exportProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						exportProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						exportProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetSitePortletExportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ExportProcess, ExportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String siteExternalReferenceCode =
-			testGetSitePortletExportProcessesPage_getSiteExternalReferenceCode();
-		String portletId = testGetSitePortletExportProcessesPage_getPortletId();
-
-		ExportProcess exportProcess1 = randomExportProcess();
-		ExportProcess exportProcess2 = randomExportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, exportProcess1, exportProcess2);
-		}
-
-		exportProcess1 = testGetSitePortletExportProcessesPage_addExportProcess(
-			siteExternalReferenceCode, portletId, exportProcess1);
-
-		exportProcess2 = testGetSitePortletExportProcessesPage_addExportProcess(
-			siteExternalReferenceCode, portletId, exportProcess2);
-
-		Page<ExportProcess> page =
-			exportProcessResource.getSitePortletExportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null, null,
-				null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ExportProcess> ascPage =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				exportProcess1, (List<ExportProcess>)ascPage.getItems());
-			assertContains(
-				exportProcess2, (List<ExportProcess>)ascPage.getItems());
-
-			Page<ExportProcess> descPage =
-				exportProcessResource.getSitePortletExportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				exportProcess2, (List<ExportProcess>)descPage.getItems());
-			assertContains(
-				exportProcess1, (List<ExportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ExportProcess
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				String siteExternalReferenceCode, String portletId,
-				ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetSitePortletExportProcessesPage_getSiteExternalReferenceCode()
-		throws Exception {
-
-		return testGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetSitePortletExportProcessesPage_getIrrelevantSiteExternalReferenceCode()
-		throws Exception {
-
-		return irrelevantGroup.getExternalReferenceCode();
-	}
-
-	protected String testGetSitePortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetSitePortletExportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
-	}
-
-	@Test
 	public void testPostAssetLibraryExportProcess() throws Exception {
 		ExportProcess randomExportProcess = randomExportProcess();
 
@@ -2689,27 +1579,6 @@ public abstract class BaseExportProcessResourceTestCase {
 
 	protected ExportProcess testPostAssetLibraryExportProcess_addExportProcess(
 			ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testPostAssetLibraryPortletExportProcess() throws Exception {
-		ExportProcess randomExportProcess = randomExportProcess();
-
-		ExportProcess postExportProcess =
-			testPostAssetLibraryPortletExportProcess_addExportProcess(
-				randomExportProcess);
-
-		assertEquals(randomExportProcess, postExportProcess);
-		assertValid(postExportProcess);
-	}
-
-	protected ExportProcess
-			testPostAssetLibraryPortletExportProcess_addExportProcess(
-				ExportProcess exportProcess)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -2755,25 +1624,6 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testPostPortletExportProcess() throws Exception {
-		ExportProcess randomExportProcess = randomExportProcess();
-
-		ExportProcess postExportProcess =
-			testPostPortletExportProcess_addExportProcess(randomExportProcess);
-
-		assertEquals(randomExportProcess, postExportProcess);
-		assertValid(postExportProcess);
-	}
-
-	protected ExportProcess testPostPortletExportProcess_addExportProcess(
-			ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
 	public void testPostSiteExportProcess() throws Exception {
 		ExportProcess randomExportProcess = randomExportProcess();
 
@@ -2785,26 +1635,6 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	protected ExportProcess testPostSiteExportProcess_addExportProcess(
-			ExportProcess exportProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testPostSitePortletExportProcess() throws Exception {
-		ExportProcess randomExportProcess = randomExportProcess();
-
-		ExportProcess postExportProcess =
-			testPostSitePortletExportProcess_addExportProcess(
-				randomExportProcess);
-
-		assertEquals(randomExportProcess, postExportProcess);
-		assertValid(postExportProcess);
-	}
-
-	protected ExportProcess testPostSitePortletExportProcess_addExportProcess(
 			ExportProcess exportProcess)
 		throws Exception {
 
@@ -3927,4 +2757,4 @@ public abstract class BaseExportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:495681531
+// LIFERAY-REST-BUILDER-HASH:-1124267225

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
@@ -1593,6 +1593,350 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	@Test
+	public void testGetPortletExportProcessesPage() throws Exception {
+		String portletId = testGetPortletExportProcessesPage_getPortletId();
+		String irrelevantPortletId =
+			testGetPortletExportProcessesPage_getIrrelevantPortletId();
+
+		Page<ExportProcess> page =
+			exportProcessResource.getPortletExportProcessesPage(
+				portletId, null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantPortletId != null) {
+			ExportProcess irrelevantExportProcess =
+				testGetPortletExportProcessesPage_addExportProcess(
+					irrelevantPortletId, randomIrrelevantExportProcess());
+
+			page = exportProcessResource.getPortletExportProcessesPage(
+				irrelevantPortletId, null, null, null,
+				Pagination.of(1, (int)totalCount + 1), null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantExportProcess, (List<ExportProcess>)page.getItems());
+			assertValid(
+				page,
+				testGetPortletExportProcessesPage_getExpectedActions(
+					irrelevantPortletId));
+		}
+
+		ExportProcess exportProcess1 =
+			testGetPortletExportProcessesPage_addExportProcess(
+				portletId, randomExportProcess());
+
+		ExportProcess exportProcess2 =
+			testGetPortletExportProcessesPage_addExportProcess(
+				portletId, randomExportProcess());
+
+		page = exportProcessResource.getPortletExportProcessesPage(
+			portletId, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(exportProcess1, (List<ExportProcess>)page.getItems());
+		assertContains(exportProcess2, (List<ExportProcess>)page.getItems());
+		assertValid(
+			page,
+			testGetPortletExportProcessesPage_getExpectedActions(portletId));
+
+		exportProcessResource.deleteExportProcess(exportProcess1.getId());
+
+		exportProcessResource.deleteExportProcess(exportProcess2.getId());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetPortletExportProcessesPage_getExpectedActions(
+				String portletId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetPortletExportProcessesPageWithPagination()
+		throws Exception {
+
+		String portletId = testGetPortletExportProcessesPage_getPortletId();
+
+		Page<ExportProcess> exportProcessesPage =
+			exportProcessResource.getPortletExportProcessesPage(
+				portletId, null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			exportProcessesPage.getTotalCount());
+
+		ExportProcess exportProcess1 =
+			testGetPortletExportProcessesPage_addExportProcess(
+				portletId, randomExportProcess());
+
+		ExportProcess exportProcess2 =
+			testGetPortletExportProcessesPage_addExportProcess(
+				portletId, randomExportProcess());
+
+		ExportProcess exportProcess3 =
+			testGetPortletExportProcessesPage_addExportProcess(
+				portletId, randomExportProcess());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<ExportProcess> page1 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				exportProcess1, (List<ExportProcess>)page1.getItems());
+
+			Page<ExportProcess> page2 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				exportProcess2, (List<ExportProcess>)page2.getItems());
+
+			Page<ExportProcess> page3 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				exportProcess3, (List<ExportProcess>)page3.getItems());
+		}
+		else {
+			Page<ExportProcess> page1 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, totalCount + 2), null);
+
+			List<ExportProcess> exportProcesses1 =
+				(List<ExportProcess>)page1.getItems();
+
+			Assert.assertEquals(
+				exportProcesses1.toString(), totalCount + 2,
+				exportProcesses1.size());
+
+			Page<ExportProcess> page2 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<ExportProcess> exportProcesses2 =
+				(List<ExportProcess>)page2.getItems();
+
+			Assert.assertEquals(
+				exportProcesses2.toString(), 1, exportProcesses2.size());
+
+			Page<ExportProcess> page3 =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)totalCount + 3), null);
+
+			assertContains(
+				exportProcess1, (List<ExportProcess>)page3.getItems());
+			assertContains(
+				exportProcess2, (List<ExportProcess>)page3.getItems());
+			assertContains(
+				exportProcess3, (List<ExportProcess>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetPortletExportProcessesPageWithSortDateTime()
+		throws Exception {
+
+		testGetPortletExportProcessesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, exportProcess1, exportProcess2) -> {
+				BeanTestUtil.setProperty(
+					exportProcess1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetPortletExportProcessesPageWithSortDouble()
+		throws Exception {
+
+		testGetPortletExportProcessesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, exportProcess1, exportProcess2) -> {
+				BeanTestUtil.setProperty(
+					exportProcess1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					exportProcess2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetPortletExportProcessesPageWithSortInteger()
+		throws Exception {
+
+		testGetPortletExportProcessesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, exportProcess1, exportProcess2) -> {
+				BeanTestUtil.setProperty(
+					exportProcess1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					exportProcess2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetPortletExportProcessesPageWithSortString()
+		throws Exception {
+
+		testGetPortletExportProcessesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, exportProcess1, exportProcess2) -> {
+				Class<?> clazz = exportProcess1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						exportProcess1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						exportProcess2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						exportProcess1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						exportProcess2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						exportProcess1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						exportProcess2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetPortletExportProcessesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, ExportProcess, ExportProcess, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String portletId = testGetPortletExportProcessesPage_getPortletId();
+
+		ExportProcess exportProcess1 = randomExportProcess();
+		ExportProcess exportProcess2 = randomExportProcess();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, exportProcess1, exportProcess2);
+		}
+
+		exportProcess1 = testGetPortletExportProcessesPage_addExportProcess(
+			portletId, exportProcess1);
+
+		exportProcess2 = testGetPortletExportProcessesPage_addExportProcess(
+			portletId, exportProcess2);
+
+		Page<ExportProcess> page =
+			exportProcessResource.getPortletExportProcessesPage(
+				portletId, null, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<ExportProcess> ascPage =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				exportProcess1, (List<ExportProcess>)ascPage.getItems());
+			assertContains(
+				exportProcess2, (List<ExportProcess>)ascPage.getItems());
+
+			Page<ExportProcess> descPage =
+				exportProcessResource.getPortletExportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				exportProcess2, (List<ExportProcess>)descPage.getItems());
+			assertContains(
+				exportProcess1, (List<ExportProcess>)descPage.getItems());
+		}
+	}
+
+	protected ExportProcess testGetPortletExportProcessesPage_addExportProcess(
+			String portletId, ExportProcess exportProcess)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetPortletExportProcessesPage_getPortletId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetPortletExportProcessesPage_getIrrelevantPortletId()
+		throws Exception {
+
+		return null;
+	}
+
+	@Test
 	public void testGetSiteExportProcessesPage() throws Exception {
 		String siteExternalReferenceCode =
 			testGetSiteExportProcessesPage_getSiteExternalReferenceCode();
@@ -2403,6 +2747,25 @@ public abstract class BaseExportProcessResourceTestCase {
 	}
 
 	protected ExportProcess testPostExportProcessRelaunch_addExportProcess(
+			ExportProcess exportProcess)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostPortletExportProcess() throws Exception {
+		ExportProcess randomExportProcess = randomExportProcess();
+
+		ExportProcess postExportProcess =
+			testPostPortletExportProcess_addExportProcess(randomExportProcess);
+
+		assertEquals(randomExportProcess, postExportProcess);
+		assertValid(postExportProcess);
+	}
+
+	protected ExportProcess testPostPortletExportProcess_addExportProcess(
 			ExportProcess exportProcess)
 		throws Exception {
 
@@ -3564,4 +3927,4 @@ public abstract class BaseExportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-722764672
+// LIFERAY-REST-BUILDER-HASH:495681531

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
@@ -243,31 +243,6 @@ public abstract class BaseImportPreviewResourceTestCase {
 	}
 
 	@Test
-	public void testPostAssetLibraryPortletImportPreview() throws Exception {
-		ImportPreview randomImportPreview = randomImportPreview();
-
-		Map<String, File> multipartFiles = getMultipartFiles();
-
-		ImportPreview postImportPreview =
-			testPostAssetLibraryPortletImportPreview_addImportPreview(
-				randomImportPreview, multipartFiles);
-
-		assertEquals(randomImportPreview, postImportPreview);
-		assertValid(postImportPreview);
-
-		assertValid(postImportPreview, multipartFiles);
-	}
-
-	protected ImportPreview
-			testPostAssetLibraryPortletImportPreview_addImportPreview(
-				ImportPreview importPreview, Map<String, File> multipartFiles)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
 	public void testPostImportPreview() throws Exception {
 		ImportPreview randomImportPreview = randomImportPreview();
 
@@ -292,30 +267,6 @@ public abstract class BaseImportPreviewResourceTestCase {
 	}
 
 	@Test
-	public void testPostPortletImportPreview() throws Exception {
-		ImportPreview randomImportPreview = randomImportPreview();
-
-		Map<String, File> multipartFiles = getMultipartFiles();
-
-		ImportPreview postImportPreview =
-			testPostPortletImportPreview_addImportPreview(
-				randomImportPreview, multipartFiles);
-
-		assertEquals(randomImportPreview, postImportPreview);
-		assertValid(postImportPreview);
-
-		assertValid(postImportPreview, multipartFiles);
-	}
-
-	protected ImportPreview testPostPortletImportPreview_addImportPreview(
-			ImportPreview importPreview, Map<String, File> multipartFiles)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
 	public void testPostSiteImportPreview() throws Exception {
 		ImportPreview randomImportPreview = randomImportPreview();
 
@@ -332,30 +283,6 @@ public abstract class BaseImportPreviewResourceTestCase {
 	}
 
 	protected ImportPreview testPostSiteImportPreview_addImportPreview(
-			ImportPreview importPreview, Map<String, File> multipartFiles)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testPostSitePortletImportPreview() throws Exception {
-		ImportPreview randomImportPreview = randomImportPreview();
-
-		Map<String, File> multipartFiles = getMultipartFiles();
-
-		ImportPreview postImportPreview =
-			testPostSitePortletImportPreview_addImportPreview(
-				randomImportPreview, multipartFiles);
-
-		assertEquals(randomImportPreview, postImportPreview);
-		assertValid(postImportPreview);
-
-		assertValid(postImportPreview, multipartFiles);
-	}
-
-	protected ImportPreview testPostSitePortletImportPreview_addImportPreview(
 			ImportPreview importPreview, Map<String, File> multipartFiles)
 		throws Exception {
 
@@ -1248,4 +1175,4 @@ public abstract class BaseImportPreviewResourceTestCase {
 		_importPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1353640579
+// LIFERAY-REST-BUILDER-HASH:-558585794

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
@@ -292,6 +292,30 @@ public abstract class BaseImportPreviewResourceTestCase {
 	}
 
 	@Test
+	public void testPostPortletImportPreview() throws Exception {
+		ImportPreview randomImportPreview = randomImportPreview();
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		ImportPreview postImportPreview =
+			testPostPortletImportPreview_addImportPreview(
+				randomImportPreview, multipartFiles);
+
+		assertEquals(randomImportPreview, postImportPreview);
+		assertValid(postImportPreview);
+
+		assertValid(postImportPreview, multipartFiles);
+	}
+
+	protected ImportPreview testPostPortletImportPreview_addImportPreview(
+			ImportPreview importPreview, Map<String, File> multipartFiles)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testPostSiteImportPreview() throws Exception {
 		ImportPreview randomImportPreview = randomImportPreview();
 
@@ -1224,4 +1248,4 @@ public abstract class BaseImportPreviewResourceTestCase {
 		_importPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-966860844
+// LIFERAY-REST-BUILDER-HASH:-1353640579

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
@@ -335,8 +335,9 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> page =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null,
-				Pagination.of(1, 10), null);
+				assetLibraryExternalReferenceCode, null,
+				RandomTestUtil.randomString(), null, null, Pagination.of(1, 10),
+				null);
 
 		long totalCount = page.getTotalCount();
 
@@ -348,7 +349,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			page = importProcessResource.getAssetLibraryImportProcessesPage(
 				irrelevantAssetLibraryExternalReferenceCode, null, null, null,
-				Pagination.of(1, (int)totalCount + 1), null);
+				null, Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -369,7 +370,7 @@ public abstract class BaseImportProcessResourceTestCase {
 				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		page = importProcessResource.getAssetLibraryImportProcessesPage(
-			assetLibraryExternalReferenceCode, null, null, null,
+			assetLibraryExternalReferenceCode, null, null, null, null,
 			Pagination.of(1, (int)totalCount + 2), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
@@ -417,7 +418,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> importProcessesPage =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null, null,
+				assetLibraryExternalReferenceCode, null, null, null, null, null,
 				null);
 
 		int totalCount = GetterUtil.getInteger(
@@ -442,7 +443,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ImportProcess> page1 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -455,7 +456,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -466,7 +467,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -478,7 +479,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		else {
 			Page<ImportProcess> page1 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, totalCount + 2), null);
 
 			List<ImportProcess> importProcesses1 =
@@ -490,7 +491,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
@@ -503,7 +504,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -643,13 +644,13 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> page =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryExternalReferenceCode, null, null, null, null,
+				assetLibraryExternalReferenceCode, null, null, null, null, null,
 				null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ImportProcess> ascPage =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -660,7 +661,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> descPage =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryExternalReferenceCode, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -693,401 +694,6 @@ public abstract class BaseImportProcessResourceTestCase {
 		throws Exception {
 
 		return irrelevantDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPage()
-		throws Exception {
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletImportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String irrelevantAssetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletImportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletImportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetAssetLibraryPortletImportProcessesPage_getIrrelevantPortletId();
-
-		Page<ImportProcess> page =
-			importProcessResource.getAssetLibraryPortletImportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if ((irrelevantAssetLibraryExternalReferenceCode != null) &&
-			(irrelevantPortletId != null)) {
-
-			ImportProcess irrelevantImportProcess =
-				testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId, randomIrrelevantImportProcess());
-
-			page =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantImportProcess, (List<ImportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetAssetLibraryPortletImportProcessesPage_getExpectedActions(
-					irrelevantAssetLibraryExternalReferenceCode,
-					irrelevantPortletId));
-		}
-
-		ImportProcess importProcess1 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomImportProcess());
-
-		page = importProcessResource.getAssetLibraryPortletImportProcessesPage(
-			assetLibraryExternalReferenceCode, portletId, null, null, null,
-			Pagination.of(1, (int)totalCount + 2), null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
-		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetAssetLibraryPortletImportProcessesPage_getExpectedActions(
-				assetLibraryExternalReferenceCode, portletId));
-
-		importProcessResource.deleteImportProcess(importProcess1.getId());
-
-		importProcessResource.deleteImportProcess(importProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetAssetLibraryPortletImportProcessesPage_getExpectedActions(
-				String assetLibraryExternalReferenceCode, String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPageWithPagination()
-		throws Exception {
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletImportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletImportProcessesPage_getPortletId();
-
-		Page<ImportProcess> importProcessesPage =
-			importProcessResource.getAssetLibraryPortletImportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				null, null);
-
-		int totalCount = GetterUtil.getInteger(
-			importProcessesPage.getTotalCount());
-
-		ImportProcess importProcess1 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomImportProcess());
-
-		ImportProcess importProcess3 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId,
-				randomImportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ImportProcess> page1 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page1.getItems());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)page2.getItems());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-		else {
-			Page<ImportProcess> page1 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, totalCount + 2), null);
-
-			List<ImportProcess> importProcesses1 =
-				(List<ImportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				importProcesses1.toString(), totalCount + 2,
-				importProcesses1.size());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ImportProcess> importProcesses2 =
-				(List<ImportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				importProcesses2.toString(), 1, importProcesses2.size());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetAssetLibraryPortletImportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetAssetLibraryPortletImportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetAssetLibraryPortletImportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetAssetLibraryPortletImportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetAssetLibraryPortletImportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, importProcess1, importProcess2) -> {
-				Class<?> clazz = importProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetAssetLibraryPortletImportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ImportProcess, ImportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String assetLibraryExternalReferenceCode =
-			testGetAssetLibraryPortletImportProcessesPage_getAssetLibraryExternalReferenceCode();
-		String portletId =
-			testGetAssetLibraryPortletImportProcessesPage_getPortletId();
-
-		ImportProcess importProcess1 = randomImportProcess();
-		ImportProcess importProcess2 = randomImportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, importProcess1, importProcess2);
-		}
-
-		importProcess1 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId, importProcess1);
-
-		importProcess2 =
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				assetLibraryExternalReferenceCode, portletId, importProcess2);
-
-		Page<ImportProcess> page =
-			importProcessResource.getAssetLibraryPortletImportProcessesPage(
-				assetLibraryExternalReferenceCode, portletId, null, null, null,
-				null, null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ImportProcess> ascPage =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)ascPage.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)ascPage.getItems());
-
-			Page<ImportProcess> descPage =
-				importProcessResource.getAssetLibraryPortletImportProcessesPage(
-					assetLibraryExternalReferenceCode, portletId, null, null,
-					null, Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)descPage.getItems());
-			assertContains(
-				importProcess1, (List<ImportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ImportProcess
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetAssetLibraryPortletImportProcessesPage_getAssetLibraryExternalReferenceCode()
-		throws Exception {
-
-		return testDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetAssetLibraryPortletImportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode()
-		throws Exception {
-
-		return irrelevantDepotEntryGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetAssetLibraryPortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetAssetLibraryPortletImportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
 	}
 
 	@Test
@@ -1309,7 +915,8 @@ public abstract class BaseImportProcessResourceTestCase {
 	@Test
 	public void testGetImportProcessesPage() throws Exception {
 		Page<ImportProcess> page = importProcessResource.getImportProcessesPage(
-			null, null, null, Pagination.of(1, 10), null);
+			null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -1320,7 +927,8 @@ public abstract class BaseImportProcessResourceTestCase {
 			testGetImportProcessesPage_addImportProcess(randomImportProcess());
 
 		page = importProcessResource.getImportProcessesPage(
-			null, null, null, Pagination.of(1, (int)totalCount + 2), null);
+			null, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -1346,7 +954,7 @@ public abstract class BaseImportProcessResourceTestCase {
 	public void testGetImportProcessesPageWithPagination() throws Exception {
 		Page<ImportProcess> importProcessesPage =
 			importProcessResource.getImportProcessesPage(
-				null, null, null, null, null);
+				null, null, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			importProcessesPage.getTotalCount());
@@ -1367,7 +975,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ImportProcess> page1 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1380,7 +988,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1391,7 +999,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1403,7 +1011,8 @@ public abstract class BaseImportProcessResourceTestCase {
 		else {
 			Page<ImportProcess> page1 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null, Pagination.of(1, totalCount + 2), null);
+					null, null, null, null, Pagination.of(1, totalCount + 2),
+					null);
 
 			List<ImportProcess> importProcesses1 =
 				(List<ImportProcess>)page1.getItems();
@@ -1414,7 +1023,8 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null, Pagination.of(2, totalCount + 2), null);
+					null, null, null, null, Pagination.of(2, totalCount + 2),
+					null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -1426,8 +1036,8 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getImportProcessesPage(
-					null, null, null, Pagination.of(1, (int)totalCount + 3),
-					null);
+					null, null, null, null,
+					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
 				importProcess1, (List<ImportProcess>)page3.getItems());
@@ -1552,12 +1162,12 @@ public abstract class BaseImportProcessResourceTestCase {
 			importProcess2);
 
 		Page<ImportProcess> page = importProcessResource.getImportProcessesPage(
-			null, null, null, null, null);
+			null, null, null, null, null, null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ImportProcess> ascPage =
 				importProcessResource.getImportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -1568,7 +1178,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> descPage =
 				importProcessResource.getImportProcessesPage(
-					null, null, null,
+					null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -1588,350 +1198,6 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testGetPortletImportProcessesPage() throws Exception {
-		String portletId = testGetPortletImportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetPortletImportProcessesPage_getIrrelevantPortletId();
-
-		Page<ImportProcess> page =
-			importProcessResource.getPortletImportProcessesPage(
-				portletId, null, null, null, Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if (irrelevantPortletId != null) {
-			ImportProcess irrelevantImportProcess =
-				testGetPortletImportProcessesPage_addImportProcess(
-					irrelevantPortletId, randomIrrelevantImportProcess());
-
-			page = importProcessResource.getPortletImportProcessesPage(
-				irrelevantPortletId, null, null, null,
-				Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantImportProcess, (List<ImportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetPortletImportProcessesPage_getExpectedActions(
-					irrelevantPortletId));
-		}
-
-		ImportProcess importProcess1 =
-			testGetPortletImportProcessesPage_addImportProcess(
-				portletId, randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetPortletImportProcessesPage_addImportProcess(
-				portletId, randomImportProcess());
-
-		page = importProcessResource.getPortletImportProcessesPage(
-			portletId, null, null, null, Pagination.of(1, (int)totalCount + 2),
-			null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
-		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetPortletImportProcessesPage_getExpectedActions(portletId));
-
-		importProcessResource.deleteImportProcess(importProcess1.getId());
-
-		importProcessResource.deleteImportProcess(importProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetPortletImportProcessesPage_getExpectedActions(
-				String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetPortletImportProcessesPageWithPagination()
-		throws Exception {
-
-		String portletId = testGetPortletImportProcessesPage_getPortletId();
-
-		Page<ImportProcess> importProcessesPage =
-			importProcessResource.getPortletImportProcessesPage(
-				portletId, null, null, null, null, null);
-
-		int totalCount = GetterUtil.getInteger(
-			importProcessesPage.getTotalCount());
-
-		ImportProcess importProcess1 =
-			testGetPortletImportProcessesPage_addImportProcess(
-				portletId, randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetPortletImportProcessesPage_addImportProcess(
-				portletId, randomImportProcess());
-
-		ImportProcess importProcess3 =
-			testGetPortletImportProcessesPage_addImportProcess(
-				portletId, randomImportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ImportProcess> page1 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page1.getItems());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)page2.getItems());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-		else {
-			Page<ImportProcess> page1 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, totalCount + 2), null);
-
-			List<ImportProcess> importProcesses1 =
-				(List<ImportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				importProcesses1.toString(), totalCount + 2,
-				importProcesses1.size());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ImportProcess> importProcesses2 =
-				(List<ImportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				importProcesses2.toString(), 1, importProcesses2.size());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetPortletImportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetPortletImportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetPortletImportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetPortletImportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetPortletImportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetPortletImportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetPortletImportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetPortletImportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, importProcess1, importProcess2) -> {
-				Class<?> clazz = importProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetPortletImportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ImportProcess, ImportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String portletId = testGetPortletImportProcessesPage_getPortletId();
-
-		ImportProcess importProcess1 = randomImportProcess();
-		ImportProcess importProcess2 = randomImportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, importProcess1, importProcess2);
-		}
-
-		importProcess1 = testGetPortletImportProcessesPage_addImportProcess(
-			portletId, importProcess1);
-
-		importProcess2 = testGetPortletImportProcessesPage_addImportProcess(
-			portletId, importProcess2);
-
-		Page<ImportProcess> page =
-			importProcessResource.getPortletImportProcessesPage(
-				portletId, null, null, null, null, null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ImportProcess> ascPage =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)ascPage.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)ascPage.getItems());
-
-			Page<ImportProcess> descPage =
-				importProcessResource.getPortletImportProcessesPage(
-					portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)descPage.getItems());
-			assertContains(
-				importProcess1, (List<ImportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ImportProcess testGetPortletImportProcessesPage_addImportProcess(
-			String portletId, ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String testGetPortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String testGetPortletImportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
-	}
-
-	@Test
 	public void testGetSiteImportProcessesPage() throws Exception {
 		String siteExternalReferenceCode =
 			testGetSiteImportProcessesPage_getSiteExternalReferenceCode();
@@ -1940,8 +1206,8 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> page =
 			importProcessResource.getSiteImportProcessesPage(
-				siteExternalReferenceCode, null, null, null,
-				Pagination.of(1, 10), null);
+				siteExternalReferenceCode, null, RandomTestUtil.randomString(),
+				null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -1952,7 +1218,7 @@ public abstract class BaseImportProcessResourceTestCase {
 					randomIrrelevantImportProcess());
 
 			page = importProcessResource.getSiteImportProcessesPage(
-				irrelevantSiteExternalReferenceCode, null, null, null,
+				irrelevantSiteExternalReferenceCode, null, null, null, null,
 				Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
@@ -1974,7 +1240,7 @@ public abstract class BaseImportProcessResourceTestCase {
 				siteExternalReferenceCode, randomImportProcess());
 
 		page = importProcessResource.getSiteImportProcessesPage(
-			siteExternalReferenceCode, null, null, null,
+			siteExternalReferenceCode, null, null, null, null,
 			Pagination.of(1, (int)totalCount + 2), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
@@ -2022,7 +1288,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> importProcessesPage =
 			importProcessResource.getSiteImportProcessesPage(
-				siteExternalReferenceCode, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			importProcessesPage.getTotalCount());
@@ -2046,7 +1312,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ImportProcess> page1 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2059,7 +1325,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2070,7 +1336,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -2082,7 +1348,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		else {
 			Page<ImportProcess> page1 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, totalCount + 2), null);
 
 			List<ImportProcess> importProcesses1 =
@@ -2094,7 +1360,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
@@ -2107,7 +1373,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -2245,12 +1511,12 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		Page<ImportProcess> page =
 			importProcessResource.getSiteImportProcessesPage(
-				siteExternalReferenceCode, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null, null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ImportProcess> ascPage =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -2261,7 +1527,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> descPage =
 				importProcessResource.getSiteImportProcessesPage(
-					siteExternalReferenceCode, null, null, null,
+					siteExternalReferenceCode, null, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -2295,382 +1561,6 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testGetSitePortletImportProcessesPage() throws Exception {
-		String siteExternalReferenceCode =
-			testGetSitePortletImportProcessesPage_getSiteExternalReferenceCode();
-		String irrelevantSiteExternalReferenceCode =
-			testGetSitePortletImportProcessesPage_getIrrelevantSiteExternalReferenceCode();
-		String portletId = testGetSitePortletImportProcessesPage_getPortletId();
-		String irrelevantPortletId =
-			testGetSitePortletImportProcessesPage_getIrrelevantPortletId();
-
-		Page<ImportProcess> page =
-			importProcessResource.getSitePortletImportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null,
-				Pagination.of(1, 10), null);
-
-		long totalCount = page.getTotalCount();
-
-		if ((irrelevantSiteExternalReferenceCode != null) &&
-			(irrelevantPortletId != null)) {
-
-			ImportProcess irrelevantImportProcess =
-				testGetSitePortletImportProcessesPage_addImportProcess(
-					irrelevantSiteExternalReferenceCode, irrelevantPortletId,
-					randomIrrelevantImportProcess());
-
-			page = importProcessResource.getSitePortletImportProcessesPage(
-				irrelevantSiteExternalReferenceCode, irrelevantPortletId, null,
-				null, null, Pagination.of(1, (int)totalCount + 1), null);
-
-			Assert.assertEquals(totalCount + 1, page.getTotalCount());
-
-			assertContains(
-				irrelevantImportProcess, (List<ImportProcess>)page.getItems());
-			assertValid(
-				page,
-				testGetSitePortletImportProcessesPage_getExpectedActions(
-					irrelevantSiteExternalReferenceCode, irrelevantPortletId));
-		}
-
-		ImportProcess importProcess1 =
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				siteExternalReferenceCode, portletId, randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				siteExternalReferenceCode, portletId, randomImportProcess());
-
-		page = importProcessResource.getSitePortletImportProcessesPage(
-			siteExternalReferenceCode, portletId, null, null, null,
-			Pagination.of(1, (int)totalCount + 2), null);
-
-		Assert.assertEquals(totalCount + 2, page.getTotalCount());
-
-		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
-		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
-		assertValid(
-			page,
-			testGetSitePortletImportProcessesPage_getExpectedActions(
-				siteExternalReferenceCode, portletId));
-
-		importProcessResource.deleteImportProcess(importProcess1.getId());
-
-		importProcessResource.deleteImportProcess(importProcess2.getId());
-	}
-
-	protected Map<String, Map<String, String>>
-			testGetSitePortletImportProcessesPage_getExpectedActions(
-				String siteExternalReferenceCode, String portletId)
-		throws Exception {
-
-		Map<String, Map<String, String>> expectedActions = new HashMap<>();
-
-		return expectedActions;
-	}
-
-	@Test
-	public void testGetSitePortletImportProcessesPageWithPagination()
-		throws Exception {
-
-		String siteExternalReferenceCode =
-			testGetSitePortletImportProcessesPage_getSiteExternalReferenceCode();
-		String portletId = testGetSitePortletImportProcessesPage_getPortletId();
-
-		Page<ImportProcess> importProcessesPage =
-			importProcessResource.getSitePortletImportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null, null,
-				null);
-
-		int totalCount = GetterUtil.getInteger(
-			importProcessesPage.getTotalCount());
-
-		ImportProcess importProcess1 =
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				siteExternalReferenceCode, portletId, randomImportProcess());
-
-		ImportProcess importProcess2 =
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				siteExternalReferenceCode, portletId, randomImportProcess());
-
-		ImportProcess importProcess3 =
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				siteExternalReferenceCode, portletId, randomImportProcess());
-
-		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
-
-		int pageSizeLimit = 500;
-
-		if (totalCount >= (pageSizeLimit - 2)) {
-			Page<ImportProcess> page1 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page1.getItems());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)page2.getItems());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(
-						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit),
-					null);
-
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-		else {
-			Page<ImportProcess> page1 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, totalCount + 2), null);
-
-			List<ImportProcess> importProcesses1 =
-				(List<ImportProcess>)page1.getItems();
-
-			Assert.assertEquals(
-				importProcesses1.toString(), totalCount + 2,
-				importProcesses1.size());
-
-			Page<ImportProcess> page2 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(2, totalCount + 2), null);
-
-			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
-
-			List<ImportProcess> importProcesses2 =
-				(List<ImportProcess>)page2.getItems();
-
-			Assert.assertEquals(
-				importProcesses2.toString(), 1, importProcesses2.size());
-
-			Page<ImportProcess> page3 =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)totalCount + 3), null);
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)page3.getItems());
-			assertContains(
-				importProcess3, (List<ImportProcess>)page3.getItems());
-		}
-	}
-
-	@Test
-	public void testGetSitePortletImportProcessesPageWithSortDateTime()
-		throws Exception {
-
-		testGetSitePortletImportProcessesPageWithSort(
-			EntityField.Type.DATE_TIME,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(),
-					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
-			});
-	}
-
-	@Test
-	public void testGetSitePortletImportProcessesPageWithSortDouble()
-		throws Exception {
-
-		testGetSitePortletImportProcessesPageWithSort(
-			EntityField.Type.DOUBLE,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0.1);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 0.5);
-			});
-	}
-
-	@Test
-	public void testGetSitePortletImportProcessesPageWithSortInteger()
-		throws Exception {
-
-		testGetSitePortletImportProcessesPageWithSort(
-			EntityField.Type.INTEGER,
-			(entityField, importProcess1, importProcess2) -> {
-				BeanTestUtil.setProperty(
-					importProcess1, entityField.getName(), 0);
-				BeanTestUtil.setProperty(
-					importProcess2, entityField.getName(), 1);
-			});
-	}
-
-	@Test
-	public void testGetSitePortletImportProcessesPageWithSortString()
-		throws Exception {
-
-		testGetSitePortletImportProcessesPageWithSort(
-			EntityField.Type.STRING,
-			(entityField, importProcess1, importProcess2) -> {
-				Class<?> clazz = importProcess1.getClass();
-
-				String entityFieldName = entityField.getName();
-
-				Method method = clazz.getMethod(
-					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
-
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()) +
-									"@liferay.com");
-				}
-				else {
-					BeanTestUtil.setProperty(
-						importProcess1, entityFieldName,
-						"aaa" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-					BeanTestUtil.setProperty(
-						importProcess2, entityFieldName,
-						"bbb" +
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()));
-				}
-			});
-	}
-
-	protected void testGetSitePortletImportProcessesPageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer
-				<EntityField, ImportProcess, ImportProcess, Exception>
-					unsafeTriConsumer)
-		throws Exception {
-
-		List<EntityField> entityFields = getEntityFields(type);
-
-		if (entityFields.isEmpty()) {
-			return;
-		}
-
-		String siteExternalReferenceCode =
-			testGetSitePortletImportProcessesPage_getSiteExternalReferenceCode();
-		String portletId = testGetSitePortletImportProcessesPage_getPortletId();
-
-		ImportProcess importProcess1 = randomImportProcess();
-		ImportProcess importProcess2 = randomImportProcess();
-
-		for (EntityField entityField : entityFields) {
-			unsafeTriConsumer.accept(
-				entityField, importProcess1, importProcess2);
-		}
-
-		importProcess1 = testGetSitePortletImportProcessesPage_addImportProcess(
-			siteExternalReferenceCode, portletId, importProcess1);
-
-		importProcess2 = testGetSitePortletImportProcessesPage_addImportProcess(
-			siteExternalReferenceCode, portletId, importProcess2);
-
-		Page<ImportProcess> page =
-			importProcessResource.getSitePortletImportProcessesPage(
-				siteExternalReferenceCode, portletId, null, null, null, null,
-				null);
-
-		for (EntityField entityField : entityFields) {
-			Page<ImportProcess> ascPage =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":asc");
-
-			assertContains(
-				importProcess1, (List<ImportProcess>)ascPage.getItems());
-			assertContains(
-				importProcess2, (List<ImportProcess>)ascPage.getItems());
-
-			Page<ImportProcess> descPage =
-				importProcessResource.getSitePortletImportProcessesPage(
-					siteExternalReferenceCode, portletId, null, null, null,
-					Pagination.of(1, (int)page.getTotalCount() + 1),
-					entityField.getName() + ":desc");
-
-			assertContains(
-				importProcess2, (List<ImportProcess>)descPage.getItems());
-			assertContains(
-				importProcess1, (List<ImportProcess>)descPage.getItems());
-		}
-	}
-
-	protected ImportProcess
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				String siteExternalReferenceCode, String portletId,
-				ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetSitePortletImportProcessesPage_getSiteExternalReferenceCode()
-		throws Exception {
-
-		return testGroup.getExternalReferenceCode();
-	}
-
-	protected String
-			testGetSitePortletImportProcessesPage_getIrrelevantSiteExternalReferenceCode()
-		throws Exception {
-
-		return irrelevantGroup.getExternalReferenceCode();
-	}
-
-	protected String testGetSitePortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testGetSitePortletImportProcessesPage_getIrrelevantPortletId()
-		throws Exception {
-
-		return null;
-	}
-
-	@Test
 	public void testPostAssetLibraryImportProcess() throws Exception {
 		ImportProcess randomImportProcess = randomImportProcess();
 
@@ -2684,27 +1574,6 @@ public abstract class BaseImportProcessResourceTestCase {
 
 	protected ImportProcess testPostAssetLibraryImportProcess_addImportProcess(
 			ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testPostAssetLibraryPortletImportProcess() throws Exception {
-		ImportProcess randomImportProcess = randomImportProcess();
-
-		ImportProcess postImportProcess =
-			testPostAssetLibraryPortletImportProcess_addImportProcess(
-				randomImportProcess);
-
-		assertEquals(randomImportProcess, postImportProcess);
-		assertValid(postImportProcess);
-	}
-
-	protected ImportProcess
-			testPostAssetLibraryPortletImportProcess_addImportProcess(
-				ImportProcess importProcess)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -2731,25 +1600,6 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	@Test
-	public void testPostPortletImportProcess() throws Exception {
-		ImportProcess randomImportProcess = randomImportProcess();
-
-		ImportProcess postImportProcess =
-			testPostPortletImportProcess_addImportProcess(randomImportProcess);
-
-		assertEquals(randomImportProcess, postImportProcess);
-		assertValid(postImportProcess);
-	}
-
-	protected ImportProcess testPostPortletImportProcess_addImportProcess(
-			ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
 	public void testPostSiteImportProcess() throws Exception {
 		ImportProcess randomImportProcess = randomImportProcess();
 
@@ -2761,26 +1611,6 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	protected ImportProcess testPostSiteImportProcess_addImportProcess(
-			ImportProcess importProcess)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testPostSitePortletImportProcess() throws Exception {
-		ImportProcess randomImportProcess = randomImportProcess();
-
-		ImportProcess postImportProcess =
-			testPostSitePortletImportProcess_addImportProcess(
-				randomImportProcess);
-
-		assertEquals(randomImportProcess, postImportProcess);
-		assertValid(postImportProcess);
-	}
-
-	protected ImportProcess testPostSitePortletImportProcess_addImportProcess(
 			ImportProcess importProcess)
 		throws Exception {
 
@@ -3903,4 +2733,4 @@ public abstract class BaseImportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1655208362
+// LIFERAY-REST-BUILDER-HASH:-140984819

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
@@ -1588,6 +1588,350 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	@Test
+	public void testGetPortletImportProcessesPage() throws Exception {
+		String portletId = testGetPortletImportProcessesPage_getPortletId();
+		String irrelevantPortletId =
+			testGetPortletImportProcessesPage_getIrrelevantPortletId();
+
+		Page<ImportProcess> page =
+			importProcessResource.getPortletImportProcessesPage(
+				portletId, null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantPortletId != null) {
+			ImportProcess irrelevantImportProcess =
+				testGetPortletImportProcessesPage_addImportProcess(
+					irrelevantPortletId, randomIrrelevantImportProcess());
+
+			page = importProcessResource.getPortletImportProcessesPage(
+				irrelevantPortletId, null, null, null,
+				Pagination.of(1, (int)totalCount + 1), null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantImportProcess, (List<ImportProcess>)page.getItems());
+			assertValid(
+				page,
+				testGetPortletImportProcessesPage_getExpectedActions(
+					irrelevantPortletId));
+		}
+
+		ImportProcess importProcess1 =
+			testGetPortletImportProcessesPage_addImportProcess(
+				portletId, randomImportProcess());
+
+		ImportProcess importProcess2 =
+			testGetPortletImportProcessesPage_addImportProcess(
+				portletId, randomImportProcess());
+
+		page = importProcessResource.getPortletImportProcessesPage(
+			portletId, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
+		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
+		assertValid(
+			page,
+			testGetPortletImportProcessesPage_getExpectedActions(portletId));
+
+		importProcessResource.deleteImportProcess(importProcess1.getId());
+
+		importProcessResource.deleteImportProcess(importProcess2.getId());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetPortletImportProcessesPage_getExpectedActions(
+				String portletId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetPortletImportProcessesPageWithPagination()
+		throws Exception {
+
+		String portletId = testGetPortletImportProcessesPage_getPortletId();
+
+		Page<ImportProcess> importProcessesPage =
+			importProcessResource.getPortletImportProcessesPage(
+				portletId, null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			importProcessesPage.getTotalCount());
+
+		ImportProcess importProcess1 =
+			testGetPortletImportProcessesPage_addImportProcess(
+				portletId, randomImportProcess());
+
+		ImportProcess importProcess2 =
+			testGetPortletImportProcessesPage_addImportProcess(
+				portletId, randomImportProcess());
+
+		ImportProcess importProcess3 =
+			testGetPortletImportProcessesPage_addImportProcess(
+				portletId, randomImportProcess());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<ImportProcess> page1 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				importProcess1, (List<ImportProcess>)page1.getItems());
+
+			Page<ImportProcess> page2 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				importProcess2, (List<ImportProcess>)page2.getItems());
+
+			Page<ImportProcess> page3 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				importProcess3, (List<ImportProcess>)page3.getItems());
+		}
+		else {
+			Page<ImportProcess> page1 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, totalCount + 2), null);
+
+			List<ImportProcess> importProcesses1 =
+				(List<ImportProcess>)page1.getItems();
+
+			Assert.assertEquals(
+				importProcesses1.toString(), totalCount + 2,
+				importProcesses1.size());
+
+			Page<ImportProcess> page2 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<ImportProcess> importProcesses2 =
+				(List<ImportProcess>)page2.getItems();
+
+			Assert.assertEquals(
+				importProcesses2.toString(), 1, importProcesses2.size());
+
+			Page<ImportProcess> page3 =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)totalCount + 3), null);
+
+			assertContains(
+				importProcess1, (List<ImportProcess>)page3.getItems());
+			assertContains(
+				importProcess2, (List<ImportProcess>)page3.getItems());
+			assertContains(
+				importProcess3, (List<ImportProcess>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetPortletImportProcessesPageWithSortDateTime()
+		throws Exception {
+
+		testGetPortletImportProcessesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, importProcess1, importProcess2) -> {
+				BeanTestUtil.setProperty(
+					importProcess1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetPortletImportProcessesPageWithSortDouble()
+		throws Exception {
+
+		testGetPortletImportProcessesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, importProcess1, importProcess2) -> {
+				BeanTestUtil.setProperty(
+					importProcess1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					importProcess2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetPortletImportProcessesPageWithSortInteger()
+		throws Exception {
+
+		testGetPortletImportProcessesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, importProcess1, importProcess2) -> {
+				BeanTestUtil.setProperty(
+					importProcess1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					importProcess2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetPortletImportProcessesPageWithSortString()
+		throws Exception {
+
+		testGetPortletImportProcessesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, importProcess1, importProcess2) -> {
+				Class<?> clazz = importProcess1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						importProcess1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						importProcess2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						importProcess1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						importProcess2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						importProcess1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						importProcess2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetPortletImportProcessesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, ImportProcess, ImportProcess, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String portletId = testGetPortletImportProcessesPage_getPortletId();
+
+		ImportProcess importProcess1 = randomImportProcess();
+		ImportProcess importProcess2 = randomImportProcess();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, importProcess1, importProcess2);
+		}
+
+		importProcess1 = testGetPortletImportProcessesPage_addImportProcess(
+			portletId, importProcess1);
+
+		importProcess2 = testGetPortletImportProcessesPage_addImportProcess(
+			portletId, importProcess2);
+
+		Page<ImportProcess> page =
+			importProcessResource.getPortletImportProcessesPage(
+				portletId, null, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<ImportProcess> ascPage =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				importProcess1, (List<ImportProcess>)ascPage.getItems());
+			assertContains(
+				importProcess2, (List<ImportProcess>)ascPage.getItems());
+
+			Page<ImportProcess> descPage =
+				importProcessResource.getPortletImportProcessesPage(
+					portletId, null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				importProcess2, (List<ImportProcess>)descPage.getItems());
+			assertContains(
+				importProcess1, (List<ImportProcess>)descPage.getItems());
+		}
+	}
+
+	protected ImportProcess testGetPortletImportProcessesPage_addImportProcess(
+			String portletId, ImportProcess importProcess)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetPortletImportProcessesPage_getPortletId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetPortletImportProcessesPage_getIrrelevantPortletId()
+		throws Exception {
+
+		return null;
+	}
+
+	@Test
 	public void testGetSiteImportProcessesPage() throws Exception {
 		String siteExternalReferenceCode =
 			testGetSiteImportProcessesPage_getSiteExternalReferenceCode();
@@ -2379,6 +2723,25 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	protected ImportProcess testPostImportProcess_addImportProcess(
+			ImportProcess importProcess)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostPortletImportProcess() throws Exception {
+		ImportProcess randomImportProcess = randomImportProcess();
+
+		ImportProcess postImportProcess =
+			testPostPortletImportProcess_addImportProcess(randomImportProcess);
+
+		assertEquals(randomImportProcess, postImportProcess);
+		assertValid(postImportProcess);
+	}
+
+	protected ImportProcess testPostPortletImportProcess_addImportProcess(
 			ImportProcess importProcess)
 		throws Exception {
 
@@ -3540,4 +3903,4 @@ public abstract class BaseImportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1730440680
+// LIFERAY-REST-BUILDER-HASH:-1655208362

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
@@ -142,92 +142,68 @@ public class ExportPreviewResourceTest
 	@Override
 	@Test
 	public void testGetAssetLibraryExportPreview() throws Exception {
+		String externalReferenceCode =
+			testDepotEntryGroup.getExternalReferenceCode();
+		String portletId = _depotObjectDefinition.getPortletId();
+
 		assertHttpResponseStatusCode(
 			404,
 			_exportPreviewResource.getAssetLibraryExportPreviewHttpResponse(
-				testDepotEntryGroup.getExternalReferenceCode(), null, null));
+				externalReferenceCode, null, 0L, null, null));
 
 		_testGetExportPreviewWithDateFilter(
 			_depotObjectDefinition,
 			(startDate, endDate) ->
 				exportPreviewResource.getAssetLibraryExportPreview(
-					testDepotEntryGroup.getExternalReferenceCode(), endDate,
-					startDate));
-		_testGetExportPreviewWithDifferentScope(
-			exportPreviewResource.getAssetLibraryExportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), null, null),
-			_companyObjectDefinition, _siteObjectDefinition);
-	}
-
-	@Override
-	@Test
-	public void testGetAssetLibraryPortletExportPreview() throws Exception {
-		String portletId = _depotObjectDefinition.getPortletId();
-
-		assertHttpResponseStatusCode(
-			404,
-			_exportPreviewResource.
-				getAssetLibraryPortletExportPreviewHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					null, 0L, null));
-
+					externalReferenceCode, endDate, 0L, null, startDate));
 		_testGetExportPreviewWithDateFilter(
 			_depotObjectDefinition,
 			(startDate, endDate) ->
-				exportPreviewResource.getAssetLibraryPortletExportPreview(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					endDate, 0L, startDate));
+				exportPreviewResource.getAssetLibraryExportPreview(
+					externalReferenceCode, endDate, 0L, portletId, startDate));
+		_testGetExportPreviewWithDifferentScope(
+			exportPreviewResource.getAssetLibraryExportPreview(
+				externalReferenceCode, null, 0L, null, null),
+			_companyObjectDefinition, _siteObjectDefinition);
 
 		long plid = _addLayoutWithPortlet(testDepotEntryGroup, portletId);
 
 		_testGetPortletExportPreview(
-			exportPreviewResource.getAssetLibraryPortletExportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), portletId, null,
-				plid, null),
+			exportPreviewResource.getAssetLibraryExportPreview(
+				externalReferenceCode, null, plid, portletId, null),
 			portletId);
 	}
 
 	@Override
 	@Test
 	public void testGetExportPreview() throws Exception {
-		assertHttpResponseStatusCode(
-			404,
-			_exportPreviewResource.getExportPreviewHttpResponse(null, null));
-
-		_testGetExportPreviewWithDateFilter(
-			_companyObjectDefinition,
-			(startDate, endDate) -> exportPreviewResource.getExportPreview(
-				endDate, startDate));
-		_testGetExportPreviewWithDeletions(
-			GroupConstants.DEFAULT_PARENT_GROUP_ID,
-			ObjectDefinitionConstants.SCOPE_COMPANY,
-			() -> exportPreviewResource.getExportPreview(null, null));
-		_testGetExportPreviewWithDifferentScope(
-			exportPreviewResource.getExportPreview(null, null),
-			_depotObjectDefinition, _siteObjectDefinition);
-	}
-
-	@Override
-	@Test
-	public void testGetPortletExportPreview() throws Exception {
 		String portletId = _companyObjectDefinition.getPortletId();
 
 		assertHttpResponseStatusCode(
 			404,
-			_exportPreviewResource.getPortletExportPreviewHttpResponse(
-				portletId, null, 0L, null));
+			_exportPreviewResource.getExportPreviewHttpResponse(
+				null, 0L, null, null));
 
 		_testGetExportPreviewWithDateFilter(
 			_companyObjectDefinition,
-			(startDate, endDate) ->
-				exportPreviewResource.getPortletExportPreview(
-					portletId, endDate, 0L, startDate));
+			(startDate, endDate) -> exportPreviewResource.getExportPreview(
+				endDate, 0L, null, startDate));
+		_testGetExportPreviewWithDateFilter(
+			_companyObjectDefinition,
+			(startDate, endDate) -> exportPreviewResource.getExportPreview(
+				endDate, 0L, portletId, startDate));
+		_testGetExportPreviewWithDeletions(
+			GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			() -> exportPreviewResource.getExportPreview(null, 0L, null, null));
+		_testGetExportPreviewWithDifferentScope(
+			exportPreviewResource.getExportPreview(null, 0L, null, null),
+			_depotObjectDefinition, _siteObjectDefinition);
 
 		long plid = _addLayoutWithPortlet(testGroup, portletId);
 
 		_testGetPortletExportPreview(
-			exportPreviewResource.getPortletExportPreview(
-				portletId, null, plid, null),
+			exportPreviewResource.getExportPreview(null, plid, portletId, null),
 			portletId);
 	}
 
@@ -235,53 +211,40 @@ public class ExportPreviewResourceTest
 	@Override
 	@Test
 	public void testGetSiteExportPreview() throws Exception {
-		assertHttpResponseStatusCode(
-			404,
-			_exportPreviewResource.getSiteExportPreviewHttpResponse(
-				testGroup.getExternalReferenceCode(), null, null));
-
-		_testGetExportPreviewWithDateFilter(
-			_siteObjectDefinition,
-			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
-				testGroup.getExternalReferenceCode(), endDate, startDate));
-		_testGetExportPreviewWithDeletions(
-			testGroup.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE,
-			() -> exportPreviewResource.getSiteExportPreview(
-				testGroup.getExternalReferenceCode(), null, null));
-		_testGetExportPreviewWithDifferentScope(
-			exportPreviewResource.getSiteExportPreview(
-				testGroup.getExternalReferenceCode(), null, null),
-			_companyObjectDefinition, _depotObjectDefinition);
-		_testGetExportPreviewWithLayoutSet(
-			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
-				testGroup.getExternalReferenceCode(), endDate, startDate));
-		_testGetSiteExportPreviewWithLayoutPageTemplateEntries();
-	}
-
-	@Override
-	@Test
-	public void testGetSitePortletExportPreview() throws Exception {
+		String externalReferenceCode = testGroup.getExternalReferenceCode();
 		String portletId = _siteObjectDefinition.getPortletId();
 
 		assertHttpResponseStatusCode(
 			404,
-			_exportPreviewResource.getSitePortletExportPreviewHttpResponse(
-				testGroup.getExternalReferenceCode(), portletId, null, 0L,
-				null));
+			_exportPreviewResource.getSiteExportPreviewHttpResponse(
+				externalReferenceCode, null, 0L, null, null));
 
 		_testGetExportPreviewWithDateFilter(
 			_siteObjectDefinition,
-			(startDate, endDate) ->
-				exportPreviewResource.getSitePortletExportPreview(
-					testGroup.getExternalReferenceCode(), portletId, endDate,
-					0L, startDate));
+			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, endDate, 0L, null, startDate));
+		_testGetExportPreviewWithDateFilter(
+			_siteObjectDefinition,
+			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, endDate, 0L, portletId, startDate));
+		_testGetExportPreviewWithDeletions(
+			testGroup.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE,
+			() -> exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, null, 0L, null, null));
+		_testGetExportPreviewWithDifferentScope(
+			exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, null, 0L, null, null),
+			_companyObjectDefinition, _depotObjectDefinition);
+		_testGetExportPreviewWithLayoutSet(
+			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, endDate, 0L, null, startDate));
+		_testGetSiteExportPreviewWithLayoutPageTemplateEntries();
 
 		long plid = _addLayoutWithPortlet(testGroup, portletId);
 
 		_testGetPortletExportPreview(
-			exportPreviewResource.getSitePortletExportPreview(
-				testGroup.getExternalReferenceCode(), portletId, null, plid,
-				null),
+			exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, null, plid, portletId, null),
 			portletId);
 	}
 
@@ -665,7 +628,7 @@ public class ExportPreviewResourceTest
 		PreviewPortletDataHandler previewPortletDataHandler =
 			_getPreviewPortletDataHandler(
 				exportPreviewResource.getSiteExportPreview(
-					testGroup.getExternalReferenceCode(), null, null),
+					testGroup.getExternalReferenceCode(), null, 0L, null, null),
 				"PORTLET_DATA_" +
 					LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES);
 

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
@@ -207,6 +207,30 @@ public class ExportPreviewResourceTest
 			_depotObjectDefinition, _siteObjectDefinition);
 	}
 
+	@Override
+	@Test
+	public void testGetPortletExportPreview() throws Exception {
+		String portletId = _companyObjectDefinition.getPortletId();
+
+		assertHttpResponseStatusCode(
+			404,
+			_exportPreviewResource.getPortletExportPreviewHttpResponse(
+				portletId, null, 0L, null));
+
+		_testGetExportPreviewWithDateFilter(
+			_companyObjectDefinition,
+			(startDate, endDate) ->
+				exportPreviewResource.getPortletExportPreview(
+					portletId, endDate, 0L, startDate));
+
+		long plid = _addLayoutWithPortlet(testGroup, portletId);
+
+		_testGetPortletExportPreview(
+			exportPreviewResource.getPortletExportPreview(
+				portletId, null, plid, null),
+			portletId);
+	}
+
 	@FeatureFlag("LPD-38869")
 	@Override
 	@Test

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
@@ -13,6 +13,8 @@ import com.liferay.exportimport.rest.client.dto.v1_0.ProcessProgress;
 import com.liferay.exportimport.rest.client.dto.v1_0.RequestPortletDataHandler;
 import com.liferay.exportimport.rest.client.dto.v1_0.RequestPortletDataHandlerControl;
 import com.liferay.exportimport.rest.client.http.HttpInvoker;
+import com.liferay.exportimport.rest.client.pagination.Page;
+import com.liferay.exportimport.rest.client.pagination.Pagination;
 import com.liferay.exportimport.rest.client.resource.v1_0.ExportProcessResource;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -178,6 +180,56 @@ public class ExportProcessResourceTest
 			exportProcess.getName() + ".lar", fileEntry.getTitle());
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Override
+	@Test
+	public void testGetExportProcessesPage() throws Exception {
+		Page<ExportProcess> page = exportProcessResource.getExportProcessesPage(
+			null, null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		ExportProcess exportProcess1 =
+			testGetExportProcessesPage_addExportProcess(randomExportProcess());
+
+		ExportProcess exportProcess2 =
+			testGetExportProcessesPage_addExportProcess(randomExportProcess());
+
+		String portletId = RandomTestUtil.randomString();
+
+		ExportProcess portletExportProcess = _addExportProcess(
+			_getCompanyGroupId(), portletId,
+			BackgroundTaskExecutorNames.
+				PORTLET_EXPORT_BACKGROUND_TASK_EXECUTOR);
+
+		page = exportProcessResource.getExportProcessesPage(
+			null, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(exportProcess1, (List<ExportProcess>)page.getItems());
+		assertContains(exportProcess2, (List<ExportProcess>)page.getItems());
+		assertValid(page, testGetExportProcessesPage_getExpectedActions());
+
+		page = exportProcessResource.getExportProcessesPage(
+			null, portletId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(
+			portletExportProcess, (List<ExportProcess>)page.getItems());
+
+		page = exportProcessResource.getExportProcessesPage(
+			null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		exportProcessResource.deleteExportProcess(exportProcess1.getId());
+		exportProcessResource.deleteExportProcess(exportProcess2.getId());
+		exportProcessResource.deleteExportProcess(portletExportProcess.getId());
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
@@ -293,6 +293,46 @@ public class ExportProcessResourceTest
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
+	@Override
+	@Test
+	public void testPostPortletExportProcess() throws Exception {
+		Group companyGroup = _stagingGroupHelper.fetchCompanyGroup(
+			testCompany.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String portletId = objectDefinition.getPortletId();
+
+		LayoutTestUtil.addPortletToLayout(layout, portletId);
+
+		assertHttpResponseStatusCode(
+			403,
+			_exportProcessResource.postPortletExportProcessHttpResponse(
+				portletId, layout.getPlid(),
+				new ExportProcessRequest() {
+					{
+						name = RandomTestUtil.randomString();
+					}
+				}));
+
+		_testPostExportProcessWithInvalidDateRange(
+			exportProcessRequest ->
+				exportProcessResource.postPortletExportProcessHttpResponse(
+					portletId, layout.getPlid(), exportProcessRequest));
+		_testPostExportProcessWithObjectDefinition(
+			exportProcessRequest ->
+				exportProcessResource.postPortletExportProcess(
+					portletId, layout.getPlid(), exportProcessRequest),
+			companyGroup.getGroupId(), objectDefinition,
+			_addObjectEntries(
+				objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
 	@FeatureFlag("LPD-38869")
 	@Override
 	@Test
@@ -476,6 +516,24 @@ public class ExportProcessResourceTest
 				percentage = 50;
 			}
 		};
+	}
+
+	@Override
+	protected ExportProcess testGetPortletExportProcessesPage_addExportProcess(
+			String portletId, ExportProcess exportProcess)
+		throws Exception {
+
+		return _addExportProcess(
+			_getCompanyGroupId(), portletId,
+			BackgroundTaskExecutorNames.
+				PORTLET_EXPORT_BACKGROUND_TASK_EXECUTOR);
+	}
+
+	@Override
+	protected String testGetPortletExportProcessesPage_getPortletId()
+		throws Exception {
+
+		return RandomTestUtil.randomString();
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
@@ -139,7 +139,8 @@ public class ExportProcessResourceTest
 				LoggerTestUtil.WARN)) {
 
 			exportProcess = exportProcessResource.postSiteExportProcess(
-				testGroup.getExternalReferenceCode(), exportProcessRequest);
+				testGroup.getExternalReferenceCode(), 0L, null,
+				exportProcessRequest);
 
 			ExportProcess finalExportProcess = exportProcess;
 
@@ -182,10 +183,13 @@ public class ExportProcessResourceTest
 	@Override
 	@Test
 	public void testPostAssetLibraryExportProcess() throws Exception {
+		String externalReferenceCode =
+			testDepotEntryGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_exportProcessResource.postAssetLibraryExportProcessHttpResponse(
-				testDepotEntryGroup.getExternalReferenceCode(),
+				externalReferenceCode, 0L, null,
 				new ExportProcessRequest() {
 					{
 						name = RandomTestUtil.randomString();
@@ -195,63 +199,36 @@ public class ExportProcessResourceTest
 		_testPostExportProcessWithInvalidDateRange(
 			exportProcessRequest ->
 				exportProcessResource.postAssetLibraryExportProcessHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					exportProcessRequest));
+					externalReferenceCode, 0L, null, exportProcessRequest));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		ObjectEntry[] objectEntries = _addObjectEntries(
+			objectDefinition, testDepotEntryGroup.getGroupId());
 
 		_testPostExportProcessWithObjectDefinition(
 			exportProcessRequest ->
 				exportProcessResource.postAssetLibraryExportProcess(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					exportProcessRequest),
-			testDepotEntryGroup.getGroupId(), objectDefinition,
-			_addObjectEntries(
-				objectDefinition, testDepotEntryGroup.getGroupId()));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
-	}
-
-	@Override
-	@Test
-	public void testPostAssetLibraryPortletExportProcess() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(
-			testDepotEntryGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_DEPOT);
+					externalReferenceCode, 0L, null, exportProcessRequest),
+			testDepotEntryGroup.getGroupId(), objectDefinition, objectEntries);
 
 		String portletId = objectDefinition.getPortletId();
 
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
+		long plid = _addLayoutWithPortlet(testDepotEntryGroup, portletId);
 
-		assertHttpResponseStatusCode(
-			403,
-			_exportProcessResource.
-				postAssetLibraryPortletExportProcessHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(),
-					new ExportProcessRequest() {
-						{
-							name = RandomTestUtil.randomString();
-						}
-					}));
-
-		_testPostExportProcessWithInvalidDateRange(
-			exportProcessRequest ->
-				exportProcessResource.
-					postAssetLibraryPortletExportProcessHttpResponse(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						portletId, layout.getPlid(), exportProcessRequest));
 		_testPostExportProcessWithObjectDefinition(
 			exportProcessRequest ->
-				exportProcessResource.postAssetLibraryPortletExportProcess(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), exportProcessRequest),
-			testDepotEntryGroup.getGroupId(), objectDefinition,
-			_addObjectEntries(
-				objectDefinition, testDepotEntryGroup.getGroupId()));
+				exportProcessResource.postAssetLibraryExportProcess(
+					externalReferenceCode, plid, portletId,
+					exportProcessRequest),
+			testDepotEntryGroup.getGroupId(), objectDefinition, objectEntries);
+
+		_testPostExportProcessWithoutPlid(
+			exportProcessRequest ->
+				exportProcessResource.postAssetLibraryExportProcessHttpResponse(
+					externalReferenceCode, 0L, portletId,
+					exportProcessRequest));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
@@ -262,6 +239,7 @@ public class ExportProcessResourceTest
 		assertHttpResponseStatusCode(
 			403,
 			_exportProcessResource.postExportProcessHttpResponse(
+				0L, null,
 				new ExportProcessRequest() {
 					{
 						name = RandomTestUtil.randomString();
@@ -272,7 +250,9 @@ public class ExportProcessResourceTest
 			testCompany.getCompanyId());
 
 		_testPostExportProcessWithInvalidDateRange(
-			exportProcessResource::postExportProcessHttpResponse);
+			exportProcessRequest ->
+				exportProcessResource.postExportProcessHttpResponse(
+					0L, null, exportProcessRequest));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_COMPANY);
@@ -281,8 +261,9 @@ public class ExportProcessResourceTest
 			objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 		_testPostExportProcessWithObjectDefinition(
-			exportProcessResource::postExportProcess, companyGroup.getGroupId(),
-			objectDefinition, objectEntries);
+			exportProcessRequest -> exportProcessResource.postExportProcess(
+				0L, null, exportProcessRequest),
+			companyGroup.getGroupId(), objectDefinition, objectEntries);
 		_testPostExportProcessWithDateRange(
 			companyGroup.getGroupId(), objectDefinition, objectEntries);
 		_testPostExportProcessWithPermissions(
@@ -290,45 +271,19 @@ public class ExportProcessResourceTest
 
 		_testPostExportProcessWithSameName(companyGroup.getGroupId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
-	}
-
-	@Override
-	@Test
-	public void testPostPortletExportProcess() throws Exception {
-		Group companyGroup = _stagingGroupHelper.fetchCompanyGroup(
-			testCompany.getCompanyId());
-
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_COMPANY);
-
 		String portletId = objectDefinition.getPortletId();
 
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
+		long plid = _addLayoutWithPortlet(testGroup, portletId);
 
-		assertHttpResponseStatusCode(
-			403,
-			_exportProcessResource.postPortletExportProcessHttpResponse(
-				portletId, layout.getPlid(),
-				new ExportProcessRequest() {
-					{
-						name = RandomTestUtil.randomString();
-					}
-				}));
-
-		_testPostExportProcessWithInvalidDateRange(
-			exportProcessRequest ->
-				exportProcessResource.postPortletExportProcessHttpResponse(
-					portletId, layout.getPlid(), exportProcessRequest));
 		_testPostExportProcessWithObjectDefinition(
+			exportProcessRequest -> exportProcessResource.postExportProcess(
+				plid, portletId, exportProcessRequest),
+			companyGroup.getGroupId(), objectDefinition, objectEntries);
+
+		_testPostExportProcessWithoutPlid(
 			exportProcessRequest ->
-				exportProcessResource.postPortletExportProcess(
-					portletId, layout.getPlid(), exportProcessRequest),
-			companyGroup.getGroupId(), objectDefinition,
-			_addObjectEntries(
-				objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID));
+				exportProcessResource.postExportProcessHttpResponse(
+					0L, portletId, exportProcessRequest));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
@@ -337,10 +292,12 @@ public class ExportProcessResourceTest
 	@Override
 	@Test
 	public void testPostSiteExportProcess() throws Exception {
+		String externalReferenceCode = testGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_exportProcessResource.postSiteExportProcessHttpResponse(
-				testGroup.getExternalReferenceCode(),
+				externalReferenceCode, 0L, null,
 				new ExportProcessRequest() {
 					{
 						name = RandomTestUtil.randomString();
@@ -350,62 +307,39 @@ public class ExportProcessResourceTest
 		_testPostExportProcessWithInvalidDateRange(
 			exportProcessRequest ->
 				exportProcessResource.postSiteExportProcessHttpResponse(
-					testGroup.getExternalReferenceCode(),
-					exportProcessRequest));
+					externalReferenceCode, 0L, null, exportProcessRequest));
 		_testPostExportProcessWithLayoutSet(
 			exportProcessRequest ->
 				exportProcessResource.postSiteExportProcessHttpResponse(
-					testGroup.getExternalReferenceCode(), exportProcessRequest),
+					externalReferenceCode, 0L, null, exportProcessRequest),
 			exportProcessRequest -> exportProcessResource.postSiteExportProcess(
-				testGroup.getExternalReferenceCode(), exportProcessRequest));
+				externalReferenceCode, 0L, null, exportProcessRequest));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry[] objectEntries = _addObjectEntries(
+			objectDefinition, testGroup.getGroupId());
 
 		_testPostExportProcessWithObjectDefinition(
 			exportProcessRequest -> exportProcessResource.postSiteExportProcess(
-				testGroup.getExternalReferenceCode(), exportProcessRequest),
-			testGroup.getGroupId(), objectDefinition,
-			_addObjectEntries(objectDefinition, testGroup.getGroupId()));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
-	}
-
-	@Override
-	@Test
-	public void testPostSitePortletExportProcess() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_SITE);
+				externalReferenceCode, 0L, null, exportProcessRequest),
+			testGroup.getGroupId(), objectDefinition, objectEntries);
 
 		String portletId = objectDefinition.getPortletId();
 
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
+		long plid = _addLayoutWithPortlet(testGroup, portletId);
 
-		assertHttpResponseStatusCode(
-			403,
-			_exportProcessResource.postSitePortletExportProcessHttpResponse(
-				testGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(),
-				new ExportProcessRequest() {
-					{
-						name = RandomTestUtil.randomString();
-					}
-				}));
-
-		_testPostExportProcessWithInvalidDateRange(
-			exportProcessRequest ->
-				exportProcessResource.postSitePortletExportProcessHttpResponse(
-					testGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), exportProcessRequest));
 		_testPostExportProcessWithObjectDefinition(
+			exportProcessRequest -> exportProcessResource.postSiteExportProcess(
+				externalReferenceCode, plid, portletId, exportProcessRequest),
+			testGroup.getGroupId(), objectDefinition, objectEntries);
+
+		_testPostExportProcessWithoutPlid(
 			exportProcessRequest ->
-				exportProcessResource.postSitePortletExportProcess(
-					testGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), exportProcessRequest),
-			testGroup.getGroupId(), objectDefinition,
-			_addObjectEntries(objectDefinition, testGroup.getGroupId()));
+				exportProcessResource.postSiteExportProcessHttpResponse(
+					externalReferenceCode, 0L, portletId,
+					exportProcessRequest));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
@@ -453,36 +387,6 @@ public class ExportProcessResourceTest
 	}
 
 	@Override
-	protected ExportProcess
-			testGetAssetLibraryPortletExportProcessesPage_addExportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				ExportProcess exportProcess)
-		throws Exception {
-
-		return _addExportProcess(
-			_getGroupId(assetLibraryExternalReferenceCode), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_EXPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected Map<String, Map<String, String>>
-			testGetAssetLibraryPortletExportProcessesPage_getExpectedActions(
-				String assetLibraryExternalReferenceCode, String portletId)
-		throws Exception {
-
-		return new HashMap<>();
-	}
-
-	@Override
-	protected String
-			testGetAssetLibraryPortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
-	}
-
-	@Override
 	protected ExportProcess testGetExportProcess_addExportProcess()
 		throws Exception {
 
@@ -519,24 +423,6 @@ public class ExportProcessResourceTest
 	}
 
 	@Override
-	protected ExportProcess testGetPortletExportProcessesPage_addExportProcess(
-			String portletId, ExportProcess exportProcess)
-		throws Exception {
-
-		return _addExportProcess(
-			_getCompanyGroupId(), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_EXPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected String testGetPortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
-	}
-
-	@Override
 	protected ExportProcess testGetSiteExportProcessesPage_addExportProcess(
 			String siteExternalReferenceCode, ExportProcess exportProcess)
 		throws Exception {
@@ -552,35 +438,6 @@ public class ExportProcessResourceTest
 		throws Exception {
 
 		return new HashMap<>();
-	}
-
-	@Override
-	protected ExportProcess
-			testGetSitePortletExportProcessesPage_addExportProcess(
-				String siteExternalReferenceCode, String portletId,
-				ExportProcess exportProcess)
-		throws Exception {
-
-		return _addExportProcess(
-			_getGroupId(siteExternalReferenceCode), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_EXPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected Map<String, Map<String, String>>
-			testGetSitePortletExportProcessesPage_getExpectedActions(
-				String siteExternalReferenceCode, String portletId)
-		throws Exception {
-
-		return new HashMap<>();
-	}
-
-	@Override
-	protected String testGetSitePortletExportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
 	}
 
 	@Override
@@ -631,6 +488,16 @@ public class ExportProcessResourceTest
 				}
 			};
 		}
+	}
+
+	private long _addLayoutWithPortlet(Group group, String portletId)
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		LayoutTestUtil.addPortletToLayout(layout, portletId);
+
+		return layout.getPlid();
 	}
 
 	private ObjectEntry[] _addObjectEntries(
@@ -852,7 +719,10 @@ public class ExportProcessResourceTest
 		Assert.assertNull(
 			_getExportedJSONArray(
 				_postExportProcess(
-					exportProcessResource::postExportProcess, objectDefinition,
+					exportProcessRequest ->
+						exportProcessResource.postExportProcess(
+							0L, null, exportProcessRequest),
+					objectDefinition,
 					exportProcessRequest -> {
 						exportProcessRequest.setEndDate(
 							new Date(time - Time.DAY));
@@ -862,7 +732,9 @@ public class ExportProcessResourceTest
 				groupId, objectDefinition));
 
 		ExportProcess exportProcess = _postExportProcess(
-			exportProcessResource::postExportProcess, objectDefinition,
+			exportProcessRequest -> exportProcessResource.postExportProcess(
+				0L, null, exportProcessRequest),
+			objectDefinition,
 			exportProcessRequest -> {
 				exportProcessRequest.setEndDate(new Date(time));
 				exportProcessRequest.setStartDate(new Date(time - Time.HOUR));
@@ -977,6 +849,27 @@ public class ExportProcessResourceTest
 			ObjectEntry::getExternalReferenceCode);
 	}
 
+	private void _testPostExportProcessWithoutPlid(
+			UnsafeFunction
+				<ExportProcessRequest, HttpInvoker.HttpResponse, Exception>
+					unsafeFunction)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.WARN)) {
+
+			ExportProcessRequest exportProcessRequest =
+				new ExportProcessRequest();
+
+			exportProcessRequest.setName(RandomTestUtil.randomString());
+
+			assertHttpResponseStatusCode(
+				400, unsafeFunction.apply(exportProcessRequest));
+		}
+	}
+
 	@TestInfo("LPD-90359")
 	private void _testPostExportProcessWithPermissions(
 			long groupId, ObjectDefinition objectDefinition,
@@ -985,7 +878,9 @@ public class ExportProcessResourceTest
 
 		JSONArray jsonArray = _getExportedJSONArray(
 			_postExportProcess(
-				exportProcessResource::postExportProcess, objectDefinition,
+				exportProcessRequest -> exportProcessResource.postExportProcess(
+					0L, null, exportProcessRequest),
+				objectDefinition,
 				exportProcessRequest -> exportProcessRequest.setPermissions(
 					true)),
 			groupId, objectDefinition);
@@ -1013,14 +908,18 @@ public class ExportProcessResourceTest
 		String name = RandomTestUtil.randomString();
 
 		ExportProcess exportProcess1 = _postExportProcess(
-			exportProcessResource::postExportProcess, objectDefinition,
+			exportProcessRequest -> exportProcessResource.postExportProcess(
+				0L, null, exportProcessRequest),
+			objectDefinition,
 			exportProcessRequest -> exportProcessRequest.setName(name));
 
 		_addObjectEntry(
 			objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 		ExportProcess exportProcess2 = _postExportProcess(
-			exportProcessResource::postExportProcess, objectDefinition,
+			exportProcessRequest -> exportProcessResource.postExportProcess(
+				0L, null, exportProcessRequest),
+			objectDefinition,
 			exportProcessRequest -> exportProcessRequest.setName(name));
 
 		JSONArray jsonArray1 = _getExportedJSONArray(

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
@@ -239,6 +239,49 @@ public class ImportPreviewResourceTest
 
 	@Override
 	@Test
+	public void testPostPortletImportPreview() throws Exception {
+		Group group = _stagingGroupHelper.fetchCompanyGroup(
+			testCompany.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+
+		ObjectDefinition objectDefinition = _publishObjectDefinitionWithEntries(
+			GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String portletId = objectDefinition.getPortletId();
+
+		LayoutTestUtil.addPortletToLayout(layout, portletId);
+
+		assertHttpResponseStatusCode(
+			403,
+			_importPreviewResource.postPortletImportPreviewHttpResponse(
+				portletId, layout.getPlid(), null,
+				HashMapBuilder.put(
+					"file",
+					_exportPortletAsFile(
+						group.getGroupId(), layout.getPlid(), portletId)
+				).build()));
+
+		_testPostImportPreviewWithInvalidFile(
+			file -> importPreviewResource.postPortletImportPreviewHttpResponse(
+				portletId, layout.getPlid(), null,
+				HashMapBuilder.put(
+					"file", file
+				).build()));
+		_testPostPortletImportPreviewWithObjectEntries(
+			group.getGroupId(), objectDefinition, layout.getPlid(),
+			file -> importPreviewResource.postPortletImportPreview(
+				portletId, layout.getPlid(), null,
+				HashMapBuilder.put(
+					"file", file
+				).build()));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Override
+	@Test
 	public void testPostSiteImportPreview() throws Exception {
 		assertHttpResponseStatusCode(
 			403,

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
@@ -112,10 +112,13 @@ public class ImportPreviewResourceTest
 	@Override
 	@Test
 	public void testPostAssetLibraryImportPreview() throws Exception {
+		String externalReferenceCode =
+			testDepotEntryGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_importPreviewResource.postAssetLibraryImportPreviewHttpResponse(
-				testDepotEntryGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file",
 					_exportLayoutAsFile(testDepotEntryGroup.getGroupId())
@@ -124,7 +127,7 @@ public class ImportPreviewResourceTest
 		_testPostImportPreviewWithInvalidFile(
 			file ->
 				importPreviewResource.postAssetLibraryImportPreviewHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(), null,
+					externalReferenceCode, 0L, null, null,
 					HashMapBuilder.put(
 						"file", file
 					).build()));
@@ -134,10 +137,21 @@ public class ImportPreviewResourceTest
 			ObjectDefinitionConstants.SCOPE_DEPOT);
 
 		try {
+			String portletId = objectDefinition.getPortletId();
+
+			long plid = _addLayoutWithPortlet(testDepotEntryGroup, portletId);
+
 			_testPostImportPreviewWithObjectEntries(
 				testDepotEntryGroup.getGroupId(), objectDefinition,
 				file -> importPreviewResource.postAssetLibraryImportPreview(
-					testDepotEntryGroup.getExternalReferenceCode(), null,
+					externalReferenceCode, 0L, null, null,
+					HashMapBuilder.put(
+						"file", file
+					).build()));
+			_testPostPortletImportPreviewWithObjectEntries(
+				testDepotEntryGroup.getGroupId(), objectDefinition, plid,
+				file -> importPreviewResource.postAssetLibraryImportPreview(
+					externalReferenceCode, plid, portletId, null,
 					HashMapBuilder.put(
 						"file", file
 					).build()));
@@ -146,55 +160,6 @@ public class ImportPreviewResourceTest
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				objectDefinition);
 		}
-	}
-
-	@Override
-	@Test
-	public void testPostAssetLibraryPortletImportPreview() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(
-			testDepotEntryGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinitionWithEntries(
-			testDepotEntryGroup.getGroupId(),
-			ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		String portletId = objectDefinition.getPortletId();
-
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
-
-		assertHttpResponseStatusCode(
-			403,
-			_importPreviewResource.
-				postAssetLibraryPortletImportPreviewHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), null,
-					HashMapBuilder.put(
-						"file",
-						_exportPortletAsFile(
-							testDepotEntryGroup.getGroupId(), layout.getPlid(),
-							portletId)
-					).build()));
-
-		_testPostImportPreviewWithInvalidFile(
-			file ->
-				importPreviewResource.
-					postAssetLibraryPortletImportPreviewHttpResponse(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						portletId, layout.getPlid(), null,
-						HashMapBuilder.put(
-							"file", file
-						).build()));
-		_testPostPortletImportPreviewWithObjectEntries(
-			testDepotEntryGroup.getGroupId(), objectDefinition,
-			layout.getPlid(),
-			file -> importPreviewResource.postAssetLibraryPortletImportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
 	@Override
@@ -206,14 +171,14 @@ public class ImportPreviewResourceTest
 		assertHttpResponseStatusCode(
 			403,
 			_importPreviewResource.postImportPreviewHttpResponse(
-				null,
+				0L, null, null,
 				HashMapBuilder.put(
 					"file", _exportLayoutAsFile(group.getGroupId())
 				).build()));
 
 		_testPostImportPreviewWithInvalidFile(
 			file -> importPreviewResource.postImportPreviewHttpResponse(
-				null,
+				0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()));
@@ -223,10 +188,21 @@ public class ImportPreviewResourceTest
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		try {
+			String portletId = objectDefinition.getPortletId();
+
+			long plid = _addLayoutWithPortlet(testGroup, portletId);
+
 			_testPostImportPreviewWithObjectEntries(
 				group.getGroupId(), objectDefinition,
 				file -> importPreviewResource.postImportPreview(
-					null,
+					0L, null, null,
+					HashMapBuilder.put(
+						"file", file
+					).build()));
+			_testPostPortletImportPreviewWithObjectEntries(
+				group.getGroupId(), objectDefinition, plid,
+				file -> importPreviewResource.postImportPreview(
+					plid, portletId, null,
 					HashMapBuilder.put(
 						"file", file
 					).build()));
@@ -239,61 +215,20 @@ public class ImportPreviewResourceTest
 
 	@Override
 	@Test
-	public void testPostPortletImportPreview() throws Exception {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			testCompany.getCompanyId());
-
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinitionWithEntries(
-			GroupConstants.DEFAULT_PARENT_GROUP_ID,
-			ObjectDefinitionConstants.SCOPE_COMPANY);
-
-		String portletId = objectDefinition.getPortletId();
-
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
-
-		assertHttpResponseStatusCode(
-			403,
-			_importPreviewResource.postPortletImportPreviewHttpResponse(
-				portletId, layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file",
-					_exportPortletAsFile(
-						group.getGroupId(), layout.getPlid(), portletId)
-				).build()));
-
-		_testPostImportPreviewWithInvalidFile(
-			file -> importPreviewResource.postPortletImportPreviewHttpResponse(
-				portletId, layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()));
-		_testPostPortletImportPreviewWithObjectEntries(
-			group.getGroupId(), objectDefinition, layout.getPlid(),
-			file -> importPreviewResource.postPortletImportPreview(
-				portletId, layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
-	}
-
-	@Override
-	@Test
 	public void testPostSiteImportPreview() throws Exception {
+		String externalReferenceCode = testGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_importPreviewResource.postSiteImportPreviewHttpResponse(
-				testGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", _exportLayoutAsFile(testGroup.getGroupId())
 				).build()));
 
 		_testPostImportPreviewWithInvalidFile(
 			file -> importPreviewResource.postSiteImportPreviewHttpResponse(
-				testGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()));
@@ -302,10 +237,21 @@ public class ImportPreviewResourceTest
 			testGroup.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE);
 
 		try {
+			String portletId = objectDefinition.getPortletId();
+
+			long plid = _addLayoutWithPortlet(testGroup, portletId);
+
 			_testPostImportPreviewWithObjectEntries(
 				testGroup.getGroupId(), objectDefinition,
 				file -> importPreviewResource.postSiteImportPreview(
-					testGroup.getExternalReferenceCode(), null,
+					externalReferenceCode, 0L, null, null,
+					HashMapBuilder.put(
+						"file", file
+					).build()));
+			_testPostPortletImportPreviewWithObjectEntries(
+				testGroup.getGroupId(), objectDefinition, plid,
+				file -> importPreviewResource.postSiteImportPreview(
+					externalReferenceCode, plid, portletId, null,
 					HashMapBuilder.put(
 						"file", file
 					).build()));
@@ -316,47 +262,14 @@ public class ImportPreviewResourceTest
 		}
 	}
 
-	@Override
-	@Test
-	public void testPostSitePortletImportPreview() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+	private long _addLayoutWithPortlet(Group group, String portletId)
+		throws Exception {
 
-		ObjectDefinition objectDefinition = _publishObjectDefinitionWithEntries(
-			testGroup.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE);
-
-		String portletId = objectDefinition.getPortletId();
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
 
 		LayoutTestUtil.addPortletToLayout(layout, portletId);
 
-		assertHttpResponseStatusCode(
-			403,
-			_importPreviewResource.postSitePortletImportPreviewHttpResponse(
-				testGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file",
-					_exportPortletAsFile(
-						testGroup.getGroupId(), layout.getPlid(), portletId)
-				).build()));
-
-		_testPostImportPreviewWithInvalidFile(
-			file ->
-				importPreviewResource.postSitePortletImportPreviewHttpResponse(
-					testGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), null,
-					HashMapBuilder.put(
-						"file", file
-					).build()));
-		_testPostPortletImportPreviewWithObjectEntries(
-			testGroup.getGroupId(), objectDefinition, layout.getPlid(),
-			file -> importPreviewResource.postSitePortletImportPreview(
-				testGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		return layout.getPlid();
 	}
 
 	private void _addObjectEntry(

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
@@ -20,6 +20,8 @@ import com.liferay.exportimport.rest.client.dto.v1_0.ImportProcessRequest;
 import com.liferay.exportimport.rest.client.dto.v1_0.ProcessProgress;
 import com.liferay.exportimport.rest.client.dto.v1_0.RequestPortletDataHandler;
 import com.liferay.exportimport.rest.client.http.HttpInvoker;
+import com.liferay.exportimport.rest.client.pagination.Page;
+import com.liferay.exportimport.rest.client.pagination.Pagination;
 import com.liferay.exportimport.rest.client.resource.v1_0.ImportPreviewResource;
 import com.liferay.exportimport.rest.client.resource.v1_0.ImportProcessResource;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
@@ -73,6 +75,7 @@ import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -129,6 +132,56 @@ public class ImportProcessResourceTest
 		super.tearDown();
 
 		_userLocalService.deleteUser(_user);
+	}
+
+	@Override
+	@Test
+	public void testGetImportProcessesPage() throws Exception {
+		Page<ImportProcess> page = importProcessResource.getImportProcessesPage(
+			null, null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		ImportProcess importProcess1 =
+			testGetImportProcessesPage_addImportProcess(randomImportProcess());
+
+		ImportProcess importProcess2 =
+			testGetImportProcessesPage_addImportProcess(randomImportProcess());
+
+		String portletId = RandomTestUtil.randomString();
+
+		ImportProcess portletImportProcess = _addImportProcess(
+			_getCompanyGroupId(), portletId,
+			BackgroundTaskExecutorNames.
+				PORTLET_IMPORT_BACKGROUND_TASK_EXECUTOR);
+
+		page = importProcessResource.getImportProcessesPage(
+			null, null, null, null, Pagination.of(1, (int)totalCount + 2),
+			null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
+		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
+		assertValid(page, testGetImportProcessesPage_getExpectedActions());
+
+		page = importProcessResource.getImportProcessesPage(
+			null, portletId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(
+			portletImportProcess, (List<ImportProcess>)page.getItems());
+
+		page = importProcessResource.getImportProcessesPage(
+			null, RandomTestUtil.randomString(), null, null,
+			Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		importProcessResource.deleteImportProcess(importProcess1.getId());
+		importProcessResource.deleteImportProcess(importProcess2.getId());
+		importProcessResource.deleteImportProcess(portletImportProcess.getId());
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
@@ -292,6 +292,42 @@ public class ImportProcessResourceTest
 
 	@Override
 	@Test
+	public void testPostPortletImportProcess() throws Exception {
+		Group companyGroup = _stagingGroupHelper.fetchCompanyGroup(
+			testCompany.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String portletId = objectDefinition.getPortletId();
+
+		LayoutTestUtil.addPortletToLayout(layout, portletId);
+
+		assertHttpResponseStatusCode(
+			403,
+			_importProcessResource.postPortletImportProcessHttpResponse(
+				portletId, layout.getPlid(), new ImportProcessRequest()));
+
+		_testPostImportProcessWithObjectDefinition(
+			() -> _exportPortletAsFile(
+				companyGroup.getGroupId(), layout.getPlid(), portletId),
+			objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			file -> _importPreviewResource.postPortletImportPreview(
+				portletId, layout.getPlid(), null,
+				HashMapBuilder.put(
+					"file", file
+				).build()),
+			importProcessRequest ->
+				importProcessResource.postPortletImportProcess(
+					portletId, layout.getPlid(), importProcessRequest));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Override
+	@Test
 	public void testPostSiteImportProcess() throws Exception {
 		assertHttpResponseStatusCode(
 			403,
@@ -492,6 +528,24 @@ public class ImportProcessResourceTest
 				percentage = 50;
 			}
 		};
+	}
+
+	@Override
+	protected ImportProcess testGetPortletImportProcessesPage_addImportProcess(
+			String portletId, ImportProcess importProcess)
+		throws Exception {
+
+		return _addImportProcess(
+			_getCompanyGroupId(), portletId,
+			BackgroundTaskExecutorNames.
+				PORTLET_IMPORT_BACKGROUND_TASK_EXECUTOR);
+	}
+
+	@Override
+	protected String testGetPortletImportProcessesPage_getPortletId()
+		throws Exception {
+
+		return RandomTestUtil.randomString();
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
@@ -134,97 +134,52 @@ public class ImportProcessResourceTest
 	@Override
 	@Test
 	public void testPostAssetLibraryImportProcess() throws Exception {
+		String externalReferenceCode =
+			testDepotEntryGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_importProcessResource.postAssetLibraryImportProcessHttpResponse(
-				testDepotEntryGroup.getExternalReferenceCode(),
-				new ImportProcessRequest()));
+				externalReferenceCode, 0L, null, new ImportProcessRequest()));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_DEPOT);
 
-		try {
-			_testPostImportProcessWithObjectDefinition(
-				() -> _exportLayoutAsFile(testDepotEntryGroup.getGroupId()),
-				objectDefinition, testDepotEntryGroup.getGroupId(),
-				file -> _importPreviewResource.postAssetLibraryImportPreview(
-					testDepotEntryGroup.getExternalReferenceCode(), null,
-					HashMapBuilder.put(
-						"file", file
-					).build()),
-				importProcessRequest ->
-					importProcessResource.postAssetLibraryImportProcess(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						importProcessRequest));
-		}
-		finally {
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
-		}
-
-		_testPostImportProcessWithPreviewForOtherGroup(
-			testGroup.getGroupId(),
-			file -> _importPreviewResource.postSiteImportPreview(
-				testGroup.getExternalReferenceCode(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()),
-			importProcessRequest ->
-				importProcessResource.postAssetLibraryImportProcessHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					importProcessRequest));
-		_testPostImportProcessWithSettings(
-			testDepotEntryGroup.getGroupId(),
+		_testPostImportProcessWithObjectDefinition(
+			() -> _exportLayoutAsFile(testDepotEntryGroup.getGroupId()),
+			objectDefinition, testDepotEntryGroup.getGroupId(),
 			file -> _importPreviewResource.postAssetLibraryImportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest ->
 				importProcessResource.postAssetLibraryImportProcess(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					importProcessRequest));
-		_testPostImportProcessWithoutPreview(
-			importProcessRequest ->
-				importProcessResource.postAssetLibraryImportProcessHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(),
-					importProcessRequest));
-	}
-
-	@Override
-	@Test
-	public void testPostAssetLibraryPortletImportProcess() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(
-			testDepotEntryGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_DEPOT);
+					externalReferenceCode, 0L, null, importProcessRequest));
 
 		String portletId = objectDefinition.getPortletId();
 
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
-
-		assertHttpResponseStatusCode(
-			403,
-			_importProcessResource.
-				postAssetLibraryPortletImportProcessHttpResponse(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), new ImportProcessRequest()));
+		long plid = _addLayoutWithPortlet(testDepotEntryGroup, portletId);
 
 		_testPostImportProcessWithObjectDefinition(
 			() -> _exportPortletAsFile(
-				testDepotEntryGroup.getGroupId(), layout.getPlid(), portletId),
+				testDepotEntryGroup.getGroupId(), plid, portletId),
 			objectDefinition, testDepotEntryGroup.getGroupId(),
-			file -> _importPreviewResource.postAssetLibraryPortletImportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), null,
+			file -> _importPreviewResource.postAssetLibraryImportPreview(
+				externalReferenceCode, plid, portletId, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest ->
-				importProcessResource.postAssetLibraryPortletImportProcess(
-					testDepotEntryGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), importProcessRequest));
+				importProcessResource.postAssetLibraryImportProcess(
+					externalReferenceCode, plid, portletId,
+					importProcessRequest));
+
+		_testPostImportProcessWithoutPlid(
+			importProcessRequest ->
+				importProcessResource.postAssetLibraryImportProcessHttpResponse(
+					externalReferenceCode, 0L, portletId,
+					importProcessRequest));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
@@ -235,7 +190,7 @@ public class ImportProcessResourceTest
 		assertHttpResponseStatusCode(
 			403,
 			_importProcessResource.postImportProcessHttpResponse(
-				new ImportProcessRequest()));
+				0L, null, new ImportProcessRequest()));
 
 		Group companyGroup = _stagingGroupHelper.fetchCompanyGroup(
 			testCompany.getCompanyId());
@@ -248,11 +203,33 @@ public class ImportProcessResourceTest
 				() -> _exportLayoutAsFile(companyGroup.getGroupId()),
 				objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID,
 				file -> _importPreviewResource.postImportPreview(
-					null,
+					0L, null, null,
 					HashMapBuilder.put(
 						"file", file
 					).build()),
-				importProcessResource::postImportProcess);
+				importProcessRequest -> importProcessResource.postImportProcess(
+					0L, null, importProcessRequest));
+
+			String portletId = objectDefinition.getPortletId();
+
+			long plid = _addLayoutWithPortlet(testGroup, portletId);
+
+			_testPostImportProcessWithObjectDefinition(
+				() -> _exportPortletAsFile(
+					companyGroup.getGroupId(), plid, portletId),
+				objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID,
+				file -> _importPreviewResource.postImportPreview(
+					plid, portletId, null,
+					HashMapBuilder.put(
+						"file", file
+					).build()),
+				importProcessRequest -> importProcessResource.postImportProcess(
+					plid, portletId, importProcessRequest));
+
+			_testPostImportProcessWithoutPlid(
+				importProcessRequest ->
+					importProcessResource.postImportProcessHttpResponse(
+						0L, portletId, importProcessRequest));
 		}
 		finally {
 			_objectDefinitionLocalService.deleteObjectDefinition(
@@ -264,76 +241,47 @@ public class ImportProcessResourceTest
 			_publishObjectDefinition(ObjectDefinitionConstants.SCOPE_COMPANY),
 			GroupConstants.DEFAULT_PARENT_GROUP_ID,
 			file -> _importPreviewResource.postImportPreview(
-				null,
+				0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
-			importProcessResource::postImportProcess);
+			importProcessRequest -> importProcessResource.postImportProcess(
+				0L, null, importProcessRequest));
 
 		_testPostImportProcessWithPreviewForOtherGroup(
 			testGroup.getGroupId(),
 			file -> _importPreviewResource.postSiteImportPreview(
-				testGroup.getExternalReferenceCode(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()),
-			importProcessResource::postImportProcessHttpResponse);
-		_testPostImportProcessWithSettings(
-			companyGroup.getGroupId(),
-			file -> _importPreviewResource.postImportPreview(
-				null,
-				HashMapBuilder.put(
-					"file", file
-				).build()),
-			importProcessResource::postImportProcess);
-		_testPostImportProcessWithoutPreview(
-			importProcessResource::postImportProcessHttpResponse);
-	}
-
-	@Override
-	@Test
-	public void testPostPortletImportProcess() throws Exception {
-		Group companyGroup = _stagingGroupHelper.fetchCompanyGroup(
-			testCompany.getCompanyId());
-
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_COMPANY);
-
-		String portletId = objectDefinition.getPortletId();
-
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
-
-		assertHttpResponseStatusCode(
-			403,
-			_importProcessResource.postPortletImportProcessHttpResponse(
-				portletId, layout.getPlid(), new ImportProcessRequest()));
-
-		_testPostImportProcessWithObjectDefinition(
-			() -> _exportPortletAsFile(
-				companyGroup.getGroupId(), layout.getPlid(), portletId),
-			objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID,
-			file -> _importPreviewResource.postPortletImportPreview(
-				portletId, layout.getPlid(), null,
+				testGroup.getExternalReferenceCode(), 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest ->
-				importProcessResource.postPortletImportProcess(
-					portletId, layout.getPlid(), importProcessRequest));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+				importProcessResource.postImportProcessHttpResponse(
+					0L, null, importProcessRequest));
+		_testPostImportProcessWithSettings(
+			companyGroup.getGroupId(),
+			file -> _importPreviewResource.postImportPreview(
+				0L, null, null,
+				HashMapBuilder.put(
+					"file", file
+				).build()),
+			importProcessRequest -> importProcessResource.postImportProcess(
+				0L, null, importProcessRequest));
+		_testPostImportProcessWithoutPreview(
+			importProcessRequest ->
+				importProcessResource.postImportProcessHttpResponse(
+					0L, null, importProcessRequest));
 	}
 
 	@Override
 	@Test
 	public void testPostSiteImportProcess() throws Exception {
+		String externalReferenceCode = testGroup.getExternalReferenceCode();
+
 		assertHttpResponseStatusCode(
 			403,
 			_importProcessResource.postSiteImportProcessHttpResponse(
-				testGroup.getExternalReferenceCode(),
-				new ImportProcessRequest()));
+				externalReferenceCode, 0L, null, new ImportProcessRequest()));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_SITE);
@@ -342,84 +290,67 @@ public class ImportProcessResourceTest
 			() -> _exportLayoutAsFile(testGroup.getGroupId()), objectDefinition,
 			testGroup.getGroupId(),
 			file -> _importPreviewResource.postSiteImportPreview(
-				testGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest -> importProcessResource.postSiteImportProcess(
-				testGroup.getExternalReferenceCode(), importProcessRequest));
+				externalReferenceCode, 0L, null, importProcessRequest));
+
+		String portletId = objectDefinition.getPortletId();
+
+		long plid = _addLayoutWithPortlet(testGroup, portletId);
+
+		_testPostImportProcessWithObjectDefinition(
+			() -> _exportPortletAsFile(testGroup.getGroupId(), plid, portletId),
+			objectDefinition, testGroup.getGroupId(),
+			file -> _importPreviewResource.postSiteImportPreview(
+				externalReferenceCode, plid, portletId, null,
+				HashMapBuilder.put(
+					"file", file
+				).build()),
+			importProcessRequest -> importProcessResource.postSiteImportProcess(
+				externalReferenceCode, plid, portletId, importProcessRequest));
+
+		_testPostImportProcessWithoutPlid(
+			importProcessRequest ->
+				importProcessResource.postSiteImportProcessHttpResponse(
+					externalReferenceCode, 0L, portletId,
+					importProcessRequest));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 
 		_testPostImportProcessWithPreviewForOtherGroup(
 			testDepotEntryGroup.getGroupId(),
 			file -> _importPreviewResource.postAssetLibraryImportPreview(
-				testDepotEntryGroup.getExternalReferenceCode(), null,
+				testDepotEntryGroup.getExternalReferenceCode(), 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest ->
 				importProcessResource.postSiteImportProcessHttpResponse(
-					testGroup.getExternalReferenceCode(),
-					importProcessRequest));
+					externalReferenceCode, 0L, null, importProcessRequest));
 		_testPostImportProcessWithSettings(
 			testGroup.getGroupId(),
 			file -> _importPreviewResource.postSiteImportPreview(
-				testGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest -> importProcessResource.postSiteImportProcess(
-				testGroup.getExternalReferenceCode(), importProcessRequest));
+				externalReferenceCode, 0L, null, importProcessRequest));
 		_testPostImportProcessWithoutPreview(
 			importProcessRequest ->
 				importProcessResource.postSiteImportProcessHttpResponse(
-					testGroup.getExternalReferenceCode(),
-					importProcessRequest));
+					externalReferenceCode, 0L, null, importProcessRequest));
 		_testPostImportProcessWithLayoutSet(
 			file -> _importPreviewResource.postSiteImportPreview(
-				testGroup.getExternalReferenceCode(), null,
+				externalReferenceCode, 0L, null, null,
 				HashMapBuilder.put(
 					"file", file
 				).build()),
 			importProcessRequest -> importProcessResource.postSiteImportProcess(
-				testGroup.getExternalReferenceCode(), importProcessRequest));
-	}
-
-	@Override
-	@Test
-	public void testPostSitePortletImportProcess() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_SITE);
-
-		String portletId = objectDefinition.getPortletId();
-
-		LayoutTestUtil.addPortletToLayout(layout, portletId);
-
-		assertHttpResponseStatusCode(
-			403,
-			_importProcessResource.postSitePortletImportProcessHttpResponse(
-				testGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), new ImportProcessRequest()));
-
-		_testPostImportProcessWithObjectDefinition(
-			() -> _exportPortletAsFile(
-				testGroup.getGroupId(), layout.getPlid(), portletId),
-			objectDefinition, testGroup.getGroupId(),
-			file -> _importPreviewResource.postSitePortletImportPreview(
-				testGroup.getExternalReferenceCode(), portletId,
-				layout.getPlid(), null,
-				HashMapBuilder.put(
-					"file", file
-				).build()),
-			importProcessRequest ->
-				importProcessResource.postSitePortletImportProcess(
-					testGroup.getExternalReferenceCode(), portletId,
-					layout.getPlid(), importProcessRequest));
-
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+				externalReferenceCode, 0L, null, importProcessRequest));
 	}
 
 	@Override
@@ -465,36 +396,6 @@ public class ImportProcessResourceTest
 	}
 
 	@Override
-	protected ImportProcess
-			testGetAssetLibraryPortletImportProcessesPage_addImportProcess(
-				String assetLibraryExternalReferenceCode, String portletId,
-				ImportProcess importProcess)
-		throws Exception {
-
-		return _addImportProcess(
-			_getGroupId(assetLibraryExternalReferenceCode), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_IMPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected Map<String, Map<String, String>>
-			testGetAssetLibraryPortletImportProcessesPage_getExpectedActions(
-				String assetLibraryExternalReferenceCode, String portletId)
-		throws Exception {
-
-		return new HashMap<>();
-	}
-
-	@Override
-	protected String
-			testGetAssetLibraryPortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
-	}
-
-	@Override
 	protected ImportProcess testGetImportProcess_addImportProcess()
 		throws Exception {
 
@@ -531,24 +432,6 @@ public class ImportProcessResourceTest
 	}
 
 	@Override
-	protected ImportProcess testGetPortletImportProcessesPage_addImportProcess(
-			String portletId, ImportProcess importProcess)
-		throws Exception {
-
-		return _addImportProcess(
-			_getCompanyGroupId(), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_IMPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected String testGetPortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
-	}
-
-	@Override
 	protected ImportProcess testGetSiteImportProcessesPage_addImportProcess(
 			String siteExternalReferenceCode, ImportProcess importProcess)
 		throws Exception {
@@ -564,35 +447,6 @@ public class ImportProcessResourceTest
 		throws Exception {
 
 		return new HashMap<>();
-	}
-
-	@Override
-	protected ImportProcess
-			testGetSitePortletImportProcessesPage_addImportProcess(
-				String siteExternalReferenceCode, String portletId,
-				ImportProcess importProcess)
-		throws Exception {
-
-		return _addImportProcess(
-			_getGroupId(siteExternalReferenceCode), portletId,
-			BackgroundTaskExecutorNames.
-				PORTLET_IMPORT_BACKGROUND_TASK_EXECUTOR);
-	}
-
-	@Override
-	protected Map<String, Map<String, String>>
-			testGetSitePortletImportProcessesPage_getExpectedActions(
-				String siteExternalReferenceCode, String portletId)
-		throws Exception {
-
-		return new HashMap<>();
-	}
-
-	@Override
-	protected String testGetSitePortletImportProcessesPage_getPortletId()
-		throws Exception {
-
-		return RandomTestUtil.randomString();
 	}
 
 	private ImportProcess _addImportProcess(
@@ -635,6 +489,16 @@ public class ImportProcessResourceTest
 				}
 			};
 		}
+	}
+
+	private long _addLayoutWithPortlet(Group group, String portletId)
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		LayoutTestUtil.addPortletToLayout(layout, portletId);
+
+		return layout.getPlid();
 	}
 
 	private void _deleteTempFileEntries(long groupId) throws Exception {
@@ -925,6 +789,22 @@ public class ImportProcessResourceTest
 					BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
 					backgroundTask.getStatus());
 			});
+	}
+
+	private void _testPostImportProcessWithoutPlid(
+			UnsafeFunction
+				<ImportProcessRequest, HttpInvoker.HttpResponse, Exception>
+					unsafeFunction)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.WARN)) {
+
+			assertHttpResponseStatusCode(
+				400, unsafeFunction.apply(new ImportProcessRequest()));
+		}
 	}
 
 	private void _testPostImportProcessWithoutPreview(

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -173,7 +173,7 @@ public class ExportImportPreviewDisplayContext {
 			return Scope.PORTLET;
 		}
 
-		if (_stagingGroupHelper.isCompanyGroup(_group)) {
+		if (_isInstanceScoped()) {
 			return Scope.COMPANY;
 		}
 
@@ -185,7 +185,7 @@ public class ExportImportPreviewDisplayContext {
 	}
 
 	public boolean isCommentsAndRatingsEnabled() {
-		if (!_stagingGroupHelper.isCompanyGroup(_group) ||
+		if (!_isInstanceScoped() ||
 			FeatureFlagManagerUtil.isEnabled(
 				_group.getCompanyId(), "LPD-43996")) {
 
@@ -236,34 +236,38 @@ public class ExportImportPreviewDisplayContext {
 					themeDisplay.getUser()
 				).build();
 
-			if (_stagingGroupHelper.isCompanyGroup(_group)) {
-				return exportPreviewResource.getExportPreview(null, null);
-			}
-
-			String externalReferenceCode = _group.getExternalReferenceCode();
-
 			String portletId = _getPortletId();
 
-			if (!Validator.isBlank(portletId)) {
-				long plid = ParamUtil.getLong(_httpServletRequest, "plid");
-
-				if (_group.isDepot()) {
-					return exportPreviewResource.
-						getAssetLibraryPortletExportPreview(
-							externalReferenceCode, portletId, null, plid, null);
+			if (Validator.isBlank(portletId)) {
+				if (_isInstanceScoped()) {
+					return exportPreviewResource.getExportPreview(null, null);
 				}
 
-				return exportPreviewResource.getSitePortletExportPreview(
-					externalReferenceCode, portletId, null, plid, null);
+				if (_group.isDepot()) {
+					return exportPreviewResource.getAssetLibraryExportPreview(
+						_group.getExternalReferenceCode(), null, null);
+				}
+
+				return exportPreviewResource.getSiteExportPreview(
+					_group.getExternalReferenceCode(), null, null);
+			}
+
+			long plid = ParamUtil.getLong(_httpServletRequest, "plid");
+
+			if (_isInstanceScoped()) {
+				return exportPreviewResource.getPortletExportPreview(
+					portletId, null, plid, null);
 			}
 
 			if (_group.isDepot()) {
-				return exportPreviewResource.getAssetLibraryExportPreview(
-					externalReferenceCode, null, null);
+				return exportPreviewResource.
+					getAssetLibraryPortletExportPreview(
+						_group.getExternalReferenceCode(), portletId, null,
+						plid, null);
 			}
 
-			return exportPreviewResource.getSiteExportPreview(
-				externalReferenceCode, null, null);
+			return exportPreviewResource.getSitePortletExportPreview(
+				_group.getExternalReferenceCode(), portletId, null, plid, null);
 		}
 		catch (Exception exception) {
 			_log.error("Unable to get export preview", exception);
@@ -290,7 +294,7 @@ public class ExportImportPreviewDisplayContext {
 	}
 
 	private String _getScopePath() {
-		if (_stagingGroupHelper.isCompanyGroup(_group)) {
+		if (_isInstanceScoped()) {
 			return StringPool.BLANK;
 		}
 
@@ -315,6 +319,16 @@ public class ExportImportPreviewDisplayContext {
 			label, " - ",
 			PortalUtil.getPortletTitle(
 				portletId, PortalUtil.getLocale(_httpServletRequest)));
+	}
+
+	private boolean _isInstanceScoped() {
+		if (_group.isControlPanel() ||
+			_stagingGroupHelper.isCompanyGroup(_group)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String _BASE_PATH = "/o/export-import/v1.0";

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -236,38 +236,22 @@ public class ExportImportPreviewDisplayContext {
 					themeDisplay.getUser()
 				).build();
 
+			long plid = ParamUtil.getLong(_httpServletRequest, "plid");
 			String portletId = _getPortletId();
 
-			if (Validator.isBlank(portletId)) {
-				if (_isInstanceScoped()) {
-					return exportPreviewResource.getExportPreview(null, null);
-				}
-
-				if (_group.isDepot()) {
-					return exportPreviewResource.getAssetLibraryExportPreview(
-						_group.getExternalReferenceCode(), null, null);
-				}
-
-				return exportPreviewResource.getSiteExportPreview(
-					_group.getExternalReferenceCode(), null, null);
-			}
-
-			long plid = ParamUtil.getLong(_httpServletRequest, "plid");
-
 			if (_isInstanceScoped()) {
-				return exportPreviewResource.getPortletExportPreview(
-					portletId, null, plid, null);
+				return exportPreviewResource.getExportPreview(
+					null, plid, portletId, null);
 			}
 
 			if (_group.isDepot()) {
-				return exportPreviewResource.
-					getAssetLibraryPortletExportPreview(
-						_group.getExternalReferenceCode(), portletId, null,
-						plid, null);
+				return exportPreviewResource.getAssetLibraryExportPreview(
+					_group.getExternalReferenceCode(), null, plid, portletId,
+					null);
 			}
 
-			return exportPreviewResource.getSitePortletExportPreview(
-				_group.getExternalReferenceCode(), portletId, null, plid, null);
+			return exportPreviewResource.getSiteExportPreview(
+				_group.getExternalReferenceCode(), null, plid, portletId, null);
 		}
 		catch (Exception exception) {
 			_log.error("Unable to get export preview", exception);
@@ -283,14 +267,14 @@ public class ExportImportPreviewDisplayContext {
 	private String _getResourceAPIURL(String endpoint) {
 		String portletId = _getPortletId();
 
-		if (!Validator.isBlank(portletId)) {
-			return StringBundler.concat(
-				_BASE_PATH, _getScopePath(), "/portlets/", _encode(portletId),
-				endpoint, "?plid=",
-				ParamUtil.getLong(_httpServletRequest, "plid"));
+		if (Validator.isBlank(portletId)) {
+			return _BASE_PATH + _getScopePath() + endpoint;
 		}
 
-		return _BASE_PATH + _getScopePath() + endpoint;
+		return StringBundler.concat(
+			_BASE_PATH, _getScopePath(), endpoint, "?plid=",
+			ParamUtil.getLong(_httpServletRequest, "plid"), "&portletId=",
+			_encode(portletId));
 	}
 
 	private String _getScopePath() {

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -8,8 +8,8 @@ package com.liferay.exportimport.web.internal.display.context;
 import com.liferay.exportimport.rest.dto.v1_0.ExportPreview;
 import com.liferay.exportimport.rest.resource.v1_0.ExportPreviewResource;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
+import com.liferay.exportimport.web.internal.util.ScopeUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.group.capability.GroupCapabilityUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -44,7 +43,7 @@ public class ExportImportPreviewDisplayContext {
 		ExportPreviewResource.Factory exportPreviewResourceFactory, Group group,
 		long groupId, HttpServletRequest httpServletRequest,
 		LiferayPortletResponse liferayPortletResponse, long liveGroupId,
-		boolean privateLayout, StagingGroupHelper stagingGroupHelper) {
+		boolean privateLayout) {
 
 		_backMVCRenderCommandName = backMVCRenderCommandName;
 		_exportPreviewResourceFactory = exportPreviewResourceFactory;
@@ -54,19 +53,17 @@ public class ExportImportPreviewDisplayContext {
 		_liferayPortletResponse = liferayPortletResponse;
 		_liveGroupId = liveGroupId;
 		_privateLayout = privateLayout;
-		_stagingGroupHelper = stagingGroupHelper;
 	}
 
 	public ExportImportPreviewDisplayContext(
 		String backMVCRenderCommandName, Group group, long groupId,
 		HttpServletRequest httpServletRequest,
 		LiferayPortletResponse liferayPortletResponse, long liveGroupId,
-		boolean privateLayout, StagingGroupHelper stagingGroupHelper) {
+		boolean privateLayout) {
 
 		this(
 			backMVCRenderCommandName, null, group, groupId, httpServletRequest,
-			liferayPortletResponse, liveGroupId, privateLayout,
-			stagingGroupHelper);
+			liferayPortletResponse, liveGroupId, privateLayout);
 	}
 
 	public String getBackURL() {
@@ -173,7 +170,7 @@ public class ExportImportPreviewDisplayContext {
 			return Scope.PORTLET;
 		}
 
-		if (_isInstanceScoped()) {
+		if (ScopeUtil.isInstanceScoped(_group)) {
 			return Scope.COMPANY;
 		}
 
@@ -185,7 +182,7 @@ public class ExportImportPreviewDisplayContext {
 	}
 
 	public boolean isCommentsAndRatingsEnabled() {
-		if (!_isInstanceScoped() ||
+		if (!ScopeUtil.isInstanceScoped(_group) ||
 			FeatureFlagManagerUtil.isEnabled(
 				_group.getCompanyId(), "LPD-43996")) {
 
@@ -239,7 +236,7 @@ public class ExportImportPreviewDisplayContext {
 			long plid = ParamUtil.getLong(_httpServletRequest, "plid");
 			String portletId = _getPortletId();
 
-			if (_isInstanceScoped()) {
+			if (ScopeUtil.isInstanceScoped(_group)) {
 				return exportPreviewResource.getExportPreview(
 					null, plid, portletId, null);
 			}
@@ -268,26 +265,13 @@ public class ExportImportPreviewDisplayContext {
 		String portletId = _getPortletId();
 
 		if (Validator.isBlank(portletId)) {
-			return _BASE_PATH + _getScopePath() + endpoint;
+			return ScopeUtil.getAPIURL(_group, endpoint);
 		}
 
 		return StringBundler.concat(
-			_BASE_PATH, _getScopePath(), endpoint, "?plid=",
+			ScopeUtil.getAPIURL(_group, endpoint), "?plid=",
 			ParamUtil.getLong(_httpServletRequest, "plid"), "&portletId=",
 			_encode(portletId));
-	}
-
-	private String _getScopePath() {
-		if (_isInstanceScoped()) {
-			return StringPool.BLANK;
-		}
-
-		if (_group.isDepot()) {
-			return "/asset-libraries/" +
-				_encode(_group.getExternalReferenceCode());
-		}
-
-		return "/sites/" + _encode(_group.getExternalReferenceCode());
 	}
 
 	private String _getTitle(String key) {
@@ -304,18 +288,6 @@ public class ExportImportPreviewDisplayContext {
 			PortalUtil.getPortletTitle(
 				portletId, PortalUtil.getLocale(_httpServletRequest)));
 	}
-
-	private boolean _isInstanceScoped() {
-		if (_group.isControlPanel() ||
-			_stagingGroupHelper.isCompanyGroup(_group)) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	private static final String _BASE_PATH = "/o/export-import/v1.0";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportImportPreviewDisplayContext.class);
@@ -334,6 +306,5 @@ public class ExportImportPreviewDisplayContext {
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final long _liveGroupId;
 	private final boolean _privateLayout;
-	private final StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
@@ -237,7 +237,7 @@ public class ExportImportProcessesDisplayContext {
 	}
 
 	private String _getFDSName(String companyFDSName, String fdsName) {
-		if (_stagingGroupHelper.isCompanyGroup(_group)) {
+		if (_isInstanceScoped()) {
 			return companyFDSName;
 		}
 
@@ -251,7 +251,7 @@ public class ExportImportProcessesDisplayContext {
 	}
 
 	private String _getScopePath() {
-		if (_stagingGroupHelper.isCompanyGroup(_group)) {
+		if (_isInstanceScoped()) {
 			return StringPool.BLANK;
 		}
 
@@ -275,6 +275,16 @@ public class ExportImportProcessesDisplayContext {
 		return StringBundler.concat(
 			LanguageUtil.get(_httpServletRequest, key), " ",
 			PortalUtil.getPortletTitle(portletId, _themeDisplay.getLocale()));
+	}
+
+	private boolean _isInstanceScoped() {
+		if (_group.isControlPanel() ||
+			_stagingGroupHelper.isCompanyGroup(_group)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String _BASE_PATH = "/o/export-import/v1.0";

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
@@ -6,11 +6,11 @@
 package com.liferay.exportimport.web.internal.display.context;
 
 import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
+import com.liferay.exportimport.web.internal.util.ScopeUtil;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -44,15 +43,13 @@ public class ExportImportProcessesDisplayContext {
 
 	public ExportImportProcessesDisplayContext(
 		Group group, long groupId, HttpServletRequest httpServletRequest,
-		LiferayPortletResponse liferayPortletResponse, boolean privateLayout,
-		StagingGroupHelper stagingGroupHelper) {
+		LiferayPortletResponse liferayPortletResponse, boolean privateLayout) {
 
 		_group = group;
 		_groupId = groupId;
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_privateLayout = privateLayout;
-		_stagingGroupHelper = stagingGroupHelper;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -67,13 +64,13 @@ public class ExportImportProcessesDisplayContext {
 	public List<FDSActionDropdownItem> getExportFDSActionDropdownItems() {
 		return ListUtil.fromArray(
 			new FDSActionDropdownItem(
-				_BASE_PATH + "/export-processes/{id}/relaunch", "reload",
-				"relaunch", LanguageUtil.get(_httpServletRequest, "relaunch"),
-				"post", null, "async"),
+				ScopeUtil.getAPIURL("/export-processes/{id}/relaunch"),
+				"reload", "relaunch",
+				LanguageUtil.get(_httpServletRequest, "relaunch"), "post", null,
+				"async"),
 			new FDSActionDropdownItem(
-				StringBundler.concat(
-					_BASE_PATH, "/export-processes/{id}/content?p_auth=",
-					AuthTokenUtil.getToken(_httpServletRequest)),
+				ScopeUtil.getAPIURL("/export-processes/{id}/content?p_auth=") +
+					AuthTokenUtil.getToken(_httpServletRequest),
 				"download", "download",
 				LanguageUtil.get(_httpServletRequest, "download"), "get", null,
 				"link",
@@ -164,11 +161,11 @@ public class ExportImportProcessesDisplayContext {
 		String portletId = _getPortletId();
 
 		if (Validator.isBlank(portletId)) {
-			return _BASE_PATH + _getScopePath() + endpoint;
+			return ScopeUtil.getAPIURL(_group, endpoint);
 		}
 
 		return StringBundler.concat(
-			_BASE_PATH, _getScopePath(), endpoint, "?portletId=",
+			ScopeUtil.getAPIURL(_group, endpoint), "?portletId=",
 			URLEncoder.encode(portletId, StandardCharsets.UTF_8));
 	}
 
@@ -176,7 +173,7 @@ public class ExportImportProcessesDisplayContext {
 		String endpoint) {
 
 		FDSActionDropdownItem fdsActionDropdownItem = new FDSActionDropdownItem(
-			_BASE_PATH + endpoint, "trash", "clear",
+			ScopeUtil.getAPIURL(endpoint), "trash", "clear",
 			LanguageUtil.get(_httpServletRequest, "clear"), "delete", null,
 			"async",
 			HashMapBuilder.<String, Object>put(
@@ -218,7 +215,7 @@ public class ExportImportProcessesDisplayContext {
 		String endpoint) {
 
 		FDSActionDropdownItem fdsActionDropdownItem = new FDSActionDropdownItem(
-			_BASE_PATH + endpoint, "trash", "delete",
+			ScopeUtil.getAPIURL(endpoint), "trash", "delete",
 			LanguageUtil.get(_httpServletRequest, "delete"), "delete", null,
 			"async",
 			HashMapBuilder.<String, Object>put(
@@ -237,7 +234,7 @@ public class ExportImportProcessesDisplayContext {
 	}
 
 	private String _getFDSName(String companyFDSName, String fdsName) {
-		if (_isInstanceScoped()) {
+		if (ScopeUtil.isInstanceScoped(_group)) {
 			return companyFDSName;
 		}
 
@@ -248,21 +245,6 @@ public class ExportImportProcessesDisplayContext {
 		return ParamUtil.getString(
 			_httpServletRequest, "portletId",
 			ParamUtil.getString(_httpServletRequest, "portletResource"));
-	}
-
-	private String _getScopePath() {
-		if (_isInstanceScoped()) {
-			return StringPool.BLANK;
-		}
-
-		String externalReferenceCode = URLEncoder.encode(
-			_group.getExternalReferenceCode(), StandardCharsets.UTF_8);
-
-		if (_group.isDepot()) {
-			return "/asset-libraries/" + externalReferenceCode;
-		}
-
-		return "/sites/" + externalReferenceCode;
 	}
 
 	private String _getTitle(String key) {
@@ -277,18 +259,6 @@ public class ExportImportProcessesDisplayContext {
 			PortalUtil.getPortletTitle(portletId, _themeDisplay.getLocale()));
 	}
 
-	private boolean _isInstanceScoped() {
-		if (_group.isControlPanel() ||
-			_stagingGroupHelper.isCompanyGroup(_group)) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	private static final String _BASE_PATH = "/o/export-import/v1.0";
-
 	private String _exportProcessesAPIURL;
 	private final Group _group;
 	private final long _groupId;
@@ -296,7 +266,6 @@ public class ExportImportProcessesDisplayContext {
 	private String _importProcessesAPIURL;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final boolean _privateLayout;
-	private final StagingGroupHelper _stagingGroupHelper;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
@@ -163,13 +163,13 @@ public class ExportImportProcessesDisplayContext {
 	private String _getAPIURL(String endpoint) {
 		String portletId = _getPortletId();
 
-		if (!Validator.isBlank(portletId)) {
-			return StringBundler.concat(
-				_BASE_PATH, _getScopePath(), "/portlets/",
-				URLEncoder.encode(portletId, StandardCharsets.UTF_8), endpoint);
+		if (Validator.isBlank(portletId)) {
+			return _BASE_PATH + _getScopePath() + endpoint;
 		}
 
-		return _BASE_PATH + _getScopePath() + endpoint;
+		return StringBundler.concat(
+			_BASE_PATH, _getScopePath(), endpoint, "?portletId=",
+			URLEncoder.encode(portletId, StandardCharsets.UTF_8));
 	}
 
 	private FDSActionDropdownItem _getClearFDSActionDropdownItem(

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
@@ -51,8 +50,7 @@ public class ViewNewExportMVCRenderCommand implements MVCRenderCommand {
 				_portal.getHttpServletRequest(renderRequest),
 				_portal.getLiferayPortletResponse(renderResponse),
 				ParamUtil.getLong(renderRequest, "liveGroupId", groupId),
-				ParamUtil.getBoolean(renderRequest, "privateLayout"),
-				_stagingGroupHelper));
+				ParamUtil.getBoolean(renderRequest, "privateLayout")));
 
 		return "/revamp/export/new_export.jsp";
 	}
@@ -65,8 +63,5 @@ public class ViewNewExportMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/util/ScopeUtil.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/util/ScopeUtil.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
+
+import java.net.URLEncoder;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Daniel Raposo
+ */
+public class ScopeUtil {
+
+	public static String getAPIURL(Group group, String endpoint) {
+		return _BASE_PATH + _getScopePath(group) + endpoint;
+	}
+
+	public static String getAPIURL(String endpoint) {
+		return _BASE_PATH + endpoint;
+	}
+
+	public static boolean isInstanceScoped(Group group) {
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (group.isControlPanel() ||
+			stagingGroupHelper.isCompanyGroup(group)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static String _getScopePath(Group group) {
+		if (isInstanceScoped(group)) {
+			return StringPool.BLANK;
+		}
+
+		String externalReferenceCode = URLEncoder.encode(
+			group.getExternalReferenceCode(), StandardCharsets.UTF_8);
+
+		if (group.isDepot()) {
+			return "/asset-libraries/" + externalReferenceCode;
+		}
+
+		return "/sites/" + externalReferenceCode;
+	}
+
+	private static final String _BASE_PATH = "/o/export-import/v1.0";
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/view_export.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/view_export.jsp
@@ -22,7 +22,7 @@ if (liveGroup == null) {
 	liveGroupId = groupId;
 }
 
-ExportImportProcessesDisplayContext exportImportProcessesDisplayContext = new ExportImportProcessesDisplayContext(liveGroup, liveGroupId, request, liferayPortletResponse, privateLayout, stagingGroupHelper);
+ExportImportProcessesDisplayContext exportImportProcessesDisplayContext = new ExportImportProcessesDisplayContext(liveGroup, liveGroupId, request, liferayPortletResponse, privateLayout);
 
 String title = exportImportProcessesDisplayContext.getExportTitle();
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
@@ -15,7 +15,7 @@ if (liveGroup == null) {
 	liveGroupId = groupId;
 }
 
-ExportImportPreviewDisplayContext exportImportPreviewDisplayContext = new ExportImportPreviewDisplayContext("/export_import/view_import_layouts", liveGroup, groupId, request, liferayPortletResponse, liveGroupId, privateLayout, stagingGroupHelper);
+ExportImportPreviewDisplayContext exportImportPreviewDisplayContext = new ExportImportPreviewDisplayContext("/export_import/view_import_layouts", liveGroup, groupId, request, liferayPortletResponse, liveGroupId, privateLayout);
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/view_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/view_import.jsp
@@ -22,7 +22,7 @@ if (liveGroup == null) {
 	liveGroupId = groupId;
 }
 
-ExportImportProcessesDisplayContext exportImportProcessesDisplayContext = new ExportImportProcessesDisplayContext(liveGroup, liveGroupId, request, liferayPortletResponse, privateLayout, stagingGroupHelper);
+ExportImportProcessesDisplayContext exportImportProcessesDisplayContext = new ExportImportProcessesDisplayContext(liveGroup, liveGroupId, request, liferayPortletResponse, privateLayout);
 
 String title = exportImportProcessesDisplayContext.getImportTitle();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100526

## What Is Being Fixed

With the export/import revamp enabled (LPD-57655), the portlet level New Export Process screen failed with "An unexpected error occurred." for any Control Panel portlet, such as a published object definition. Those screens run against the Control Panel group, which is neither a site, a CMS group, nor an asset library, so every endpoint they called answered 404, and the instance scope had no portlet endpoint at all. The classic UI works because it uses the legacy configuration iframe instead of the REST preview. The import side failed the same way.

## How It Is Being Fixed

The Control Panel group is now treated as instance scoped, like the company group, so the screens resolve their data group the same way the instance level export already did.

Reaching that fix meant deciding where the portlet belongs in the API. Every export and import endpoint existed twice, once for a scope and once for a portlet of that scope, which is twelve paths and eighteen operations of pure duplication, and adding a thirteenth pair for the instance scope would have made it worse. A portlet is not a sub resource of a site, an asset library, or the instance, it is a narrower selection of what to export or import, so it moved into a portletId query parameter next to the plid that goes with it. That removes the twelve duplicated paths, collapses six resource methods into three per resource, and drops about five thousand lines of generated client, base impl, and test case code. The package is a breaking change, so the resource package and bundle versions are raised in the baseLine commit.

Posting a process with a portletId and no plid used to create a background task that failed asynchronously with a missing layout, and now answers 400. The group lookups that each resource carried its own copy of are unified in one util.

## PR Check

**pr-check: PASS** — tested on `48617d6`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "48617d6cdadef19dca10e2bd2501659909b620ce"} -->

