### PR TITLE
LPD-101963 Neutralize CSV formula injection in batch engine export

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
@@ -5,12 +5,15 @@
 
 package com.liferay.batch.engine.internal;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.CSVUtil;
 
 /**
  * Neutralizes spreadsheet formula injection (CWE-1236) when exporting to CSV
- * and XLS. The neutralization logic is shared with the rest of the portal
- * through {@link CSVUtil}.
+ * and XLS, and reverses the neutralization when importing so that a value
+ * survives an export and import round trip unchanged. The neutralization is
+ * shared with the rest of the portal through {@link CSVUtil}; only the inverse,
+ * needed because the batch engine re-imports its own exports, lives here.
  *
  * @author Gabor Komaromi
  */
@@ -22,6 +25,17 @@ public class BatchEngineFormulaInjectionUtil {
 		}
 
 		return CSVUtil.escapeValue((String)value);
+	}
+
+	public static String restore(String value) {
+		if ((value == null) || (value.length() < 2) ||
+			(value.charAt(0) != CharPool.APOSTROPHE) ||
+			!CSVUtil.isFormulaInjectionPrefix(value.charAt(1))) {
+
+			return value;
+		}
+
+		return value.substring(1);
 	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -9,12 +9,6 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.CSVUtil;
 
 /**
- * Neutralizes spreadsheet formula injection (CWE-1236) when exporting to CSV
- * and XLS, and reverses the neutralization when importing so that a value
- * survives an export and import round trip unchanged. The neutralization is
- * shared with the rest of the portal through {@link CSVUtil}; only the inverse,
- * needed because the batch engine re-imports its own exports, lives here.
- *
  * @author Gabor Komaromi
  */
 public class BatchEngineFormulaInjectionUtil {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineFormulaInjectionUtil.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.internal;
+
+import com.liferay.portal.kernel.util.CSVUtil;
+
+/**
+ * Neutralizes spreadsheet formula injection (CWE-1236) when exporting to CSV
+ * and XLS. The neutralization logic is shared with the rest of the portal
+ * through {@link CSVUtil}.
+ *
+ * @author Gabor Komaromi
+ */
+public class BatchEngineFormulaInjectionUtil {
+
+	public static Object neutralize(Object value) {
+		if (!(value instanceof String)) {
+			return value;
+		}
+
+		return CSVUtil.escapeValue((String)value);
+	}
+
+}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/CSVBatchEngineImportTaskItemReaderImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/CSVBatchEngineImportTaskItemReaderImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.batch.engine.internal.reader;
 
+import com.liferay.batch.engine.internal.BatchEngineFormulaInjectionUtil;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.CSVUtil;
@@ -108,7 +109,9 @@ public class CSVBatchEngineImportTaskItemReaderImpl
 
 			fieldNameValueMapHandler.handle(
 				fieldName, fieldNameValueMap,
-				CSVUtil.decode(_enclosingCharacter, _delimiter, values.get(i)));
+				BatchEngineFormulaInjectionUtil.restore(
+					CSVUtil.decode(
+						_enclosingCharacter, _delimiter, values.get(i))));
 		}
 
 		return fieldNameValueMap;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/XLSBatchEngineImportTaskItemReaderImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/XLSBatchEngineImportTaskItemReaderImpl.java
@@ -5,6 +5,8 @@
 
 package com.liferay.batch.engine.internal.reader;
 
+import com.liferay.batch.engine.internal.BatchEngineFormulaInjectionUtil;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -100,7 +102,9 @@ public class XLSBatchEngineImportTaskItemReaderImpl
 							getFieldNameValueMapHandler(fieldName);
 
 				fieldNameValueMapHandler.handle(
-					fieldName, fieldNameValueMap, cell.getStringCellValue());
+					fieldName, fieldNameValueMap,
+					BatchEngineFormulaInjectionUtil.restore(
+						cell.getStringCellValue()));
 			}
 		}
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.batch.engine.csv.ColumnDescriptor;
 import com.liferay.batch.engine.csv.ColumnDescriptorProvider;
+import com.liferay.batch.engine.internal.BatchEngineFormulaInjectionUtil;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -90,6 +91,13 @@ public class ColumnValuesExtractor {
 
 			blankValues[childFieldColumnDescriptor.getIndex()] =
 				childFieldColumnDescriptor.getValue(item);
+		}
+
+		for (Object[] rowValues : values) {
+			for (int i = 0; i < rowValues.length; i++) {
+				rowValues[i] = BatchEngineFormulaInjectionUtil.neutralize(
+					rowValues[i]);
+			}
 		}
 
 		return values;

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/CSVBatchEngineImportTaskItemReaderImplTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/CSVBatchEngineImportTaskItemReaderImplTest.java
@@ -276,6 +276,41 @@ public class CSVBatchEngineImportTaskItemReaderImplTest
 	}
 
 	@Test
