### PR TITLE
LPD-102339 Escape the device user name in Push Notifications

### DIFF
--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/devices.jspf
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/devices.jspf
@@ -40,7 +40,7 @@ pushNotificationsDeviceSearchContainer.setResultsAndTotal(() -> PushNotification
 			<liferay-ui:search-container-column-text
 				cssClass="table-cell-expand table-title"
 				name="full-name"
-				value="<%= deviceUser.getFullName() %>"
+				value="<%= HtmlUtil.escape(deviceUser.getFullName()) %>"
 			/>
 
 			<liferay-ui:search-container-column-text

--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,6 +25,7 @@ page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader" %><%@
 page import="com.liferay.portal.kernel.service.UserLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@

--- a/modules/apps/push-notifications/push-notifications-web/test.properties
+++ b/modules/apps/push-notifications/push-notifications-web/test.properties
@@ -1,0 +1,11 @@
+modified.files.includes[relevant][push-notifications-web-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][push-notifications-web-playwright-rule]=\
+    push-notifications-web.main
+
+relevant.rule.names=push-notifications-web-playwright-rule
+
+test.batch.names[relevant][push-notifications-web-playwright-rule]=\
+    playwright-js-tomcat101-postgresql163
+
+testray.main.component.name=Notifications

--- a/modules/test/playwright/fixtures/pushNotificationsPagesTest.ts
+++ b/modules/test/playwright/fixtures/pushNotificationsPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {PushNotificationsPage} from '../pages/push-notifications-web/PushNotificationsPage';
+
+const pushNotificationsPagesTest = test.extend<{
+	pushNotificationsPage: PushNotificationsPage;
+}>({
+	pushNotificationsPage: async ({page}, use) => {
+		await use(new PushNotificationsPage(page));
+	},
+});
+
+export {pushNotificationsPagesTest};

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -77,6 +77,7 @@ import {JSONWebServicesLayoutSetPrototypeApiHelper} from './json-web-services/JS
 import {JSONWebServicesMBApiHelper} from './json-web-services/JSONWebServicesMBApiHelper';
 import {JSONWebServicesOSBAsahApiHelper} from './json-web-services/JSONWebServicesOSBAsahApiHelper';
 import {JSONWebServicesOSBFaroApiHelper} from './json-web-services/JSONWebServicesOSBFaroApiHelper';
+import {JSONWebServicesPushNotificationsDeviceApiHelper} from './json-web-services/JSONWebServicesPushNotificationsDeviceApiHelper';
 import {JSONWebServicesResourcePermissionApiHelper} from './json-web-services/JSONWebServicesResourcePermissionApiHelper';
 import {JSONWebServicesRoleApiHelper} from './json-web-services/JSONWebServicesRoleApiHelper';
 import {JSONWebServicesSegmentsEntryApiHelper} from './json-web-services/JSONWebServicesSegmentsEntryApiHelper';
@@ -204,6 +205,7 @@ export class ApiHelpers {
 	readonly jsonWebServicesMBApiHelper: JSONWebServicesMBApiHelper;
 	readonly jsonWebServicesOSBAsah: JSONWebServicesOSBAsahApiHelper;
 	readonly jsonWebServicesOSBFaro: JSONWebServicesOSBFaroApiHelper;
+	readonly jsonWebServicesPushNotificationsDevice: JSONWebServicesPushNotificationsDeviceApiHelper;
 	readonly jsonWebServicesResourcePermissionApiHelper: JSONWebServicesResourcePermissionApiHelper;
 	readonly jsonWebServicesRole: JSONWebServicesRoleApiHelper;
 	readonly jsonWebServicesSegmentsEntry: JSONWebServicesSegmentsEntryApiHelper;
@@ -319,6 +321,8 @@ export class ApiHelpers {
 		this.jsonWebServicesMBApiHelper = new JSONWebServicesMBApiHelper(this);
 		this.jsonWebServicesOSBFaro = new JSONWebServicesOSBFaroApiHelper(this);
 		this.jsonWebServicesOSBAsah = new JSONWebServicesOSBAsahApiHelper(this);
+		this.jsonWebServicesPushNotificationsDevice =
+			new JSONWebServicesPushNotificationsDeviceApiHelper(this);
 		this.jsonWebServicesResourcePermissionApiHelper =
 			new JSONWebServicesResourcePermissionApiHelper(this);
 		this.jsonWebServicesRole = new JSONWebServicesRoleApiHelper(this);
@@ -731,6 +735,11 @@ export class DataApiHelpers extends ApiHelpers {
 			}
 			else if (item.type === 'productConfigurationList') {
 				await this.headlessCommerceAdminCatalog.deleteProductConfigurationList(
+					item.id
+				);
+			}
+			else if (item.type === 'pushNotificationsDevice') {
+				await this.jsonWebServicesPushNotificationsDevice.deletePushNotificationsDevice(
 					item.id
 				);
 			}

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesPushNotificationsDeviceApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesPushNotificationsDeviceApiHelper.ts
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {request} from '@playwright/test';
+
+import {liferayConfig} from '../../liferay.config';
+import getRandomString from '../../utils/getRandomString';
+import {ApiHelpers, DataApiHelpers} from '../ApiHelpers';
+
+type TPushNotificationsDevice = {
+
+	// A device belongs to whoever registers it. Passing credentials registers
+	// it for that user instead of the signed in one
+
+	authorization?: string;
+	platform?: string;
+	pushNotificationsDeviceId?: string;
+	token?: string;
+	userId?: string;
+};
+
+export class JSONWebServicesPushNotificationsDeviceApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = '/api/jsonws/pushnotifications.pushnotificationsdevice';
+	}
+
+	async addPushNotificationsDevice(
+		pushNotificationsDevice?: TPushNotificationsDevice
+	): Promise<TPushNotificationsDevice> {
+		const {authorization, platform, token} = {
+			platform: 'android',
+			token: getRandomString(),
+			...(pushNotificationsDevice || {}),
+		};
+
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('platform', platform);
+		urlSearchParams.append('token', token);
+
+		const url = `${liferayConfig.environment.baseUrl}${this.basePath}/add-push-notifications-device`;
+
+		let device: TPushNotificationsDevice;
+
+		if (authorization) {
+
+			// The signed in session outranks the credentials, so the call has
+			// to be made from a context that carries no cookies
+
+			const context = await request.newContext({
+				extraHTTPHeaders: {
+					'Authorization': authorization,
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
+
+			const response = await context.post(url, {
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+			});
+
+			device = await response.json();
+
+			await context.dispose();
+		}
+		else {
+			device = await this.apiHelpers.post(url, {
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			});
+		}
+
+		if (this.apiHelpers instanceof DataApiHelpers) {
+			this.apiHelpers.data.push({
+				id: device.pushNotificationsDeviceId,
+				type: 'pushNotificationsDevice',
+			});
+		}
+
+		return device;
+	}
+
+	async deletePushNotificationsDevice(pushNotificationsDeviceId: string) {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append(
+			'pushNotificationsDeviceId',
+			pushNotificationsDeviceId
+		);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/delete-push-notifications-device`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+}

--- a/modules/test/playwright/pages/push-notifications-web/PushNotificationsPage.ts
+++ b/modules/test/playwright/pages/push-notifications-web/PushNotificationsPage.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {DataTablePage} from '../account-admin-web/DataTablePage';
+import {GlobalMenuPage} from '../product-navigation-applications-menu/GlobalMenuPage';
+
+export class PushNotificationsPage {
+	readonly devicesNavigationItem: Locator;
+	readonly devicesTable: DataTablePage;
+	readonly globalMenuPage: GlobalMenuPage;
+	readonly page: Page;
+	readonly testNavigationItem: Locator;
+
+	constructor(page: Page) {
+		this.devicesNavigationItem = page.getByRole('link', {name: 'Devices'});
+		this.devicesTable = new DataTablePage(
+			page,
+			page.locator(
+				'#portlet_com_liferay_push_notifications_web_portlet_PushNotificationsPortlet'
+			)
+		);
+		this.globalMenuPage = new GlobalMenuPage(page);
+		this.page = page;
+		this.testNavigationItem = page.getByRole('link', {name: 'Test'});
+	}
+
+	async goto() {
+		await this.globalMenuPage.goToControlPanel('Push Notifications');
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -198,6 +198,7 @@ import {config as productNavigationApplicationsMenuConfig} from './tests/product
 import {config as productNavigationControlMenuWeb} from './tests/product-navigation-control-menu-web/main/config';
 import {config as productNavigationProductMenuWeb} from './tests/product-navigation-product-menu-web/main/config';
 import {config as productNavigationUserPersonalBarWebConfig} from './tests/product-navigation-user-personal-bar-web/main/config';
+import {config as pushNotificationsWebConfig} from './tests/push-notifications-web/main/config';
 import {config as questionsWebConfig} from './tests/questions-web/main/config';
 import {config as redirectWebConfig} from './tests/redirect-web/main/config';
 import {config as rolesAdminWebConfig} from './tests/roles-admin-web/main/config';
@@ -459,6 +460,7 @@ export default defineConfig({
 		productNavigationControlMenuWeb,
 		productNavigationProductMenuWeb,
 		productNavigationUserPersonalBarWebConfig,
+		pushNotificationsWebConfig,
 		questionsWebConfig,
 		redirectWebConfig,
 		rolesAdminWebConfig,

--- a/modules/test/playwright/tests/push-notifications-web/main/config.ts
+++ b/modules/test/playwright/tests/push-notifications-web/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'push-notifications-web.main',
+	testDir: 'tests/push-notifications-web/main',
+};

--- a/modules/test/playwright/tests/push-notifications-web/main/pushNotificationsDevices.spec.ts
+++ b/modules/test/playwright/tests/push-notifications-web/main/pushNotificationsDevices.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pushNotificationsPagesTest} from '../../../fixtures/pushNotificationsPagesTest';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	loginTest(),
+	pushNotificationsPagesTest
+);
+
+test(
+	'JavaScript in a device user name is not executed when viewing the devices',
+	{tag: '@LPD-102339'},
+	async ({apiHelpers, page, pushNotificationsPage}) => {
+		const dialogs: string[] = [];
+
+		page.on('dialog', async (dialog) => {
+			dialogs.push(dialog.message());
+
+			await dialog.dismiss();
+		});
+
+		// Create a user whose last name carries a script payload. The full name
+		// is abbreviated past 75 characters, so keep it short enough to be
+		// rendered whole
+
+		const familyName = `${getRandomInt()}<img src=x onerror=alert('XSS')>`;
+
+		const userAccount = await apiHelpers.headlessAdminUser.postUserAccount({
+			familyName,
+			givenName: 'Xss',
+		});
+
+		const companyId = await page.evaluate(() =>
+			Liferay.ThemeDisplay.getCompanyId()
+		);
+
+		// A device belongs to whoever registers it, so the user has to make
+		// the call themselves for their name to reach the devices list
+
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: getRandomString(),
+			rolePermissions: [
+				{
+					actionIds: ['MANAGE_DEVICES'],
+					primaryKey: companyId,
+					resourceName: 'com.liferay.push.notifications',
+					scope: 1,
+				},
+			],
+		});
+
+		await apiHelpers.headlessAdminUser.postRoleByExternalReferenceCodeUserAccountAssociation(
+			role.externalReferenceCode,
+			userAccount.id
+		);
+
+		await apiHelpers.jsonWebServicesPushNotificationsDevice.addPushNotificationsDevice(
+			{
+				authorization: `Basic ${btoa(`${userAccount.emailAddress}:test`)}`,
+			}
+		);
+
+		await pushNotificationsPage.goto();
+
+		// The script in the device user name is rendered as text, not executed
+
+		await expect(
+			pushNotificationsPage.devicesTable.cell(
+				`${userAccount.givenName} ${familyName}`
+			)
+		).toBeVisible();
+
+		expect(dialogs).toHaveLength(0);
+	}
+);

--- a/modules/test/playwright/tests/push-notifications-web/main/test.properties
+++ b/modules/test/playwright/tests/push-notifications-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Notifications


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102339

## What Is Being Fixed

The Push Notifications admin portlet rendered each device owner's full name unescaped in the Devices list, so a user whose first or last name carried markup got that markup injected into the page. Any user able to register a device — and to set their own name — could store a script that then ran in the browser of every administrator who opened the list.

## How It Is Being Fixed

The full name is now passed through `HtmlUtil.escape` before it reaches the search container column, so the name renders as text.

A Playwright test covers the fix. It creates a user whose last name carries an `<img src=x onerror=alert('XSS')>` payload, registers a push notifications device on that user's behalf, opens the Devices list as an administrator, and asserts both that the payload appears as literal text and that no dialog fired. A device belongs to whoever registers it, so the test grants the user MANAGE_DEVICES and issues the registration from a cookieless request, since the signed in administrator session would otherwise outrank the credentials. The test was confirmed to fail against the unescaped JSP, where the payload renders as a real element and the alert genuinely fires, and to pass with the fix.

## PR Check

**pr-check: PASS** — tested on `328e6c2e71c0a60a51eb077b0c9a849cabcf6f6e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| PQL Validation | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "328e6c2e71c0a60a51eb077b0c9a849cabcf6f6e"} -->
