### PR TITLE
LPD-101831 Escape batch plan title

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
@@ -49,7 +49,7 @@ SearchContainer<BatchPlannerPlanDisplay> batchPlannerPlanDisplaySearchContainer 
 					).buildPortletURL()
 				%>'
 				name="name"
-				value="<%= batchPlannerPlanDisplay.getTitle() %>"
+				value="<%= HtmlUtil.escape(batchPlannerPlanDisplay.getTitle()) %>"
 			/>
 
 			<liferay-ui:search-container-column-text

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
@@ -36,7 +36,7 @@ BatchPlannerPlanDisplay batchPlannerPlanDisplay = (BatchPlannerPlanDisplay)reque
 						<clay:col
 							md="8"
 						>
-							<%= batchPlannerPlanDisplay.getTitle() %>
+							<%= HtmlUtil.escape(batchPlannerPlanDisplay.getTitle()) %>
 						</clay:col>
 					</clay:row>
 

--- a/modules/test/playwright/tests/batch-planner/main/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/main/import.spec.ts
@@ -15,6 +15,7 @@ import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import createTempFile from '../../../utils/createTempFile';
+import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {dataMigrationCenterPagesTest} from './fixtures/dataMigrationCenterPagesTest';
@@ -1667,6 +1668,76 @@ test('cannot see relationship nested field', async ({
 
 	await expect(page.getByText('testRelationship')).not.toBeVisible();
 });
+
+test(
+	'escapes the plan title in the plan list and plan details views',
+	{tag: '@LPD-101831'},
+	async ({apiHelpers, dataMigrationCenterPage, page}) => {
+		const planNameSuffix = getRandomInt();
+		const planName = `<img src=x onerror="window.xss=1"> ${planNameSuffix}`;
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.postObjectDefinition(
+				companyObjectDefinition
+			);
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		// Import a file under a plan name carrying an HTML payload
+
+		await dataMigrationCenterPage.goto();
+		await dataMigrationCenterPage.goToImportFile();
+
+		await dataMigrationCenterPage.importFile(
+			OBJECT_ENTRY_ENTITY_TYPE,
+			path.join(__dirname, '/dependencies/object_entries.csv'),
+			'UPSERT',
+			'UPDATE',
+			planName
+		);
+
+		await expect(
+			page.getByText('The import process completed successfully.')
+		).toBeVisible();
+
+		// Check the plan list view
+
+		await dataMigrationCenterPage.gotoPage();
+
+		const planLink = page
+			.getByRole('table')
+			.getByRole('link', {name: new RegExp(`${planNameSuffix}$`)});
+
+		await expect(planLink).toBeVisible();
+
+		await expect(page.locator('img[src="x"]')).toHaveCount(0);
+		await expect(planLink).toHaveText(planName);
+
+		const planId = new URL(
+			await planLink.getAttribute('href'),
+			page.url()
+		).searchParams.get(
+			'_com_liferay_batch_planner_web_internal_portlet_BatchPlannerPortlet_batchPlannerPlanId'
+		);
+
+		// Check the plan details view
+
+		await planLink.click();
+
+		await expect(page.getByText('Batch Engine Task Details')).toBeVisible();
+
+		await expect(page.locator('img[src="x"]')).toHaveCount(0);
+		await expect(page.getByText(planName, {exact: true})).toBeVisible();
+
+		await apiHelpers.delete(`/o/batch-planner/v1.0/plans/${planId}`);
+	}
+);
 
 test.describe('can rely on anyOf form validation', () => {
 	const studentObjectDefinition: ObjectDefinition = {

--- a/modules/test/playwright/tests/batch-planner/main/pages/DataMigrationCenterPage.ts
+++ b/modules/test/playwright/tests/batch-planner/main/pages/DataMigrationCenterPage.ts
@@ -25,6 +25,7 @@ export class DataMigrationCenterPage {
 	readonly attributeCodeCheckBox: Locator;
 	readonly importStrategySelector: Locator;
 	readonly fileSelector: Locator;
+	readonly nameInput: Locator;
 	readonly nextButton: Locator;
 	readonly scopeSelector: Locator;
 	readonly startImportButton: () => Promise<Locator>;
@@ -54,6 +55,7 @@ export class DataMigrationCenterPage {
 		this.fileSelector = page.locator(
 			'#_com_liferay_batch_planner_web_internal_portlet_BatchPlannerPortlet_importFile'
 		);
+		this.nameInput = page.getByLabel('Name', {exact: true});
 		this.nextButton = page.getByRole('button', {name: 'Next'});
 		this.scopeSelector = page.getByLabel('Scope', {exact: true});
 		this.updateStrategySelector = page.getByLabel('Update Strategy');
@@ -116,10 +118,16 @@ export class DataMigrationCenterPage {
 		entitType: string,
 		filePath: string,
 		importStrategy: string,
-		updateStrategy: string
+		updateStrategy: string,
+		name?: string
 	) {
 		await this.selectFile(filePath);
 		await this.selectEntityType(entitType);
+
+		if (name) {
+			await this.nameInput.fill(name);
+		}
+
 		await this.importStrategySelector.selectOption(importStrategy);
 		await this.updateStrategySelector.selectOption(updateStrategy);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101831

## What Is Being Fixed

The batch planner plan title was rendered unescaped in the plan list (`view.jsp`) and the plan details view (`view_batch_planner_plan.jsp`). The title is the plan's name, and the import flow takes that name straight from a user-supplied `name` request parameter without validating its characters, so an importing user could store markup in it and have the browser execute it for anyone who later opened either view.

## How It Is Being Fixed

Both JSPs now pass the title through `HtmlUtil.escape`, so the stored name renders as text instead of markup. A Playwright test covers the fix end to end: it imports a file under a plan name carrying an `<img src=x onerror=...>` payload, then asserts on both the plan list and the plan details view that no `img` element was injected into the DOM and that the payload reads back as literal text. The test was verified against a build with the escaping reverted, where it fails on the injected element.

## PR Check

**pr-check: PASS** — tested on `8d6c2280dcc8c9cdeee9f5993871a9f4c9bd35df`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8d6c2280dcc8c9cdeee9f5993871a9f4c9bd35df"} -->