+	public void testReadNeutralizedFormulaValue() throws Exception {
+		try (CSVBatchEngineImportTaskItemReaderImpl
+				csvBatchEngineImportTaskItemReaderImpl =
+					_getCSVBatchEngineImportTaskItemReader(
+						FIELD_NAMES, true, null, null,
+						new Object[][] {
+							{
+								createDateString, "'=1+1", 1, "sample name",
+								"naziv"
+							}
+						})) {
+
+			validate(
+				createDateString, "=1+1", 1L,
+				HashMapBuilder.put(
+					"createDate", "createDate"
+				).put(
+					"description", "description"
+				).put(
+					"id", "id"
+				).put(
+					"name_i18n_en", "name"
+				).put(
+					"name_i18n_hr", "name"
+				).build(),
+				csvBatchEngineImportTaskItemReaderImpl.read(),
+				HashMapBuilder.put(
+					"en", "sample name"
+				).put(
+					"hr", "naziv"
+				).build());
+		}
+	}
+
+	@Test
 	public void testReadRowsWithEnclosingCharacter() throws Exception {
 		for (String delimiter : _CSV_DELIMITERS) {
 			for (String enclosingCharacter : _CSV_ENCLOSING_CHARACTERS) {

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/XLSBatchEngineImportTaskItemReaderImplTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/XLSBatchEngineImportTaskItemReaderImplTest.java
@@ -250,6 +250,38 @@ public class XLSBatchEngineImportTaskItemReaderImplTest
 	}
 
 	@Test
+	public void testReadNeutralizedFormulaValue() throws Exception {
+		try (XLSBatchEngineImportTaskItemReaderImpl
+				xlsBatchEngineImportTaskItemReaderImpl =
+					_getXLSBatchEngineImportTaskItemReader(
+						FIELD_NAMES,
+						new Object[][] {
+							{createDate, "'=1+1", 1L, "sample name", "naziv"}
+						})) {
+
+			validate(
+				createDateString, "=1+1", 1L,
+				HashMapBuilder.put(
+					"createDate", "createDate"
+				).put(
+					"description", "description"
+				).put(
+					"id", "id"
+				).put(
+					"name_i18n_en", "name"
+				).put(
+					"name_i18n_hr", "name"
+				).build(),
+				xlsBatchEngineImportTaskItemReaderImpl.read(),
+				HashMapBuilder.put(
+					"en", "sample name"
+				).put(
+					"hr", "naziv"
+				).build());
+		}
+	}
+
+	@Test
 	public void testReadRowsWithCommaInsideQuotes() throws Exception {
 		try (XLSBatchEngineImportTaskItemReaderImpl
 				xlsBatchEngineImportTaskItemReaderImpl =

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/CSVBatchEngineExportTaskItemWriterImplTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/CSVBatchEngineExportTaskItemWriterImplTest.java
@@ -45,6 +45,35 @@ public class CSVBatchEngineExportTaskItemWriterImplTest
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testWriteRowsNeutralizesFormulaValues() throws Exception {
+		List<String> fieldNames = Arrays.asList("description", "id");
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		try (CSVBatchEngineExportTaskItemWriterImpl
+				csvBatchEngineExportTaskItemWriterImpl =
+					new CSVBatchEngineExportTaskItemWriterImpl(
+						null, 0, StringPool.COMMA, fieldNameObjectValuePairs,
+						fieldNames, unsyncByteArrayOutputStream,
+						HashMapBuilder.<String, Serializable>put(
+							"containsHeaders", "false"
+						).build(),
+						null)) {
+
+			csvBatchEngineExportTaskItemWriterImpl.write(
+				Arrays.asList(
+					_createItem("=1+1", 1L), _createItem("@SUM(1)", 2L),
+					_createItem("+1", 3L), _createItem("-1", 4L),
+					_createItem("safe", 5L)));
+		}
+
+		Assert.assertEquals(
+			"'=1+1,1\r\n'@SUM(1),2\r\n'+1,3\r\n'-1,4\r\nsafe,5\r\n",
+			unsyncByteArrayOutputStream.toString());
+	}
+
+	@Test
 	public void testWriteRowsWithDefinedFieldNames1() throws Exception {
 		_testWriteRows(Arrays.asList("createDate", "description", "id"));
 	}
@@ -85,6 +114,15 @@ public class CSVBatchEngineExportTaskItemWriterImplTest
 		}
 		catch (IllegalArgumentException illegalArgumentException) {
 		}
+	}
+
+	private Item _createItem(String description, long id) {
+		Item item = new Item();
+
+		item.setDescription(description);
+		item.setId(id);
+
+		return item;
 	}
 
 	private String _formatValue(Object value, int fieldIndex) {

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImplTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImplTest.java
@@ -52,6 +52,45 @@ public class XLSBatchEngineExportTaskItemWriterImplTest
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testWriteRowsNeutralizesFormulaValues() throws Exception {
+		List<String> fieldNames = Arrays.asList("description", "id");
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		try (XLSBatchEngineExportTaskItemWriterImpl
+				xlsBatchEngineExportTaskItemWriterImpl =
+					new XLSBatchEngineExportTaskItemWriterImpl(
+						null, 0, fieldNameObjectValuePairs, fieldNames,
+						unsyncByteArrayOutputStream, null)) {
+
+			xlsBatchEngineExportTaskItemWriterImpl.write(
+				Arrays.asList(
+					_createItem("=1+1", 1L), _createItem("@SUM(1)", 2L),
+					_createItem("+1", 3L), _createItem("-1", 4L),
+					_createItem("safe", 5L)));
+		}
+
+		Workbook workbook = new XSSFWorkbook(
+			new ByteArrayInputStream(
+				unsyncByteArrayOutputStream.toByteArray()));
+
+		Sheet sheet = workbook.getSheetAt(0);
+
+		String[] expectedValues = {"'=1+1", "'@SUM(1)", "'+1", "'-1", "safe"};
+
+		for (int i = 0; i < expectedValues.length; i++) {
+			Cell cell = sheet.getRow(
+				i + 1
+			).getCell(
+				0
+			);
+
+			Assert.assertEquals(expectedValues[i], cell.getStringCellValue());
+		}
+	}
+
+	@Test
 	public void testWriteRowsWithDefinedFieldNames1() throws Exception {
 		_testWriteRows(Arrays.asList("createDate", "description", "id"));
 	}
@@ -82,6 +121,15 @@ public class XLSBatchEngineExportTaskItemWriterImplTest
 		}
 		catch (IllegalArgumentException illegalArgumentException) {
 		}
+	}
+
+	private Item _createItem(String description, long id) {
+		Item item = new Item();
+
+		item.setDescription(description);
+		item.setId(id);
+
+		return item;
 	}
 
 	private byte[] _getExpectedContent(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CSVUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CSVUtil.java
@@ -66,4 +66,20 @@ public class CSVUtil {
 		return StringPool.QUOTE.concat(s.concat(StringPool.QUOTE));
 	}
 
+	public static String escapeValue(String s) {
+		if ((s == null) || s.isEmpty() ||
+			!isFormulaInjectionPrefix(s.charAt(0))) {
+
+			return s;
+		}
+
+		return StringPool.APOSTROPHE.concat(s);
+	}
+
+	public static boolean isFormulaInjectionPrefix(char c) {
+		return (c == CharPool.AT) || (c == CharPool.EQUAL) ||
+			(c == CharPool.MINUS) || (c == CharPool.PLUS) ||
+			(c == CharPool.RETURN) || (c == CharPool.TAB);
+	}
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CSVUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CSVUtil.java
@@ -77,9 +77,14 @@ public class CSVUtil {
 	}
 
 	public static boolean isFormulaInjectionPrefix(char c) {
-		return (c == CharPool.AT) || (c == CharPool.EQUAL) ||
+		if ((c == CharPool.AT) || (c == CharPool.EQUAL) ||
 			(c == CharPool.MINUS) || (c == CharPool.PLUS) ||
-			(c == CharPool.RETURN) || (c == CharPool.TAB);
+			(c == CharPool.RETURN) || (c == CharPool.TAB)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 100.0.0
+version 100.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101963

## What Is Being Fixed

The batch engine CSV and XLS export wrote field values verbatim. A value
beginning with a spreadsheet formula trigger (=, +, -, @, tab, carriage
return) — for example a user account whose givenName is "=1+1" — was emitted
unchanged, so opening the exported file in Excel or LibreOffice executed it as
a formula (CSV formula injection, CWE-1236).

## How It Is Being Fixed

The neutralization is added to CSVUtil in portal-kernel as escapeValue, a
one-way transform that prefixes such values with an apostrophe, together with
isFormulaInjectionPrefix which exposes the trigger set. This lives in the
kernel because the same gap exists in other CSV exporters that already depend
on CSVUtil, so the logic is shared rather than duplicated. The batch engine
routes every exported cell through it in the shared ColumnValuesExtractor,
which covers both the CSV and XLS writers at their single choke point. Because
the batch engine also re-imports its own exports, the CSV and XLS import
readers reverse the neutralization through a small internal helper that reuses
the kernel predicate, so an export and import round trip is lossless.

## PR Check

**pr-check: PASS** — tested on `33bdc23598c1d624517179f1f52cb90c273eaa96`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "33bdc23598c1d624517179f1f52cb90c273eaa96"} -->
