### PR TITLE
LPD-103299 Fix restClient template test's reminder-query failure

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
@@ -6,12 +6,14 @@
 package com.liferay.portal.vulcan.internal.template.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.ZipFileTestUtil;
@@ -78,7 +80,10 @@ public class RESTClientTemplateContextContributorTest {
 
 			PropsValues.TERMS_OF_USE_REQUIRED = false;
 
-			try {
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"USERS_REMINDER_QUERIES_ENABLED", false)) {
+
 				HTTPTestUtil.customize(
 				).withoutModulePath(
 				).apply(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103299

## Failing Test

`com.liferay.portal.vulcan.internal.template.test.RESTClientTemplateContextContributorTest`

`modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java`

```
java.lang.AssertionError:
Expected: (a string containing "Name: spain." and a string containing "Page Size (default): 20." and a string containing "Page Size (query): 1." and a string containing "User: test.")
     but: a string containing "Name: spain." was "<!DOCTYPE html> ... <title>Password Reminder - LiJV0Biz - Liferay</title> ..." (full HTML response omitted)
```

## Root Cause

Commit `9fc1698` ("LPD-94309 Test server-side restClient keeps the page user") made the test's Basic Auth header genuinely sign in as the default admin for the first time. Since then, `PortalRequestProcessor`'s check that a signed-in user has completed a reminder query (a recovery question and answer pair) redirects to `/c/portal/update_reminder_query` instead of serving the requested fragment, on any environment where that admin has never set one up — a second, distinct onboarding gate from the Terms-of-Use one already handled under LPD-97133.

## Fix

Temporarily forcing `PropsValues.USERS_REMINDER_QUERIES_ENABLED` false around the signed-in request, mirroring the existing defense already in place for `PropsValues.TERMS_OF_USE_REQUIRED`, disables `PortalRequestProcessor`'s reminder-query check regardless of the admin's actual state, and restores it immediately after.

- `modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java`

## PR Check

**pr-check: PASS** — tested on `f77a54ea4bb2623e869eabcae2bfadcda6ce8928`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f77a54ea4bb2623e869eabcae2bfadcda6ce8928"} -->
