### PR TITLE
LPD-102889 Give per-screen identity to the shared FDS table tests

### DIFF
--- a/modules/test/playwright/tests/mcp-server-web/main/dataMasks.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/dataMasks.spec.ts
@@ -104,6 +104,7 @@ const test = baseTest.extend<{
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Type', 'Description', 'Last Modified'],
+	name: 'Data Masks',
 	rowActions: ['Edit', 'Duplicate', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-90205',

--- a/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/prompts.spec.ts
@@ -87,6 +87,7 @@ const test = baseTest.extend<{
 
 createFDSTableTests(test, {
 	columns: ['Name', 'Identifier', 'Description', 'Status', 'Last Modified'],
+	name: 'Prompts',
 	rowActions: ['Edit', 'Duplicate', 'Delete'],
 	sortOptions: ['Name', 'Last Modified'],
 	tag: '@LPD-98309',

--- a/modules/test/playwright/tests/mcp-server-web/main/utils/createFDSTableTests.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/utils/createFDSTableTests.ts
@@ -10,6 +10,7 @@ import getRandomString from '../../../../utils/getRandomString';
 
 export interface FDSTableOptions {
 	columns: string[];
+	name: string;
 	rowActions: string[];
 	sortOptions: string[];
 	tag: string | string[];
@@ -29,9 +30,9 @@ export function createFDSTableTests<
 	},
 	TWorkerArgs,
 >(test: TestType<TArgs, TWorkerArgs>, options: FDSTableOptions) {
-	const {columns, rowActions, sortOptions, tag} = options;
+	const {columns, name, rowActions, sortOptions, tag} = options;
 
-	test.describe('FDS table', () => {
+	test.describe(`${name} - FDS Table`, () => {
 		let seededItemName: string;
 
 		// Seed one item so the FDS renders the table instead of the empty state


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102889

## What Is Being Fixed

Testray subtask ST-1 on Task 511081064 groups five Playwright case results (mcp-server-web's FDS table tests: sort options, empty search, table columns, search by name, row actions) that have recorded UNTESTED on every run of [master] ci:test:headless going back to the earliest available history (2026-07-29). The recorded "error" is not a test assertion at all — it's the CI harness's own fallback text ("Unable to run test on CI: stop-docker-containers: ..." or "... Playwright Test timeout of 90000ms exceeded"), meaning these tests never actually executed.

`createFDSTableTests()` is a generator shared by `dataMasks.spec.ts` (LPD-90205) and `prompts.spec.ts` (LPD-98309). Because its `test()` calls physically live inside the shared utility file, Playwright reports the exact same file:line for both callers, and until now the generated titles ("FDS table > ...") were identical too — a hard test-identity collision, confirmed by `playwright test --list` showing the same `createFDSTableTests.ts:43:3` entry twice. This only surfaces when both spec files run together in the same project, which is how CI's full-suite run works but not a local single-file `yarn test <file>` — matching the "fails in CI, not locally" symptom reported against this subtask.

## How It Is Being Fixed

`FDSTableOptions` gains a required `name` field, and the generator scopes its `test.describe` title with it ("Data Masks - FDS Table" / "Prompts - FDS Table") instead of the generic "FDS table". The two callers now produce distinct test titles, which is enough for Playwright to tell them apart even though the source location is still shared.

## Why Are There No Tests?

The fix corrects the identity of ten already-existing generated tests rather than adding new behavior; there's no reasonable way to write a test that reproduces "Playwright collides two dynamically generated test IDs across sibling spec files" without re-creating the exact scenario this fix removes. Verification is `playwright test --list`, which now shows all ten FDS-table tests as distinct entries, and the module's own format/typecheck pass. The real confirmation is the next `[master] ci:test:headless` build reporting real pass/fail for these ten instead of UNTESTED.

## PR Check

**pr-check: PASS** — tested on `46539b84ed066c86398293ed2653c0dff801baae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "46539b84ed066c86398293ed2653c0dff801baae"} -->
