### PR TITLE
LPD-103034 Publish the page before opening its live staging URL

### DIFF
--- a/modules/apps/export-import/export-import-test-util/bnd.bnd
+++ b/modules/apps/export-import/export-import-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Test Utilities
 Bundle-SymbolicName: com.liferay.exportimport.test.util
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	com.liferay.exportimport.test.rule,\
 	com.liferay.exportimport.test.util,\

--- a/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/packageinfo
+++ b/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
@@ -80,6 +80,7 @@ test(
 		apiHelpers,
 		exportImportStagingInstanceSettingsPage,
 		page,
+		pageEditorPage,
 		portletPublishToLivePage,
 	}) => {
 		const site = await apiHelpers.headlessAdminSite.postSite({
@@ -91,6 +92,11 @@ test(
 			options: {type: 'content'},
 			title: getRandomString(),
 		});
+
+		// Publish the page so it can be reached through its live friendly URL
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+		await pageEditorPage.publishPage();
 
 		await exportImportStagingInstanceSettingsPage.goto();
 		await exportImportStagingInstanceSettingsPage.checkConfigurationOption({
@@ -145,6 +151,7 @@ test(
 		apiHelpers,
 		exportImportStagingSystemSettingsPage,
 		page,
+		pageEditorPage,
 		portletPublishToLivePage,
 	}) => {
 		const site = await apiHelpers.headlessAdminSite.postSite({
@@ -156,6 +163,11 @@ test(
 			options: {type: 'content'},
 			title: getRandomString(),
 		});
+
+		// Publish the page so it can be reached through its live friendly URL
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+		await pageEditorPage.publishPage();
 
 		await exportImportStagingSystemSettingsPage.goto();
 		await exportImportStagingSystemSettingsPage.checkConfigurationOption({
@@ -282,6 +294,7 @@ test(
 		apiHelpers,
 		exportImportStagingInstanceSettingsPage,
 		page,
+		pageEditorPage,
 		portletPublishToLivePage,
 	}) => {
 		const site = await apiHelpers.headlessAdminSite.postSite({
@@ -293,6 +306,11 @@ test(
 			options: {type: 'content'},
 			title: getRandomString(),
 		});
+
+		// Publish the page so it can be reached through its live friendly URL
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+		await pageEditorPage.publishPage();
 
 		await exportImportStagingInstanceSettingsPage.goto();
 		await exportImportStagingInstanceSettingsPage.checkConfigurationOption({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103034

## What Is Being Fixed

Three Playwright tests in `stagingConfiguration.spec.ts` create a site, add a single `content`-type layout, and immediately navigate to its live staging URL without ever publishing it. This started failing on `[master] ci:test:headless` build 361 (Testray Task 511081064, subtasks ST-54, ST-55, ST-56) with a "You do not have permission to view this page" error inside the `Publish to Live` iframe.

Bisecting Testray's pass/fail history narrowed the regression to commit `bbf8708` ("LPD-100303 Skip unpublished layouts in `_getViewableLayoutComposite`"), which added an `isPublished()` gate to `ServicePreAction._getViewableLayoutComposite` so an unpublished draft can no longer be picked as a site's default layout. That method is also called directly whenever a specific layout has already been resolved from a friendly URL (`ServicePreAction.java:1227`), so navigating straight to a freshly created content page's own live URL now fails the same way whenever the site has no other published page to fall back to — exactly what these three tests do.

This is not a new bug: `LPD-101984` (`aaa9976`) hit the identical regression in a different spec and documented it explicitly — *"Since LPD-100303 the live friendly URL of an unpublished content page no longer resolves"* — and fixed it by publishing the page first rather than reverting the portal check. `LPD-100303`'s own ticket confirms the change was scoped to the default-layout/logout-redirect scenario; the broader effect on direct navigation to an unpublished page's own URL is an accepted, documented consequence, not something to walk back. `LPD-101567` hit the same pattern a third time, and its description records that a bug was raised against this exact portal behavior (`LPD-101553`) and closed as **Won't Fix**, with the reasoning "the change removed a hole rather than an entry point" — confirming this is intended behavior, not a regression to revert.

## How Is It Being Fixed

Following the same precedent as `LPD-101984`: publish the page via `pageEditorPage.goto(layout, site.friendlyUrlPath)` + `pageEditorPage.publishPage()` right after creating it, before navigating to its live URL, in all three affected tests.

Verified locally: all three previously-failing tests pass, and the full `stagingConfiguration.spec.ts` file was run to confirm no regressions (8/8 pass).

## Why Are There No Tests?

This fixes three existing tests to match a deliberate, already-documented portal behavior change (`LPD-100303`); it does not add new product behavior needing new coverage. The three tests this restores are themselves the test coverage.

## Unrelated Commit Carried In This PR

Running `baseline-all` (a `pr-check` precondition, and repo-wide by design, not diff-scoped) surfaced a pre-existing, unrelated semantic-versioning gap in `export-import-test-util`: commit `f805ac8` (`LPD-100541`) added a new public class without bumping the module's version, and its Testray CI coverage for exactly this check turned out to have been silently stale for over a year (last real attempt: 2025-07-30, "Unable to run test on CI" / a 2-hour downstream timeout), so nothing has surfaced the drift since. Bundled the one-line minor bump under its own commit, attributed to `LPD-100541` rather than this ticket, rather than leaving `pr-check` failing for a reason this PR didn't cause.

## PR Check

**pr-check: PASS** — tested on `5280a6539f4d91c3b89aa2983439b60dad9e22ec`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "5280a6539f4d91c3b89aa2983439b60dad9e22ec"} -->


